### PR TITLE
TUNE-0092: bats CI workflow — full tests/ suite on push+PR

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -1,0 +1,34 @@
+name: bats
+
+# TUNE-0092 — full bats regression suite for the framework repo.
+# Runs every *.bats file under tests/ on every PR and on push to main.
+# Complements the scoped bats jobs in security.yml (regression-bats, doc-refs,
+# task-id-gate) and dev-tools-lint.yml (bats-self-tests) by covering the rest
+# of the suite that previously had no CI gate.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: bats-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  full-suite:
+    name: bats tests/ (full)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install bats
+        run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends bats
+
+      - name: Run full bats suite
+        run: bats tests/


### PR DESCRIPTION
## Summary

- Add `.github/workflows/bats.yml` running `bats tests/` (full suite, 16 files / 160 tests) on every PR and on push to `main`.
- Complements scoped bats jobs in `security.yml` (regression-bats, doc-refs, task-id-gate) and `dev-tools-lint.yml` (bats-self-tests) by covering the rest of the suite that previously had no CI gate.
- Single `ubuntu-latest` job, `apt-get bats`, `actions/checkout` SHA-pinned to v5.0.1, `permissions: contents: read`, concurrency group with `cancel-in-progress: true`.

## Why

Spawned from TUNE-0090 archive § Outstanding Follow-ups. Previously, framework regressions (archive-contract-lint, cta-format, curate-runtime, datarim-doctor, deprecation-banners, dr-archive-step-0-5, install, optimize-audit, optimize-merge, pre-archive-check, reflect-removal-sweep, stack-agnostic-gate, update, validate-override, version-consistency-check) could land silently between archives — the suite ran only when an operator manually invoked `bats tests/`.

## Local verification

- `python3 -c 'yaml.safe_load(open(".github/workflows/bats.yml"))'` → OK
- `actionlint .github/workflows/bats.yml` → clean
- `bats tests/` on `origin/main` → 160/160 green
- `bats tests/` on this branch → 160/160 green

## Test plan

- [ ] PR CI: new `bats tests/ (full)` job appears and is green.
- [ ] After merge, push to main: workflow re-runs and is green.
- [ ] Forced-regression demo (separate throwaway PR): remove a `/dr-doctor` mention from `CLAUDE.md`, observe `test-command-doc-coverage.bats` red; revert, observe green.