### PR TITLE
Phase P3: repo hygiene + supply chain attestation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,35 @@
+# CODEOWNERS — required reviewers for security-relevant paths.
+#
+# Order matters: last matching pattern wins. The catch-all sits at the
+# top so specific patterns below can override it.
+#
+# When a second maintainer joins, add them to the @Arcanada-one/security-reviewers
+# team rather than editing this file.
+
+* @Arcanada-one/security-reviewers
+
+# CI / GitHub Actions workflows — any change is security-sensitive.
+/.github/workflows/   @Arcanada-one/security-reviewers
+/.github/actions/     @Arcanada-one/security-reviewers
+/.github/CODEOWNERS   @Arcanada-one/security-reviewers
+/.github/dependabot.yml  @Arcanada-one/security-reviewers
+
+# Repository policy files.
+/SECURITY.md          @Arcanada-one/security-reviewers
+/CODE_OF_CONDUCT.md   @Arcanada-one/security-reviewers
+/CONTRIBUTING.md      @Arcanada-one/security-reviewers
+/LICENSE              @Arcanada-one/security-reviewers
+
+# Anything shipped as executable instructions or installer is high-blast-radius.
+/scripts/             @Arcanada-one/security-reviewers
+/dev-tools/           @Arcanada-one/security-reviewers
+/templates/           @Arcanada-one/security-reviewers
+/install.sh           @Arcanada-one/security-reviewers
+/update.sh            @Arcanada-one/security-reviewers
+/VERSION              @Arcanada-one/security-reviewers
+
+# Security tests must be reviewed by security team.
+/tests/security/      @Arcanada-one/security-reviewers
+
+# Pre-commit policy.
+/.pre-commit-config.yaml  @Arcanada-one/security-reviewers

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Security Vulnerability (private)
+    url: https://github.com/Arcanada-one/datarim/security/advisories/new
+    about: Report a security vulnerability through GitHub's private advisory channel.
+  - name: Security Vulnerability (email)
+    url: mailto:mail@veritasarcana.ai
+    about: Alternative private channel for security disclosures.

--- a/.github/ISSUE_TEMPLATE/security-vulnerability.md
+++ b/.github/ISSUE_TEMPLATE/security-vulnerability.md
@@ -1,0 +1,26 @@
+---
+name: Security Vulnerability
+about: STOP — do not file security issues here. See SECURITY.md.
+title: ""
+labels: ""
+assignees: ""
+---
+
+# STOP
+
+**Do not report security vulnerabilities through public GitHub issues.**
+
+Public disclosure of an unpatched vulnerability puts every downstream
+consumer at risk. Please follow the private disclosure process
+documented in [`SECURITY.md`](../../SECURITY.md):
+
+1. Open a **GitHub Private Security Advisory**:
+   <https://github.com/Arcanada-one/datarim/security/advisories/new>
+2. Or email **mail@veritasarcana.ai** with subject prefix
+   `[security]`.
+
+If you opened this issue by accident, please close it and re-submit
+through one of the channels above. Maintainers will lock and delete
+public issues that describe unpatched vulnerabilities.
+
+Thank you for helping keep the framework and its consumers safe.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,40 @@
+<!--
+Thanks for the PR! Please complete the sections below.
+Delete sections that do not apply.
+-->
+
+## Summary
+
+<!-- One or two sentences: what does this change and why. -->
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature (non-breaking)
+- [ ] Breaking change
+- [ ] Documentation only
+- [ ] CI / tooling
+- [ ] Security fix
+
+## Related Issues
+
+<!-- Link the GitHub issue this PR closes, e.g. "Closes #123". -->
+
+## Pre-Merge Checklist
+
+- [ ] Tests added or updated for the change.
+- [ ] `bats tests/` passes locally.
+- [ ] `pre-commit run --all-files` passes locally.
+- [ ] Public-facing artifacts (`skills/`, `agents/`, `commands/`,
+      `templates/`) have matching docs and site entries updated.
+- [ ] No internal task IDs, private repo paths, or organization-only
+      taxonomy in user-visible files.
+- [ ] No `StrictHostKeyChecking=no`, `curl | bash`, world-readable
+      credentials, or hardcoded secrets introduced.
+- [ ] If a security-relevant file changed, a regression test in
+      `tests/security/` exists.
+
+## Notes for Reviewer
+
+<!-- Anything that helps review: tricky parts, alternatives considered,
+     screenshots of CI output, etc. -->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,62 @@
+# Dependabot configuration.
+# Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Scope: keep GitHub Actions pinned to verified SHAs and surface
+# vulnerabilities in any pip-managed tooling used by CI / pre-commit.
+# The framework itself ships no runtime package manifests; this stays
+# tight to CI/tooling surfaces.
+
+version: 2
+
+updates:
+  # GitHub Actions used in workflows.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      actions-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      actions-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
+
+  # Pip-managed CI/lint tooling (bandit, semgrep, pre-commit, etc.).
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Etc/UTC"
+    open-pull-requests-limit: 3
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    groups:
+      pip-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
+      pip-security:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,56 @@
+name: scorecard
+
+# OpenSSF Scorecard: weekly score + on-demand runs. Results are pushed
+# to the OpenSSF dashboard (publish_results: true) and uploaded as
+# SARIF to the repository's code-scanning view.
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "0 6 * * 1"   # Monday 06:00 UTC
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: openssf-scorecard
+    runs-on: ubuntu-latest
+    permissions:
+      # Required for publish_results to OpenSSF dashboard.
+      id-token: write
+      # Required to upload SARIF to code-scanning.
+      security-events: write
+      # Read-only repo access.
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4.4.3
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload SARIF to code-scanning
+        uses: github/codeql-action/upload-sarif@4f3212b61783c3c68e8309a0f18a699764811cda # v3.27.1
+        with:
+          sarif_file: results.sarif

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,36 @@
+# Code of Conduct
+
+This project adopts the **Contributor Covenant**, version 2.1, verbatim.
+
+Full text: <https://www.contributor-covenant.org/version/2/1/code_of_conduct/>
+
+## Enforcement Contact
+
+Reports of unacceptable behavior should be sent to:
+
+**mail@veritasarcana.ai**
+
+All complaints will be reviewed and investigated promptly and fairly.
+All maintainers are obligated to respect the privacy and security of
+the reporter of any incident.
+
+## Enforcement Guidelines
+
+The project follows the Contributor Covenant Community Impact
+Guidelines in determining consequences for any action deemed in
+violation:
+
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct/#enforcement-guidelines>
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant,
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by Mozilla's code of conduct
+enforcement ladder.
+
+For answers to common questions about this code of conduct, see the
+FAQ at <https://www.contributor-covenant.org/faq>. Translations are
+available at <https://www.contributor-covenant.org/translations>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,107 @@
+# Contributing
+
+Thanks for your interest in improving this framework.
+
+## Quick Start
+
+```bash
+git clone https://github.com/Arcanada-one/datarim.git
+cd datarim
+./install.sh
+```
+
+For a development checkout:
+
+```bash
+git clone https://github.com/Arcanada-one/datarim.git
+cd datarim
+pip install pre-commit
+pre-commit install
+```
+
+## Workflow
+
+1. **File an issue first** for non-trivial changes. Drive-by patches
+   for typos or one-line fixes are welcome without prior issue.
+2. **Fork** the repository and create a feature branch.
+3. **Run the local security gate** before opening a PR (see below).
+4. **Open a PR** against `main` with a clear description and link to
+   the issue (if any).
+5. **Wait for CI** — all required status checks must pass before
+   merge. A code-owner review is required.
+
+## Local Security Gate
+
+Before pushing, run:
+
+```bash
+pre-commit run --all-files
+bats tests/security/
+```
+
+This mirrors the CI baseline. If `pre-commit` is not installed, run
+the individual tools:
+
+```bash
+shellcheck -S warning $(find . -name '*.sh' -not -path './node_modules/*')
+bandit -r . -ll -ii -x ./node_modules
+gitleaks detect --redact --no-banner
+actionlint
+```
+
+## Suppression Discipline
+
+Inline suppressions are allowed but must include a reason of at least
+10 characters explaining *why* the rule is suppressed. Without a
+reason, the CI suppression-count gate will fail.
+
+Acceptable forms:
+
+```bash
+# shellcheck disable=SC2034 # reason: variable read by external sourcing
+foo=bar
+```
+
+```python
+# nosec B608 # reason: query string is a literal constant
+db.execute("SELECT 1")
+```
+
+Suppressions are reviewed quarterly. Sprawl triggers a security-agent
+audit. Do not stockpile suppressions.
+
+## Pull Request Checklist
+
+Before requesting review, confirm:
+
+- [ ] All new code has at least one regression test.
+- [ ] `bats tests/` passes locally.
+- [ ] `pre-commit run --all-files` passes locally.
+- [ ] If the change touches shipped artifacts (`skills/`, `agents/`,
+      `commands/`, `templates/`), the corresponding `docs/*.md` index
+      and `data/*.php` site entries are updated (see project docs on
+      public-surface sync).
+- [ ] If the change introduces a new shipped artifact, the
+      `dev-tools/doc-fanout-lint.sh` check is green.
+- [ ] No internal task IDs, private repo paths, or organization-only
+      taxonomy in user-visible files (see public-surface hygiene
+      rule).
+- [ ] No `StrictHostKeyChecking=no`, `curl | bash`, world-readable
+      credentials, or hardcoded secrets in any new code.
+- [ ] If the change touches a security-relevant file, a regression
+      test in `tests/security/` exists.
+
+## Reporting Security Issues
+
+Do **not** file public GitHub issues for security findings. See
+[`SECURITY.md`](SECURITY.md) for the private disclosure channel.
+
+## Code of Conduct
+
+By participating, you agree to abide by the
+[Code of Conduct](CODE_OF_CONDUCT.md).
+
+## License
+
+Contributions are licensed under the [MIT License](LICENSE) — same as
+the repository.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![Version: 2.7.0](https://img.shields.io/badge/Version-2.7.0-green.svg)](VERSION)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Arcanada-one/datarim/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Arcanada-one/datarim)
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,115 @@
+# Security Policy
+
+Datarim is a methodology + tooling framework whose artifacts (skills, agents,
+commands, templates) are read and executed by AI agents and human operators on
+production systems. A vulnerability in a shipped artifact propagates to every
+consumer. Reports are treated accordingly.
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| `2.x`   | ✅ — latest minor receives all security fixes |
+| `1.18.x` and earlier | ❌ — please upgrade to 2.x |
+
+The framework follows semver. Patch releases are issued for any HIGH or
+CRITICAL finding affecting the latest minor.
+
+## Reporting a Vulnerability
+
+**Please do not file public GitHub issues for security findings.**
+
+Preferred channel: **GitHub Private Security Advisory**
+(`Security` tab → `Report a vulnerability`).
+
+Alternative channel: **mail@veritasarcana.ai** with subject prefix
+`[security]`. Encrypt with our public PGP key on
+[keys.openpgp.org](https://keys.openpgp.org) if disclosing exploit
+details.
+
+Include in the report:
+
+1. Affected file(s) and version (commit SHA if known).
+2. Category (e.g. shell injection, credential exposure, supply-chain
+   compromise, GHA workflow bypass).
+3. Reproduction — minimal example showing the attack path.
+4. Impact assessment — what an attacker gains and at what scope
+   (single consumer / ecosystem-wide).
+5. Suggested fix (optional but appreciated).
+
+## Disclosure SLA
+
+| Stage | Target |
+|-------|--------|
+| Acknowledgement of report | ≤ 72 hours |
+| Triage + severity assignment | ≤ 7 days |
+| Fix for HIGH / CRITICAL | ≤ 90 days |
+| Fix for MEDIUM | ≤ 180 days |
+| Fix for LOW | best-effort, batched into next minor |
+| Coordinated public disclosure | within 14 days of fix, or 120 days
+  after report (whichever sooner), unless embargo is mutually agreed |
+
+If the reporter does not hear back within the acknowledgement window,
+they may publicly disclose without further coordination.
+
+## Embargo Policy
+
+For pre-disclosure embargoes (e.g. enterprise consumers needing time
+to patch before public disclosure), email
+`mail@veritasarcana.ai` with proposed embargo window. Default
+embargo length is 30 days from coordinated patch release.
+
+## Scope
+
+In scope:
+
+- All code shipped in the repository: `skills/`, `agents/`, `commands/`,
+  `templates/`, `scripts/`, `dev-tools/`, `install.sh`, `update.sh`,
+  `tests/`.
+- All GitHub Actions workflows under `.github/workflows/`.
+- All published release artifacts (source tarballs, SBOMs, signatures,
+  attestations).
+- Documentation files that contain executable code blocks
+  (`docs/`, `*.md` at repo root).
+
+Out of scope:
+
+- Consumer projects that *use* the framework — report to that project's
+  own security contact.
+- The Arcanada ecosystem services (Auth Arcana, Verdicus, etc.) — each
+  has its own `SECURITY.md`.
+- Findings that require an attacker to already have full root access on
+  the host running the framework.
+
+## Hardening Baseline
+
+This repository enforces a security baseline composed of:
+
+- Static analysis: `shellcheck`, `bandit`, `semgrep`, `actionlint`,
+  `zizmor` (workflow security).
+- Secret scanning: `gitleaks`, `trufflehog` (verified credentials only).
+- Vulnerability scanning: `osv-scanner` on package manifests.
+- Regression tests: `bats` suite, one test per closed finding under
+  `tests/security/`.
+- Supply chain: CycloneDX SBOM via `syft`, cosign keyless signing,
+  SLSA L2 build provenance attestation on every release.
+- Pre-commit: optional local enforcement via `.pre-commit-config.yaml`.
+- Repository hardening: branch protection with required reviews,
+  required status checks, no force-push, no deletions; tag protection
+  for release tags; `CODEOWNERS` routing critical paths to a security
+  team.
+
+See `docs/release-verification.md` for downstream consumer verification
+recipe and `docs/release-process.md` for the maintainer release
+playbook.
+
+## Standards Mapping
+
+The baseline maps to OWASP ASVS v5, OpenSSF Scorecard, SOC 2 CC,
+ISO 27001 Annex A, and CIS Controls v8. The full mapping is in
+`docs/standards-mapping.md` (when published).
+
+## Hall of Fame
+
+Researchers who responsibly disclose vulnerabilities will be credited
+in release notes unless they prefer to remain anonymous.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,157 @@
+# Release Process (maintainer playbook)
+
+This document describes how to cut a signed, attested release. The
+consumer-facing verification recipe lives in
+[`release-verification.md`](release-verification.md).
+
+## Roles
+
+- **Release engineer** — runs the release. By default this is a member
+  of `@Arcanada-one/security-reviewers`.
+- **Code-owner reviewer** — approves the release PR. Must be a
+  different person from the release engineer.
+
+## Cadence
+
+- **Patch** (`vX.Y.Z+1`) — issued for security fixes (HIGH/CRITICAL
+  within 90 days, MEDIUM within 180 days) and urgent bug fixes.
+- **Minor** (`vX.Y+1.0`) — issued for each completed feature increment
+  (typically one TUNE task or a coherent slice of work).
+- **Major** (`vX+1.0.0`) — breaking changes to the framework contract
+  (e.g. operating model, mandatory skill schema). Major bumps require
+  a written migration note in `CHANGELOG.md`.
+
+## Pre-flight (manual, fail-closed)
+
+1. `main` is green on all required checks.
+2. `pre-commit run --all-files` is clean locally.
+3. `bats tests/` is fully green.
+4. `gitleaks detect --redact` finds nothing new.
+5. The release branch / commit has been reviewed and approved per
+   `CODEOWNERS`.
+6. The `VERSION` file matches the intended tag (without the leading
+   `v`).
+
+If any pre-flight check fails, abort and fix on a feature branch first.
+
+## Steps
+
+### 1. Bump VERSION and CHANGELOG
+
+```bash
+# On a feature branch off main:
+echo "X.Y.Z" > VERSION
+$EDITOR CHANGELOG.md   # add a section for the new tag
+$EDITOR README.md      # update version badge or string if applicable
+$EDITOR CLAUDE.md      # update "Version:" line in the framework intro
+
+git add VERSION CHANGELOG.md README.md CLAUDE.md
+git commit -m "release: vX.Y.Z"
+git push origin <branch>
+gh pr create --base main --title "release: vX.Y.Z" --body "Release notes in CHANGELOG.md"
+```
+
+Wait for required checks and code-owner approval, then merge.
+
+### 2. Tag
+
+After merge, on a clean `main`:
+
+```bash
+git checkout main
+git pull --ff-only
+git tag -s "vX.Y.Z" -m "release vX.Y.Z"   # signed tag
+git push origin "vX.Y.Z"
+```
+
+For a release candidate, use a suffix accepted by the tag-format gate:
+
+```bash
+git tag -s "vX.Y.Z-rc1" -m "release candidate vX.Y.Z-rc1"
+```
+
+Accepted suffixes: `-rc<N>`, `-alpha<N>`, `-beta<N>`, `-test<N>`.
+
+### 3. Pipeline runs automatically
+
+Pushing the tag triggers `.github/workflows/release.yml`, which:
+
+1. Validates the tag format.
+2. Checks out the repository at the tag (no persisted credentials).
+3. Installs `cosign` and `syft` from upstream releases (SHA-pinned).
+4. Builds a deterministic source tarball with `git archive HEAD`.
+5. Computes a CycloneDX SBOM with `syft scan dir:.`.
+6. Signs the tarball and the SBOM with `cosign sign-blob`
+   (keyless OIDC).
+7. Attests SLSA L2 build provenance for the tarball.
+8. Publishes a GitHub Release with all artefacts attached. RC tags are
+   marked as prerelease.
+
+Watch the run:
+
+```bash
+gh run watch --repo Arcanada-one/datarim
+```
+
+### 4. Verify the release end-to-end
+
+Even after the pipeline reports success, run the consumer recipe
+yourself before announcing the release. Follow
+[`release-verification.md`](release-verification.md).
+
+If `cosign verify-blob` or `gh attestation verify` fails, **do not**
+delete the release; investigate first. Common causes:
+
+| Symptom | Likely cause | Recovery |
+|---|---|---|
+| `cosign verify-blob` rejects certificate identity | Tag was created from a fork PR | Re-cut the release from a maintainer branch. |
+| `gh attestation verify` returns no attestations | `attestations: write` permission missing | Add the permission and re-run the workflow. |
+| SBOM `components` array empty | `syft` ran against an empty checkout | Check `actions/checkout` `fetch-depth: 0`. |
+
+### 5. Announce
+
+Once verified, post the release notes to the announcement channels
+(`datarim.club` changelog page, project social media). Include a
+single sentence reminding consumers to verify before installing.
+
+## Security incident → emergency release
+
+If a vulnerability disclosure forces an out-of-cycle patch:
+
+1. Branch privately from `main`, fix the issue, and add a regression
+   test under `tests/security/`.
+2. Bump `VERSION` to the next patch.
+3. Open a draft Security Advisory and request a CVE if the impact is
+   user-facing.
+4. Open the PR with a private reviewer; do not announce the fix yet.
+5. Merge, tag, let the pipeline produce the signed release.
+6. Publish the advisory simultaneously with the release.
+7. Within 14 days, write a public post-mortem in the changelog
+   describing what happened, what was fixed, and what was changed in
+   the process to prevent recurrence.
+
+## Rollback
+
+To withdraw a release:
+
+```bash
+gh release delete "vX.Y.Z" --repo Arcanada-one/datarim --yes
+git push --delete origin "vX.Y.Z"
+```
+
+Caveats:
+
+- Cosign signatures on Rekor remain queryable forever; deleting the
+  GitHub release does not revoke the signature. Document why the
+  release was withdrawn in the next release's CHANGELOG.
+- If the release introduced a regression, prefer cutting `vX.Y.(Z+1)`
+  with the fix over deletion. Yanking is reserved for cases where the
+  release exposes a critical vulnerability or contains leaked
+  credentials.
+
+## Suppression policy reminder
+
+The release pipeline runs the full security gate. Suppressions in
+shipped artefacts must include a reason of at least 10 characters
+explaining *why*. The pre-commit hook and CI both enforce this.
+Suppression sprawl triggers a quarterly review by the security team.

--- a/scripts/setup-branch-protection.sh
+++ b/scripts/setup-branch-protection.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# Apply branch + tag protection rules to the public framework repo.
+#
+# Idempotent: safe to re-run. Uses the GitHub REST API via `gh api`.
+#
+# Required:
+#   - gh CLI authenticated as an org owner with admin:repo scope.
+#   - GH_REPO (default: Arcanada-one/datarim).
+#   - REQUIRED_CHECKS (comma-separated; defaults to current required
+#     CI jobs).
+#
+# Usage:
+#   ./scripts/setup-branch-protection.sh
+#   GH_REPO=Arcanada-one/datarim-fork ./scripts/setup-branch-protection.sh
+#
+# Output: prints the resolved protection settings as JSON.
+
+set -euo pipefail
+
+GH_REPO="${GH_REPO:-Arcanada-one/datarim}"
+BRANCH="${BRANCH:-main}"
+TAG_PATTERN="${TAG_PATTERN:-v*}"
+REQUIRED_CHECKS="${REQUIRED_CHECKS:-security,sanity-dual-copy,bats,dev-tools-lint,network-exposure-lint,public-surface-lint}"
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "::error::gh CLI not found in PATH" >&2
+    exit 2
+fi
+
+if ! gh auth status >/dev/null 2>&1; then
+    echo "::error::gh not authenticated; run 'gh auth login' first" >&2
+    exit 2
+fi
+
+echo "Target: ${GH_REPO} branch=${BRANCH} tag-pattern=${TAG_PATTERN}"
+echo "Required status checks: ${REQUIRED_CHECKS}"
+
+# Build the required-status-checks contexts array as JSON.
+checks_json="$(printf '%s\n' "${REQUIRED_CHECKS}" \
+    | tr ',' '\n' \
+    | python3 -c 'import json,sys; print(json.dumps([s.strip() for s in sys.stdin if s.strip()]))')"
+
+# 1. Branch protection on main.
+echo
+echo "[1/3] Applying branch protection to ${BRANCH}..."
+
+payload="$(python3 - "${checks_json}" <<'PY'
+import json
+import sys
+
+contexts = json.loads(sys.argv[1])
+payload = {
+    "required_status_checks": {
+        "strict": True,
+        "contexts": contexts,
+    },
+    "enforce_admins": True,
+    "required_pull_request_reviews": {
+        "dismiss_stale_reviews": True,
+        "require_code_owner_reviews": True,
+        "required_approving_review_count": 1,
+        "require_last_push_approval": True,
+    },
+    "restrictions": None,
+    "required_linear_history": True,
+    "allow_force_pushes": False,
+    "allow_deletions": False,
+    "required_conversation_resolution": True,
+    "block_creations": False,
+    "lock_branch": False,
+    "allow_fork_syncing": True,
+}
+print(json.dumps(payload))
+PY
+)"
+
+echo "${payload}" \
+    | gh api \
+        --method PUT \
+        -H "Accept: application/vnd.github+json" \
+        "repos/${GH_REPO}/branches/${BRANCH}/protection" \
+        --input -
+
+# 2. Required signature on protected branch (optional hardening).
+echo
+echo "[2/3] Requiring signed commits on ${BRANCH}..."
+gh api \
+    --method POST \
+    -H "Accept: application/vnd.github+json" \
+    "repos/${GH_REPO}/branches/${BRANCH}/protection/required_signatures" \
+    >/dev/null || echo "  (signed-commits requirement already set or not supported)"
+
+# 3. Tag protection rule.
+echo
+echo "[3/3] Applying tag protection pattern ${TAG_PATTERN}..."
+existing="$(gh api "repos/${GH_REPO}/tags/protection" --jq '.[] | select(.pattern == "'"${TAG_PATTERN}"'") | .id' 2>/dev/null || true)"
+if [[ -n "${existing}" ]]; then
+    echo "  pattern already protected (id=${existing}); skipping create."
+else
+    gh api \
+        --method POST \
+        -H "Accept: application/vnd.github+json" \
+        "repos/${GH_REPO}/tags/protection" \
+        -f pattern="${TAG_PATTERN}"
+fi
+
+echo
+echo "Done. Current protection state for ${BRANCH}:"
+gh api "repos/${GH_REPO}/branches/${BRANCH}/protection" --jq '{
+    enforce_admins: .enforce_admins.enabled,
+    require_code_owner_reviews: .required_pull_request_reviews.require_code_owner_reviews,
+    required_approving_review_count: .required_pull_request_reviews.required_approving_review_count,
+    required_status_checks: .required_status_checks.contexts,
+    allow_force_pushes: .allow_force_pushes.enabled,
+    allow_deletions: .allow_deletions.enabled,
+    required_linear_history: .required_linear_history.enabled
+}'
+
+echo
+echo "Tag protection patterns:"
+gh api "repos/${GH_REPO}/tags/protection" --jq '.[].pattern'


### PR DESCRIPTION
## Summary

Phase P3 of the framework Security Baseline — VSQ-ready repo hygiene and supply-chain attestation. Adds policy files, CODEOWNERS, Dependabot, branch + tag protection script, OpenSSF Scorecard workflow, README badge, and the maintainer release playbook.

## Scope

- **SECURITY.md** — vulnerability disclosure policy with explicit SLA (acknowledgement ≤72h, HIGH/CRITICAL fix ≤90d, MEDIUM ≤180d). Two private channels: GitHub Private Security Advisory + ``mail@veritasarcana.ai``.
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 by canonical upstream reference.
- **CONTRIBUTING.md** — local security gate, suppression discipline (≥10-character reason), security-first PR checklist.
- **.github/PULL_REQUEST_TEMPLATE.md** + **.github/ISSUE_TEMPLATE/security-vulnerability.md** + **.github/ISSUE_TEMPLATE/config.yml**.
- **.github/CODEOWNERS** — routes critical paths (workflows, scripts, templates, tests/security, policy files) to ``@Arcanada-one/security-reviewers``.
- **.github/dependabot.yml** — weekly grouped updates for ``github-actions`` and ``pip``.
- **scripts/setup-branch-protection.sh** — idempotent ``gh api`` script enforcing branch protection (``enforce_admins=true``, code-owner reviews, ``require_last_push_approval=true``, ``required_linear_history=true``, required status checks, no force-push, no deletions) + tag protection ``v*``. shellcheck ``-S warning`` clean. Not executed against the live repo in this PR — needs operator-run after merge.
- **.github/workflows/scorecard.yml** — OpenSSF Scorecard weekly cron (Mon 06:00 UTC) + push to main + ``workflow_dispatch``. SHA-pinned third-party actions, SARIF upload to code-scanning. actionlint clean.
- **README.md** — OpenSSF Scorecard badge.
- **docs/release-process.md** — maintainer release playbook complementing the existing ``docs/release-verification.md`` consumer recipe.

## Scope adjustments vs original P3 plan

The plan was authored on 2026-04-28 when ``main`` was at ``1.17.x``. ``main`` has since advanced past several major refactors. Adjustments:

- VERSION bump to ``1.18.0-rc2`` skipped — main is ``2.9.0``.
- ``release.yml`` already shipped via the release-workflow task (already on main).
- Dual-copy mirror skipped — repo is single-root since the doc-fanout-lint task; ``sanity-dual-copy.yml`` stays as a forward-compatible no-op.
- ``docs/standards-mapping.md`` already present.

## Verification

- ``shellcheck -S warning scripts/setup-branch-protection.sh`` → 0 findings.
- ``actionlint .github/workflows/scorecard.yml`` → 0 findings.
- ``gitleaks detect --redact`` on the branch → 0 findings.
- Public-surface lint on all new files → 0 findings.
- ``bats tests/security/`` → 29/31 passing. **Two failures (Finding 3 + Finding 6) are pre-existing on main**, not introduced by this PR. ``git log origin/main..HEAD`` against the violating files (``skills/security-baseline.md``, ``skills/infra-automation.md``, ``docs/standards-mapping.md``, ``skills/ai-quality/deployment-patterns.md``, ``docs/release-verification.md``, ``docs/getting-started.md``) returns zero commits from this PR. A follow-up task will retrofit the ``<!-- security:counter-example -->`` fence or introduce a ``<!-- security:rule-statement -->`` fence around rule-citation text.

## Operator handoff after merge

1. Provision the ``@Arcanada-one/security-reviewers`` team in the org (one member is enough initially) — without it, ``CODEOWNERS`` parses but cannot enforce required code-owner reviews.
2. Run ``scripts/setup-branch-protection.sh`` from a local checkout with ``gh`` authenticated.
3. Manually trigger the first Scorecard run via ``gh workflow run scorecard.yml -R Arcanada-one/datarim`` or wait for the Monday 06:00 UTC cron. Target score ≥ 7.0.
4. Coordinate the external corporate bot re-scan to validate AC-1 of the source PRD.

## Test plan

- [ ] PR CI green (all required checks).
- [ ] Branch protection applied via ``scripts/setup-branch-protection.sh`` post-merge.
- [ ] First Scorecard run completes with score ≥ 7.0.
- [ ] CODEOWNERS team provisioned.