### PR TITLE
ci: green-up actionlint, regression-bats, task-id-gate on main

### DIFF
--- a/.github/workflows/dr-orchestrate-contract.yml
+++ b/.github/workflows/dr-orchestrate-contract.yml
@@ -34,18 +34,22 @@ jobs:
           DR_ORCH_INBOUND_TOKEN: ${{ secrets.DR_ORCH_INBOUND_TOKEN || 'ci-test-token' }}
           DR__ORCH_DIR: ${{ github.workspace }}/plugins/dr-orchestrate
         run: |
-          export DR_ORCH_DIR="$(pwd)"
+          DR_ORCH_DIR="$(pwd)"
+          export DR_ORCH_DIR
           webhook \
             -hooks config/hooks.yaml \
             -port 8090 \
             -verbose \
             &
+          webhook_pid=$!
           # Wait for listener to be ready
-          for i in $(seq 1 10); do
-            curl -fsS http://127.0.0.1:8090 >/dev/null 2>&1 && break || true
+          for _ in $(seq 1 10); do
+            if curl -fsS http://127.0.0.1:8090 >/dev/null 2>&1; then
+              break
+            fi
             sleep 0.5
           done
-          echo "WEBHOOK_PID=$!" >> "$GITHUB_ENV"
+          echo "WEBHOOK_PID=${webhook_pid}" >> "$GITHUB_ENV"
 
       - name: Run schemathesis
         working-directory: plugins/dr-orchestrate

--- a/commands/dr-plugin.md
+++ b/commands/dr-plugin.md
@@ -1,6 +1,6 @@
 # /dr-plugin — Datarim Plugin System CLI
 
-**Source:** [PRD-TUNE-0101](../../../../datarim/prd/PRD-TUNE-0101-plugin-system-core.md), [plans/TUNE-0101-plan.md](../../../../datarim/plans/TUNE-0101-plan.md)
+**Source:** plugin-system core PRD and plan (see workspace `datarim/prd/` and `datarim/plans/` indexes).
 **Status (Phase A scaffold):** `list` + first-run bootstrap implemented; `enable`/`disable`/`sync`/`doctor` deferred to next iterations.
 
 ## Purpose

--- a/skills/ai-quality/bash-pitfalls.md
+++ b/skills/ai-quality/bash-pitfalls.md
@@ -234,7 +234,7 @@ require GNU coreutils — most dev hosts in this ecosystem are macOS.
 
 ### Why this matters in practice
 
-TUNE-0164 plan §5.4 originally specified `date +%s%N` for the security-floor
+An earlier orchestrator plan §5.4 originally specified `date +%s%N` for the security-floor
 cooldown clock. The first smoke run on the mac dev box produced timestamps
 ending in literal `%N`, breaking the cooldown arithmetic without any error.
 The fix above was applied during `/dr-do` and is now the canonical recipe.
@@ -279,7 +279,7 @@ echo 'foo: "bar"' | sed -E 's/^foo: "(.*)"$/\1/'
 
 ### Why this matters in practice
 
-TUNE-0164 plan §5.5 used `awk '... sub(/^"(.*)"$/, "\\1") ...'` for stripping
+An earlier orchestrator plan §5.5 used `awk '... sub(/^"(.*)"$/, "\\1") ...'` for stripping
 quotes around YAML scalar values. First smoke test produced `\1` literal in
 the output instead of the quoted contents. Replaced with `match()` +
 `substr()` and the fixture cleared.

--- a/skills/datarim-doctor.md
+++ b/skills/datarim-doctor.md
@@ -49,8 +49,8 @@ Examples (compliant):
 
 <!-- gate:history-allowed -->
 ```
-- TUNE-0071 · in_progress · P1 · L3 · Index-Style Refactor → tasks/TUNE-0071-task-description.md
-- INFRA-0099 · pending · P2 · L2 · Vault MFA Rollout → tasks/INFRA-0099-task-description.md
+- <TASK-ID-A> · in_progress · P1 · L3 · <Title> → tasks/<TASK-ID-A>-task-description.md
+- <TASK-ID-B> · pending · P2 · L2 · <Title> → tasks/<TASK-ID-B>-task-description.md
 ```
 <!-- /gate:history-allowed -->
 
@@ -67,7 +67,7 @@ Section headers (`## Active`, `## Pending`, etc.) and blank lines are allowed �
 ## Active Tasks
 <!-- strict mirror of tasks.md § Active — identical lines, identical order -->
 
-- TUNE-0071 · in_progress · P1 · L3 · Index-Style Refactor → tasks/TUNE-0071-task-description.md
+- <TASK-ID-A> · in_progress · P1 · L3 · <Title> → tasks/<TASK-ID-A>-task-description.md
 
 ## Last Updated
 YYYY-MM-DD HH:MM · short summary
@@ -187,7 +187,7 @@ Applied by `scripts/datarim-doctor.sh --fix`. Single transactional sequence guar
 17. Conflict policy is configurable via `--conflict-policy=prompt|keep|overwrite|skip|abort` (default `prompt`; auto-`skip` in non-TTY); `--no-prompt` is the canonical CI alias for `skip`.
 18. The legacy `backlog-archive.md` is preserved in-tree as `backlog-archive.md.pre-v2.bak` (sidecar; operator-visible).
 
-### Pass 6 — Operational-files archive section migration (TUNE-0085 v1.21.5, hardened TUNE-0088 v1.21.6)
+### Pass 6 — Operational-files archive section migration
 
 Strips legacy archive sections (`## Archived` in `tasks.md` / `backlog.md`; `### Archived`, `### Recently Archived`, `## Последние завершённые` in `activeContext.md`) and migrates each archive bullet to a canonical `documentation/archive/{area}/archive-{TASK-ID}.md` doc. The canonical thin-index contract (§ activeContext.md thin contract above, § Operational File Schema) prohibits archive sections in operational files: completion history lives in `documentation/archive/`, recency hint is computed at runtime via `/dr-status --recent N`. Pass 6 enforces that contract.
 
@@ -198,12 +198,12 @@ Four archive-bullet shapes are recognised (priority S1 → S2 → S4 → S3):
 - **S4 (mid-bold-context):** `- **TASK-ID** context-words — title` (context word(s) between `**ID**` and em-dash)
 - **S3 (plain-bold):** `- **TASK-ID** — title` (no date, no link, no mid-bold context)
 
-Task IDs may be **compound** — `DEV-1226`, `DEV-1212-S8`, `DEV-1196-FOLLOWUP-lock-ownership-doc`. Numeric component (`-[0-9]{4}`) is required; suffix `(-[A-Za-z0-9]+)*` is optional.
+Task IDs may be **compound** — `<PREFIX-NNNN>`, `<PREFIX-NNNN>-<SUFFIX>`, `<PREFIX-NNNN>-<FOLLOWUP-SLUG>`. Numeric component (`-[0-9]{4}`) is required; suffix `(-[A-Za-z0-9]+)*` is optional.
 
 Per bullet:
 
 1. Validate task ID matches `^[A-Z]{2,10}-[0-9]{4}(-[A-Za-z0-9]+)*$`. Invalid → preserve in operational file with manual-migration marker.
-2. **Explicit-pointer dispatch:** if bullet body contains `→ documentation/archive/{path}.md`, prefer that path as canonical; otherwise fall back to `prefix_to_area()` (TUNE-0076 mapping) → `documentation/archive/{area}/archive-{ID}.md`.
+2. **Explicit-pointer dispatch:** if bullet body contains `→ documentation/archive/{path}.md`, prefer that path as canonical; otherwise fall back to `prefix_to_area()` (prefix→area mapping) → `documentation/archive/{area}/archive-{ID}.md`.
 3. Path-traversal safety: canonical path MUST stay under `documentation/archive/`; violation rejects explicit pointer and falls back to `prefix_to_area`. If fallback also escapes → preserve, warn.
 4. **Verified case** — canonical archive exists with `{ID}` literal inside → strip bullet from operational file.
 5. **Missing case** — canonical absent at computed path → defensive `find documentation/archive/ -name "archive-{ID}.md"` (depth ≤ 3) checks every area subdir; if found with ID literal, strip bullet with warning `archive at unexpected area`. Otherwise synthesise stub with frontmatter (`id`, `title`, `status`, `{status}_at`, `source: synthesised from operational-file by datarim-doctor.sh Pass 6`, `original_block_sha`) + body = original bullet content; strip bullet.
@@ -213,12 +213,12 @@ Per bullet:
 
 Unparseable bullets (no shape match) → preserve with warning `Pass 6: unparseable archive bullet`. Operator fixes manually.
 
-After per-file processing, Doctor logs a one-line summary: `Pass 6 {file}: parsed={N} stripped={M} synthesised={K} skipped={L}`. Distributed users see exactly what migrated; tarball backup (TUNE-0077) covers rollback.
+After per-file processing, Doctor logs a one-line summary: `Pass 6 {file}: parsed={N} stripped={M} synthesised={K} skipped={L}`. Distributed users see exactly what migrated; tarball backup covers rollback.
 
 **Idempotent:** files without any archive header early-return; second `--fix` on a migrated tree produces zero changes.
 
 <!-- security:counter-example -->
-*Counter-example — what Doctor MUST NOT do (Approach D, rejected by QA TUNE-0085):* add a whitelist exception that preserves archive sections by design. This would legalise non-compliant pattern, accumulate token-bloat in operational files (12-18 KB on typical installations × 10-30 reads per session = 120-540 KB lost tokens), and contradict the canonical contract `datarim-system.md § activeContext.md thin contract` («one section only», v1.19.1). Migration, not preservation, is the correct enforcement.
+*Counter-example — what Doctor MUST NOT do (Approach D, rejected on QA):* add a whitelist exception that preserves archive sections by design. This would legalise non-compliant pattern, accumulate token-bloat in operational files (12-18 KB on typical installations × 10-30 reads per session = 120-540 KB lost tokens), and contradict the canonical contract `datarim-system.md § activeContext.md thin contract` («one section only», v1.19.1). Migration, not preservation, is the correct enforcement.
 <!-- /security:counter-example -->
 
 ### Pass 7 — HTML-comment archive notes (verified-strip)

--- a/skills/datarim-system.md
+++ b/skills/datarim-system.md
@@ -43,7 +43,7 @@ Separator: `·` (U+00B7 MIDDLE DOT). Arrow: `→` (U+2192). Title: 1–80 chars,
 Example:
 <!-- gate:history-allowed -->
 ```
-- TUNE-0071 · in_progress · P1 · L3 · Index-Style Refactor → tasks/TUNE-0071-task-description.md
+- <TASK-ID> · in_progress · P1 · L3 · <Title> → tasks/<TASK-ID>-task-description.md
 ```
 <!-- /gate:history-allowed -->
 
@@ -164,7 +164,7 @@ structure (literal `Edit` operations against the plan-quoted code).
 working context window if loaded raw, and forces re-reads at every
 verification stage. One delegated call returns a stable specification that
 anchors every subsequent decision and survives session compaction. This
-pattern was canonicalised after TUNE-0164 (775-line plan, 436-line PRD,
+pattern was canonicalised in v2 of the orchestrator plan (775-line plan, 436-line PRD,
 431-line INSIGHTS) shipped end-to-end without ever reading the plan body
 into the main context, with zero V-AC misses.
 

--- a/skills/reflecting.md
+++ b/skills/reflecting.md
@@ -47,7 +47,7 @@ This skill is **invoked internally by `/dr-archive` Step 0.5** for every complet
     - This is a suggestion only — do not run optimization automatically.
 8.  **FOLLOW-UP TASKS**:
     - Review the "Next Steps" section of the reflection document.
-    - **Out-of-scope drift auto-detection (TUNE-0082):** scan implementation notes and "What Didn't" section for phrases indicating drift spotted but not fixed (heuristics: `out-of-scope`, `still stale`, `also stale`, `runtime ... lagging`, `symmetric ... drift`, `separate task`, `deferred`, `noted for follow-up`). For each match, auto-suggest a follow-up backlog entry with proposed prefix + brief title rather than relying on operator memory. Surface the suggestions explicitly in the reflection's "Follow-Up Tasks" section so `/dr-archive` Step 4 picks them up.
+    - **Out-of-scope drift auto-detection:** scan implementation notes and "What Didn't" section for phrases indicating drift spotted but not fixed (heuristics: `out-of-scope`, `still stale`, `also stale`, `runtime ... lagging`, `symmetric ... drift`, `separate task`, `deferred`, `noted for follow-up`). For each match, auto-suggest a follow-up backlog entry with proposed prefix + brief title rather than relying on operator memory. Surface the suggestions explicitly in the reflection's "Follow-Up Tasks" section so `/dr-archive` Step 4 picks them up.
     - If follow-up tasks are identified, **return the list to `/dr-archive` Step 4 consumer** (do NOT write to backlog here).
     - `/dr-archive` Step 4 handles backlog writes to keep the workflow clean.
 9.  **OUTPUT**: `datarim/reflection/reflection-[id].md`.

--- a/skills/research-workflow.md
+++ b/skills/research-workflow.md
@@ -143,7 +143,7 @@ The plan was written within the last 24 hours, no parallel sessions touched the 
 
 ### Source
 
-INFRA-0015 Phase 1 (2026-05-04): plan called for one integration approach; pre-flight discovery showed that an earlier task in the same project had already shipped the alternative approach (a substantial body of working code). Following the plan would have discarded shipped work. Pivot to the rejected-but-now-correct alternative was captured in `INSIGHTS-INFRA-0015.md` § GD-01. Phase 1 effort dropped from a planned 1-2 days to ~2 hours by following the plan's already-rejected alternative — with a concrete reason for the pivot rather than blind execution.
+Example — past task Phase 1: plan called for one integration approach; pre-flight discovery showed that an earlier task in the same project had already shipped the alternative approach (a substantial body of working code). Following the plan would have discarded shipped work. Pivot to the rejected-but-now-correct alternative was captured in the corresponding `INSIGHTS-<TASK-ID>.md` § GD-01. Phase 1 effort dropped from a planned 1-2 days to ~2 hours by following the plan's already-rejected alternative — with a concrete reason for the pivot rather than blind execution.
 
 ---
 

--- a/skills/security-baseline.md
+++ b/skills/security-baseline.md
@@ -9,7 +9,7 @@ target_aal: 2
 # Security Baseline (S1–S9)
 
 > **Authority:** RFC 2119 keywords (MUST / MUST NOT / SHOULD / MAY) apply throughout this document.
-> **Origin:** corporate security audit, 2026-04-28 — full audit log: `~/arcanada/documentation/archive/security/findings-2026-04-28.md` (relocated from framework repo by TUNE-0090, 2026-05-03). Research baseline: `~/arcanada/datarim/insights/INSIGHTS-security-baseline-oss-cli-2026.md`.
+> **Origin:** corporate security audit, 2026-04-28 — full audit log: `~/arcanada/documentation/archive/security/findings-2026-04-28.md` . Research baseline: `~/arcanada/datarim/insights/INSIGHTS-security-baseline-oss-cli-2026.md`.
 > **Companion skills:** [`skills/security.md`](security.md) (operational recipes — git history scrub, Tailscale+VPN coexistence, recon-vs-compromise heuristics, cross-stack relative-path includes) and [`skills/release-verify.md`](release-verify.md) (S4 consumer-side verify entry point).
 > **CI baseline:** [`tests/security/baseline.json`](../tests/security/baseline.json) — machine-readable suppressions registry + required-jobs status.
 > **Standards mapping:** [`docs/standards-mapping.md`](../docs/standards-mapping.md) (S8 — full ASVS / SOC 2 / ISO 27001 / CIS table).
@@ -34,7 +34,9 @@ target_aal: 2
 
 ## Threat model
 
-Datarim ships skills, templates, agents, and commands that AI agents copy into runtime and execute, often with elevated privileges (root SSH, OAuth tokens with write scope, package installation). A vulnerable line in a shipped script is replicated into every consumer's production runbook. A documented `curl | bash` recipe in a skill becomes the canonical install pattern across the ecosystem. **Every shipped artefact is production code under attack.**
+Datarim ships skills, templates, agents, and commands that AI agents copy into runtime and execute, often with elevated privileges (root SSH, OAuth tokens with write scope, package installation). A vulnerable line in a shipped script is replicated into every consumer's production runbook. <!-- security:rule-statement -->
+A documented `curl | bash` recipe in a skill becomes the canonical install pattern across the ecosystem.
+<!-- /security:rule-statement --> **Every shipped artefact is production code under attack.**
 
 The kill chain to defend against:
 
@@ -63,15 +65,19 @@ The baseline therefore optimises for **shipped-artefact correctness** over local
    ```
 4. **Heredoc terminators MUST be quoted** (`<<'EOF'`) to suppress shell expansion when the heredoc carries variables that must reach the consumer literally (e.g. installer recipes, snippet generators). Unquoted heredocs (`<<EOF`) are allowed only when expansion is the explicit intent — document inline.
 5. **No `eval`** on user-controlled or filesystem-derived input.
+<!-- security:rule-statement -->
 6. **No `curl | bash`** install recipes. Hash-pinned tarballs or package-manager installs only. See S4 for supply-chain detail.
 7. **No `ssh -o StrictHostKeyChecking=no`** in any canonical recipe. Bootstrap host keys via `ssh-keyscan -H "$host" >> ~/.ssh/known_hosts` and document key-rotation policy.
+<!-- /security:rule-statement -->
 8. **`shellcheck -S warning` clean** for committed `*.sh`. Suppression via `# shellcheck disable=...` MUST cite reason + finding-ID + reviewer in an adjacent comment (see § Suppression policy).
 
 ### MUST NOT
 
 - Embed `set -e` without `-u` and `-o pipefail` (silent unset-var bugs).
 - Use `cd` without `cd "$dir" || exit 1` (or strict-mode equivalent).
+<!-- security:rule-statement -->
 - Pipe-source untrusted content into a shell (`bash <(curl ...)` is `curl | bash` in disguise).
+<!-- /security:rule-statement -->
 
 ### Counter-example fence demonstration
 
@@ -167,7 +173,9 @@ with os.fdopen(fd, "w") as f:
 
 ### Required rules
 
+<!-- security:rule-statement -->
 1. **No `curl | bash`** install recipes anywhere — neither prescribed nor demonstrated outside a counter-example fence.
+<!-- /security:rule-statement -->
 2. **Hash-pinned installs** — direct downloads MUST verify SHA-256 against a checksum sourced from a separate channel (release notes, signed manifest, official mirror). Do not derive the checksum from the same URL as the artefact.
 3. **GitHub Actions pinned to commit SHA** — never tag-pinned (`@v4`), never branch-pinned (`@main`). Each `uses:` line MUST resolve to a 40-char SHA, with a comment naming the human-readable version for auditability.
 4. **Explicit `permissions:` block** at workflow or job level — least privilege by default (`permissions: { contents: read }`), elevate only where required.
@@ -203,7 +211,9 @@ Corrected: download the tarball, verify SHA-256 against a separately-sourced che
 ### Required rules
 
 1. **Placeholders, not real IDs** — examples MUST use `<PLACEHOLDER>`, `${ENV_VAR}`, or obviously synthetic strings (`example.com`, `acme-corp`). Real OAuth client IDs, real tenant IDs, real internal hostnames in shipped docs are S3 violations.
+<!-- security:rule-statement -->
 2. **Never prescribe an unsafe pattern** outside a counter-example fence. A skill that says "this is the canonical install — `curl | bash`" silently authorises every consumer to ship that recipe. Reword OR fence.
+<!-- /security:rule-statement -->
 3. **Counter-example fence syntax is mandatory** for any block teaching what NOT to do (see canonical syntax below).
 4. **Scope-aware claims** — a skill that names a stack (NestJS, Django, etc.) MUST live behind `<!-- gate:example-only -->` or be relocated to a project's `CLAUDE.md`. Framework runtime stays stack-agnostic per [`skills/evolution/stack-agnostic-gate.md`](evolution/stack-agnostic-gate.md).
 
@@ -409,7 +419,7 @@ Both skills cross-link freely; neither replaces the other. CLAUDE.md § Security
 
 ## Source artefacts
 
-- Corporate audit, 2026-04-28: `~/arcanada/documentation/archive/security/findings-2026-04-28.md` (relocated from framework repo by TUNE-0090, 2026-05-03)
+- Corporate audit, 2026-04-28: `~/arcanada/documentation/archive/security/findings-2026-04-28.md` 
 - Audit baseline (machine-readable): [`tests/security/baseline.json`](../tests/security/baseline.json)
 - Research baseline: `~/arcanada/datarim/insights/INSIGHTS-security-baseline-oss-cli-2026.md` (575 LoC OSS CLI security research, 2026-04-28)
 - Recovery archive (incident → rule expansion): security incident archive at `documentation/archive/security/`

--- a/tests/security/finding-3-ssh-host-key-bypass.bats
+++ b/tests/security/finding-3-ssh-host-key-bypass.bats
@@ -6,6 +6,8 @@
 # Datarim § Security Mandate S1 forbids unfenced StrictHostKeyChecking=no in any
 # shipped artifact. Pedagogical counter-examples must be wrapped in
 # <!-- security:counter-example --> ... <!-- /security:counter-example -->.
+# Canonical rule-statement text that cites the forbidden literal pattern is
+# wrapped in <!-- security:rule-statement --> ... <!-- /security:rule-statement -->.
 
 setup() {
   REPO_ROOT="$(git -C "$BATS_TEST_DIRNAME" rev-parse --show-toplevel)"
@@ -26,6 +28,10 @@ for root in roots:
         cleaned = re.sub(
             r'<!-- security:counter-example -->.*?<!-- /security:counter-example -->',
             '', text, flags=re.S,
+        )
+        cleaned = re.sub(
+            r'<!-- security:rule-statement -->.*?<!-- /security:rule-statement -->',
+            '', cleaned, flags=re.S,
         )
         for m in re.finditer(r'StrictHostKeyChecking\s*=\s*no', cleaned):
             line = cleaned[:m.start()].count('\n') + 1

--- a/tests/security/finding-6-curl-bash-install.bats
+++ b/tests/security/finding-6-curl-bash-install.bats
@@ -6,6 +6,8 @@
 # Datarim § Security Mandate S4 forbids unfenced `curl ... | bash` (or sh) in
 # any shipped artifact. Pedagogical counter-examples must be wrapped in
 # <!-- security:counter-example --> ... <!-- /security:counter-example -->.
+# Canonical rule-statement text that cites the forbidden literal pattern is
+# wrapped in <!-- security:rule-statement --> ... <!-- /security:rule-statement -->.
 
 setup() {
   REPO_ROOT="$(git -C "$BATS_TEST_DIRNAME" rev-parse --show-toplevel)"
@@ -27,6 +29,10 @@ for root in roots:
         cleaned = re.sub(
             r'<!-- security:counter-example -->.*?<!-- /security:counter-example -->',
             '', text, flags=re.S,
+        )
+        cleaned = re.sub(
+            r'<!-- security:rule-statement -->.*?<!-- /security:rule-statement -->',
+            '', cleaned, flags=re.S,
         )
         for m in pattern.finditer(cleaned):
             line = cleaned[:m.start()].count('\n') + 1


### PR DESCRIPTION
Closes 3 of the 9 baseline-red jobs on `security.yml`:

- **actionlint** — fix SC2155/SC2034/SC2015 in `.github/workflows/dr-orchestrate-contract.yml` shell block.
- **regression-bats** — extend Finding 3 + Finding 6 scanners to honour `<!-- security:rule-statement -->` fence around canonical rule-citation text. Wrap matching rule statements in `skills/security-baseline.md`.
- **task-id-gate** — strip 20 task-ID provenance references from `skills/` and `commands/` per Public Surface Hygiene Mandate. Replace with placeholders or rephrase. 7 files affected.

After merge, expected green: actionlint, regression-bats, task-id-gate. Still red: bandit-extracted, doc-refs, markdown-policy, semgrep, shellcheck-extracted, zizmor — addressed in follow-up PRs.