### PR TITLE
ci: green-up bats.yml full-suite — D5, T17, 155-char descs, T3a whitelist

### DIFF
--- a/scripts/datarim-doctor.sh
+++ b/scripts/datarim-doctor.sh
@@ -539,6 +539,9 @@ mkdir -p "$BACKUP_DIR"
     tar -czf "$BACKUP_TARBALL" -C "$(dirname "$ROOT_ABS")" "$(basename "$ROOT_ABS")" 2>/dev/null
 ) || { log "ERROR: backup tarball failed: $BACKUP_TARBALL"; exit 2; }
 [ -s "$BACKUP_TARBALL" ] || { log "ERROR: backup tarball empty: $BACKUP_TARBALL"; exit 2; }
+# Explicit chmod — some tar implementations override umask on the output file
+# (observed on GitHub Actions ubuntu-latest GNU tar). Backup is private.
+chmod 0600 "$BACKUP_TARBALL"
 
 # Capture pre-fix parsed-block count (single source of truth for invariant)
 PARSED_COUNT=0

--- a/skills/brainstorming.md
+++ b/skills/brainstorming.md
@@ -1,6 +1,6 @@
 ---
 name: brainstorming
-description: "You MUST use this before any creative work — creating features, building components, adding functionality, or modifying behavior. Explores user intent, requirements and design before implementation."
+description: "MUST use this before any creative work — features, components, functionality, behavior changes. Explores user intent and design before implementation."
 runtime: [claude, codex]
 current_aal: 1
 target_aal: 2

--- a/skills/finishing-a-development-branch.md
+++ b/skills/finishing-a-development-branch.md
@@ -1,6 +1,6 @@
 ---
 name: finishing-a-development-branch
-description: Use when implementation is complete, all tests pass, and you need to decide how to integrate the work - guides completion of development work by presenting structured options for merge, PR, or cleanup
+description: "Use when implementation is complete and all tests pass. Decides how to integrate the work via merge, PR, or cleanup with structured options."
 runtime: [claude, codex]
 current_aal: 1
 target_aal: 2

--- a/skills/receiving-code-review.md
+++ b/skills/receiving-code-review.md
@@ -1,6 +1,6 @@
 ---
 name: receiving-code-review
-description: Use when receiving code review feedback, before implementing suggestions, especially if feedback seems unclear or technically questionable - requires technical rigor and verification, not performative agreement or blind implementation
+description: "Use when receiving review feedback before implementing suggestions. Requires technical verification, not performative agreement or blind implementation."
 runtime: [claude, codex]
 current_aal: 1
 target_aal: 2

--- a/skills/self-verification.md
+++ b/skills/self-verification.md
@@ -1,6 +1,6 @@
 ---
 name: self-verification
-description: Orchestrator skill для runtime-aware self-verification (manual /dr-verify). Tri-layer architecture: Layer 1 deterministic floor (shell pipeline, no LLM cost) → Layer 2 cross-model peer-review (DeepSeek via coworker, ~14× cheaper than Sonnet, clean context — no self-agreement bias) → Layer 3 native runtime dispatch (Claude 3-agent parallel; Codex single-prompt retained as [experimental] fallback). Findings-only mode.
+description: "Orchestrator for runtime-aware self-verification (manual /dr-verify). Tri-layer: deterministic shell, peer-review, runtime dispatch."
 runtime: [claude, codex]
 current_aal: 1
 target_aal: 2

--- a/skills/using-git-worktrees.md
+++ b/skills/using-git-worktrees.md
@@ -1,6 +1,6 @@
 ---
 name: using-git-worktrees
-description: Use when starting feature work that needs isolation from current workspace or before executing implementation plans - ensures an isolated workspace exists via native tools or git worktree fallback
+description: "Use when starting feature work that needs isolation or before executing plans. Ensures an isolated workspace via native tools or git worktree fallback."
 runtime: [claude, codex]
 current_aal: 1
 target_aal: 2

--- a/skills/verification-before-completion.md
+++ b/skills/verification-before-completion.md
@@ -1,6 +1,6 @@
 ---
 name: verification-before-completion
-description: Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verification commands and confirming output before making any success claims; evidence before assertions always
+description: "Use before claiming work complete, fixed, or passing — and before committing or opening PRs. Run verification commands and confirm output first."
 runtime: [claude, codex]
 current_aal: 2
 target_aal: 3

--- a/tests/check-drift.bats
+++ b/tests/check-drift.bats
@@ -59,9 +59,14 @@ setup() {
 }
 
 @test "D5 AC-3 check-drift SCOPES list matches install.sh contract (static grep)" {
-    # Static check: both scripts list the same 4 scopes.
-    grep -E "^INSTALL_SCOPES=\\(agents skills commands templates\\)" "$FAKE_REPO/install.sh"
-    grep -E "^SCOPES=\\(agents skills commands templates\\)" "$FAKE_REPO/scripts/check-drift.sh"
+    # Static check: install.sh installs at least the 4 runtime scopes that
+    # check-drift.sh audits (`agents skills commands templates`).
+    # install.sh MAY install additional scopes (scripts, tests) beyond the
+    # runtime-symlink set — check-drift.sh only audits the runtime scopes.
+    # Contract: prefix-match. install.sh must declare the 4 in order at the
+    # head of the array; check-drift.sh must declare exactly those 4.
+    grep -E '^INSTALL_SCOPES=\(agents skills commands templates( [a-z]+)*\)' "$FAKE_REPO/install.sh"
+    grep -E '^SCOPES=\(agents skills commands templates\)' "$FAKE_REPO/scripts/check-drift.sh"
 }
 
 # ---------- TUNE-0030: Symlink detection ----------

--- a/tests/reflect-removal-sweep.bats
+++ b/tests/reflect-removal-sweep.bats
@@ -31,6 +31,9 @@
 #                                 commands/dr-reflect.md removal example
 #                                 (added by TUNE-0034 — fragment split; v1.10.0
 #                                 / TUNE-0013 mentioned inline)
+#   - docs/evolution-log.md       evolution-log records prior bats-baseline
+#                                 entries that mention the historical
+#                                 /dr-reflect command — read-only ledger.
 #   - changelog.php (website)     v1.10.0 release entry — not in framework
 #                                 repo; covered by Phase 5 website sweep.
 #   - documentation/archive/framework/  historical task archives
@@ -43,6 +46,7 @@ REPO="${BATS_TEST_DIRNAME}/.."
 WHITELIST=(
     "CLAUDE.md"
     "docs/pipeline.md"
+    "docs/evolution-log.md"
     "commands/dr-archive.md"
     "skills/reflecting.md"
     "skills/evolution.md"


### PR DESCRIPTION
Closes 4 of the 6 failing bats tests in `bats.yml` full-suite. Remaining 2 (shared-mode untracked-file, T17b-related) require CI re-run to confirm — they pass locally on macOS but failed on Linux CI baseline.

- **D5 check-drift SCOPES**: relax install.sh regex (it ships scripts + tests via legacy copy mode; check-drift.sh audits only the 4 runtime scopes).
- **T17 backup mode**: explicit `chmod 0600` after tar — observed GH Actions GNU tar overriding subshell umask 077.
- **155-char skill descriptions**: shorten 6 over-budget descriptions to 132–152 chars.
- **T3a dr-reflect whitelist**: add `docs/evolution-log.md` (historical ledger) to the whitelist.