### PR TITLE
ci: close remaining bats.yml failures (T17 stat-order, T47 untracked-file classification)

### DIFF
--- a/scripts/pre-archive-check.sh
+++ b/scripts/pre-archive-check.sh
@@ -383,6 +383,20 @@ if [ -n "$SHARED_REPO" ]; then
                 block=1
                 hit_unattributed=1
             fi
+        elif [ -z "$diff_changes" ] && [ -z "$diff_changes_cached" ] \
+             && printf ',%s,' "$body_ids" | grep -q ",$TASK_ID,"; then
+            # Untracked file fallback: no diff exists, fall back to body
+            # scan. If TASK_ID is present in the body, classify as "own"
+            # (mixed when other IDs are also present). Preserves the
+            # legacy body-scan behaviour for ad-hoc untracked notes.
+            if [ "$body_ids" = "$TASK_ID" ]; then
+                klass="own"
+                hit_own=1
+            else
+                klass="mixed"
+                hit_mixed=1
+            fi
+            block=1
         elif printf ',%s,' "$diff_line_ids" | grep -q ",$TASK_ID,"; then
             # TUNE-0068: own/mixed gate considers only IDs on actual diff lines
             # (`^[+-][^+-]`). Committed-body and hunk-context IDs no longer
@@ -402,7 +416,7 @@ if [ -n "$SHARED_REPO" ]; then
             saw_foreign=1
         fi
         printf '%s\t%s\t%s\n' "$file" "$klass" "$found_ids"
-    done < <(git -C "$SHARED_REPO" status --porcelain 2>/dev/null)
+    done < <(git -C "$SHARED_REPO" status --porcelain --untracked-files=all 2>/dev/null)
 
     if [ "$block" -eq 0 ]; then
         # Schema-compliance gate (TUNE-0071) runs after clean-git success.

--- a/tests/datarim-doctor.bats
+++ b/tests/datarim-doctor.bats
@@ -186,7 +186,10 @@ teardown() {
     mkdir -p "$BACKUP_DIR"
     DATARIM_DOCTOR_BACKUP_DIR="$BACKUP_DIR" "$DOCTOR" --root="$TMPROOT/datarim" --fix >/dev/null
     tarball="$(find "$BACKUP_DIR" -name 'datarim-backup-*.tgz')"
-    mode="$(stat -f '%Lp' "$tarball" 2>/dev/null || stat -c '%a' "$tarball" 2>/dev/null)"
+    # Try GNU stat first (Linux: `-c %a`), fall back to BSD/macOS stat
+    # (`-f %Lp`). The reverse order silently mis-reports on Linux because
+    # GNU `stat -f` switches the command into file-system-status mode.
+    mode="$(stat -c '%a' "$tarball" 2>/dev/null || stat -f '%Lp' "$tarball" 2>/dev/null)"
     [ "$mode" = "600" ]
 }
 


### PR DESCRIPTION
Closes the last 2 of 6 baseline-red bats tests:

- **T17** — `stat -f` is file-system-status on GNU/Linux; output was garbage but exit-zero, masking the chmod fix. Reorder to try `stat -c` (Linux) first.
- **T47** — `git status --porcelain` collapses untracked subdirs to `?? datarim/`; the script saw a directory path and skipped body scan. Switched to `--untracked-files=all` so individual files are listed, and added an own/mixed classification branch for untracked files whose body contains the operator's `--task-id`.