### PR TITLE
ci: close remaining security.yml jobs (markdown-policy, doc-refs, semgrep, shellcheck-extracted, bandit-extracted, zizmor)

### DIFF
--- a/.docrefignore
+++ b/.docrefignore
@@ -15,3 +15,11 @@
 
 # --- Phantom template referenced by skills/security-baseline.md (TUNE-0045 carry-over)
 templates/security-workflow.yml
+
+# --- Phantom Diátaxis stub-file headers in templates/project-docs-stubs.md.
+# The template defines stub file CONTENT (consumer creates the files).
+# Linter mis-detects "## File: <path>" headers as bare-path mentions.
+docs/reference/architecture.md
+docs/how-to/testing.md
+docs/how-to/deployment.md
+docs/how-to/gotchas.md

--- a/.github/workflows/dr-orchestrate-contract.yml
+++ b/.github/workflows/dr-orchestrate-contract.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Install Python + schemathesis
         run: pip install schemathesis

--- a/.github/workflows/network-exposure-lint.yml
+++ b/.github/workflows/network-exposure-lint.yml
@@ -61,12 +61,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout target repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Checkout Datarim linter
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Arcanada-one/datarim
           ref: ${{ inputs.datarim_ref }}

--- a/.github/workflows/public-surface-lint.yml
+++ b/.github/workflows/public-surface-lint.yml
@@ -52,12 +52,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout target repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Checkout Datarim linter
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: Arcanada-one/datarim
           ref: ${{ inputs.datarim_ref }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -346,6 +346,8 @@ jobs:
             awk '
               /^[[:space:]]*<!--[[:space:]]*security:counter-example[[:space:]]*-->[[:space:]]*$/ { skip=1; next }
               /^[[:space:]]*<!--[[:space:]]*\/security:counter-example[[:space:]]*-->[[:space:]]*$/ { skip=0; next }
+              /^[[:space:]]*<!--[[:space:]]*security:rule-statement[[:space:]]*-->[[:space:]]*$/ { skip=1; next }
+              /^[[:space:]]*<!--[[:space:]]*\/security:rule-statement[[:space:]]*-->[[:space:]]*$/ { skip=0; next }
               skip == 1 { next }
               /StrictHostKeyChecking=no/ { printf "%s:%d:[ssh-disable] %s\n", FILENAME, NR, $0; found=1 }
               /curl[[:space:]]+[^|]*\|[[:space:]]*bash([[:space:]]|$)/ { printf "%s:%d:[curl-bash] %s\n", FILENAME, NR, $0; found=1 }

--- a/docs/standards-mapping.md
+++ b/docs/standards-mapping.md
@@ -43,7 +43,9 @@ A Datarim-managed project that wants ASVS v5 Level 2 must add an application-lev
 
 Datarim baseline aligns with the **Common Criteria** (CC1–CC9), specifically:
 
+<!-- security:rule-statement -->
 - **CC6 — Logical & Physical Access:** S3 (credentials), S2 (atomic mode-0o600 writes), S1 (no `StrictHostKeyChecking=no`).
+<!-- /security:rule-statement -->
 - **CC7 — System Operations:** S7 (CI verification gate), S9 (incident response).
 - **CC8 — Change Management:** S4 (supply chain), S5 (docs-as-code), S6 (repo hygiene).
 - **CC9 — Risk Mitigation:** S4 (signed releases, SBOM), S6 (CODEOWNERS, branch protection).

--- a/scripts/datarim-doctor.sh
+++ b/scripts/datarim-doctor.sh
@@ -23,6 +23,7 @@
 # Source: PRD-TUNE-0071, plans/TUNE-0071-plan.md.
 
 set -euo pipefail
+# nosemgrep: bash.lang.security.ifs-tampering.ifs-tampering -- intentional strict-mode IFS scope is process-wide, single-script
 IFS=$'\n\t'
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/scripts/dr-plugin.sh
+++ b/scripts/dr-plugin.sh
@@ -24,6 +24,7 @@
 # Source: PRD-TUNE-0101, plans/TUNE-0101-plan.md § Phase A.
 
 set -euo pipefail
+# nosemgrep: bash.lang.security.ifs-tampering.ifs-tampering -- intentional strict-mode IFS scope is process-wide, single-script
 IFS=$'\n\t'
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"

--- a/skills/ai-quality/deployment-patterns.md
+++ b/skills/ai-quality/deployment-patterns.md
@@ -258,6 +258,7 @@ Register `close_client()` in FastAPI lifespan `yield` block.
 Never use `except Exception: pass` in production code. Always log with `exc_info=True`:
 
 ```python
+# nosec-extract -- pedagogical except-fragment, intentionally non-parsable
 # BAD
 except Exception:
     pass

--- a/skills/security-baseline.md
+++ b/skills/security-baseline.md
@@ -137,9 +137,10 @@ Corrected:
 
 ```python
 import os, requests
+CRED_PATH = os.environ["CREDS_PATH"]
 resp = requests.get(url, timeout=10)  # verify=True by default
 resp.raise_for_status()
-fd = os.open("/tmp/cred.txt", os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+fd = os.open(CRED_PATH, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
 with os.fdopen(fd, "w") as f:
     f.write(resp.text)
 ```

--- a/templates/docker-smoke-checklist.md
+++ b/templates/docker-smoke-checklist.md
@@ -11,7 +11,8 @@ Reference: `$HOME/.claude/skills/testing.md` § Live Docker Smoke Test Before Ar
 ## Step 1 — Compose Validity
 
 ```bash
-cd <repo>/_docker && docker compose config --quiet && echo VALID || echo INVALID
+# noshellcheck-extract
+cd "$REPO_DIR/_docker" && docker compose config --quiet && echo VALID || echo INVALID
 ```
 
 **PASS**: `VALID` printed. **FAIL**: any YAML parse / schema error.


### PR DESCRIPTION
Closes the last 6 baseline-red jobs on `security.yml`. After merge all 14 jobs in the security workflow should be green.

- **markdown-policy**: awk scanner now honours `<!-- security:rule-statement -->` fence; remaining rule-citation in standards-mapping.md fenced.
- **doc-refs**: 4 template-stub-path orphans added to `.docrefignore` baseline.
- **semgrep**: 2× `bash.lang.security.ifs-tampering` suppressed inline with reason (strict-mode IFS).
- **shellcheck-extracted**: docker-smoke-checklist template — `<repo>` placeholder replaced with `$REPO_DIR` variable + extract-skip marker.
- **bandit-extracted**: security-baseline.md GOOD example uses env var instead of hardcoded /tmp path; deployment-patterns.md non-parsable except-fragment marked nosec-extract.
- **zizmor**: 5× `actions/checkout@v6` SHA-pinned to v6.0.2.