### PR TITLE
ci: close zizmor (dependabot-auto-merge dangerous-triggers + dr-orchestrate-contract permissions)

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -10,6 +10,10 @@ name: dependabot-auto-merge
 # the checks pass.
 
 on:
+  # zizmor: ignore[dangerous-triggers] — pull_request_target is the canonical
+  # Dependabot auto-merge pattern. The workflow runs with the base-ref code,
+  # not PR code; only metadata is inspected by the action. Branch protection
+  # required-status-checks guard the actual merge.
   pull_request_target:
     branches: [main]
 

--- a/.github/workflows/dr-orchestrate-contract.yml
+++ b/.github/workflows/dr-orchestrate-contract.yml
@@ -8,6 +8,9 @@ on:
     paths:
       - 'plugins/dr-orchestrate/**'
 
+permissions:
+  contents: read
+
 jobs:
   schemathesis:
     name: Schemathesis contract tests


### PR DESCRIPTION
Closes the last blocking job in security.yml.

- dependabot-auto-merge.yml: inline `zizmor: ignore[dangerous-triggers]` with rationale — `pull_request_target` is the canonical Dependabot pattern (workflow uses base-ref code only; required-status-check gating is on main).
- dr-orchestrate-contract.yml: top-level least-privilege `permissions: { contents: read }` block.

After merge security.yml should be green. shellcheck-extracted/bandit-extracted remain continue-on-error per P2.5 baseline triage — not blocking.