### PR TITLE
TUNE-0217: CI cleanup — semgrep + task-id-gate + T359 desc trim

### DIFF
--- a/commands/dr-archive.md
+++ b/commands/dr-archive.md
@@ -17,7 +17,7 @@ Complete and archive current task.
 
 0. **TASK RESOLUTION**: Apply Task Resolution Rule from `$HOME/.claude/skills/datarim-system.md` § Task Resolution Rule. Resolve which task is being archived (from argument or disambiguation). Use the resolved task ID for all subsequent steps.
 
-0.05. **READ INIT-TASK** (mandatory per `$HOME/.claude/skills/init-task-persistence.md`): Open `datarim/tasks/{TASK-ID}-init-task.md` if present. Read the full `## Operator brief (verbatim)` section AND every `## Append-log` entry. The archive document MUST include a `## Выполнение ожиданий оператора` section (F6 of TUNE-0210 contract) that reflects how each operator-stated expectation was met. Missing init-task is non-blocking on archive — note its absence under § Legacy and continue.
+0.05. **READ INIT-TASK** (mandatory per `$HOME/.claude/skills/init-task-persistence.md`): Open `datarim/tasks/{TASK-ID}-init-task.md` if present. Read the full `## Operator brief (verbatim)` section AND every `## Append-log` entry. The archive document MUST include a `## Выполнение ожиданий оператора` section (F6 of init-task contract) that reflects how each operator-stated expectation was met. Missing init-task is non-blocking on archive — note its absence under § Legacy and continue.
 
 0.1. **PRE-ARCHIVE CLEAN-GIT CHECK** (MANDATORY):
 
@@ -182,7 +182,7 @@ Complete and archive current task.
    - Task summary
    - Implementation details
    - Reflection insights
-   - **`## Выполнение ожиданий оператора` section (MANDATORY when `datarim/tasks/{TASK-ID}-expectations.md` exists, per F6 of TUNE-0210 contract):**
+   - **`## Выполнение ожиданий оператора` section (MANDATORY when `datarim/tasks/{TASK-ID}-expectations.md` exists, per F6 of the init-task contract):**
      - Read `datarim/tasks/{TASK-ID}-expectations.md` and render every item from `## Ожидания` in its original order.
      - Each rendered bullet: bold operator-words formulation, followed by the final `/dr-qa` status word (one of «выполнено», «частично», «не выполнено», «неприменимо» — never the schema enum `met`/`partial`/`missed`/`n-a`) and one or two plain-language sentences of comment sourced from the item's most recent `#### История статусов` line (`reason: …`).
      - **No tables in this section.** Bullet list only (single-level allowed; nested bullets forbidden).

--- a/dev-tools/check-expectations-checklist.sh
+++ b/dev-tools/check-expectations-checklist.sh
@@ -382,7 +382,7 @@ verify_routing() {
 
     if [ "${#blocking[@]}" -gt 0 ]; then
         local focus
-        focus=$(IFS=,; echo "${blocking[*]}")
+        focus=$(IFS=,; echo "${blocking[*]}")  # nosemgrep: bash.lang.security.ifs-tampering.ifs-tampering
         echo "BLOCKED: ${#blocking[@]} expectation(s) require resolution"
         echo "Focus items: $focus"
         echo "Next step:   /dr-do $id --focus-items $focus"

--- a/skills/init-task-persistence.md
+++ b/skills/init-task-persistence.md
@@ -1,6 +1,6 @@
 ---
 name: init-task-persistence
-description: Init-task artifact contract — verbatim operator brief + append-log, mandatory read by every pipeline command. Source of truth for operator intent across the task lifecycle.
+description: Init-task artefact: verbatim operator brief + append-log, mandatory read by every pipeline command. Source of truth for operator intent.
 runtime: [claude, codex]
 current_aal: 1
 target_aal: 2
@@ -42,7 +42,7 @@ captured_by: /dr-init         # literal — required
 operator: <name>              # operator identifier — required
 status: canonical             # canonical | amended — required (transitions on first append)
 source: /dr-init              # /dr-init | backlog — recommended
-source_backlog_ref: <ref>     # only when source: backlog (e.g. backlog.md#TUNE-0042)
+source_backlog_ref: <ref>     # only when source: backlog (e.g. backlog.md#<backlog-id>)
 ---
 ```
 
@@ -87,7 +87,7 @@ _(пусто на момент создания)_
 - **Append-only by convention.** Operators may delete or edit prior entries;
   the validator does not enforce that. The convention exists so reviewers can
   trust the log as a chronological record.
-- **One entry per amendment.** Each block starts with `### <ISO-8601 timestamp>
+- **One entry per amendment.** Each block starts with `### <ISO 8601 timestamp>
   — amendment by <author>` and lists the changes as plain prose or a
   short bullet list. No tables.
 - **Reading order.** Agents read the verbatim brief first, then every
@@ -180,7 +180,7 @@ follows the `### <ISO> — amendment by …` convention but uses a distinct
 marker so `grep` and the validator can tell the two apart.
 
 ```markdown
-### <ISO-8601 timestamp> — Q&A by /dr-<stage> (round <N>)
+### <ISO 8601 timestamp> — Q&A by /dr-<stage> (round <N>)
 
 **Question (verbatim, asked by <agent role>):**
 

--- a/skills/visual-maps/pipeline-routing.md
+++ b/skills/visual-maps/pipeline-routing.md
@@ -108,7 +108,7 @@ graph LR
     style QA fill:#fbbf24,stroke:#d97706,color:#1f2937
 ```
 
-Three artefact nodes were introduced in v2.8.0 (TUNE-0210):
+Three artefact nodes were introduced in v2.8.0:
 
 - **`init-task`** — `datarim/tasks/{TASK-ID}-init-task.md`. Verbatim operator brief captured at `/dr-init`; appended (never overwritten) by the operator across the lifecycle. Read mandatorily by every pipeline command.
 - **`expectations`** — `datarim/tasks/{TASK-ID}-expectations.md`. Operator-readable wishlist of «what to verify after the work is done». Written at `/dr-prd` (or `/dr-plan` for L2 without PRD). Verified at `/dr-qa` and `/dr-compliance` via `dev-tools/check-expectations-checklist.sh --verify`.

--- a/skills/visual-maps/utility-and-dependencies.md
+++ b/skills/visual-maps/utility-and-dependencies.md
@@ -165,7 +165,7 @@ graph LR
     researcher_agent --> sys & research_wf & tech
 ```
 
-## New v2.8.0 Skills (TUNE-0210)
+## New v2.8.0 Skills
 
 Four operator-facing skills introduced in v2.8.0 augment the canonical agent ↔ skill graph above:
 


### PR DESCRIPTION
## Summary

Closes 3 of 4 CI red workflows introduced by PR #31 merge:

1. **semgrep** — `dev-tools/check-expectations-checklist.sh:385` IFS-tampering false positive (IFS scoped to subshell, safe). Inline `# nosemgrep` annotation.
2. **task-id-gate** — 7 history-agnostic violations across skills/ + commands/. Fix: drop `(TUNE-0210)` provenance suffix, `ISO-8601` → `ISO 8601`, `TUNE-0042` → `<backlog-id>`, F6 contract phrasing.
3. **T359** — `init-task-persistence` description trimmed 172 → 136 chars (cap 155).

`shellcheck-extracted` remains pre-existing informational baseline (continue-on-error), not addressed.

## Local validation

- `scripts/task-id-gate.sh skills` → PASS clean
- `scripts/task-id-gate.sh commands` → PASS clean
- `bats tests/` → 616/616 (zero fails)

## Test plan

- [x] task-id-gate scope tests T11/T12 pass
- [x] T359 description cap test passes
- [x] full bats suite green
- [ ] CI required checks all green on PR