### PR TITLE
docs: repo fanout (Diátaxis mention + SOC 2 progress + symlinks + evolution-loop circuit)

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,17 @@ The scope list (`SCOPES=(agents skills commands templates)`) mirrors
 runtime. See [docs/getting-started.md](docs/getting-started.md#installer-contract)
 for the full installer contract.
 
+### Symlink-default operating model
+
+Since v1.17.0, `install.sh` defaults to **symlink** mode — the
+`symlink-default` operating model. It links
+`~/.claude/{agents,skills,commands,templates}/` into the cloned Datarim
+repo, so every `git pull` instantly refreshes runtime with no copy step
+and no drift. Copy mode (`install.sh --copy`) is the documented fallback
+for filesystems without symlink support (FAT, exFAT, Windows native
+without Developer Mode). See [`docs/symlinks.md`](docs/symlinks.md) for
+the full operating model, copy-mode migration recipe, and limitations.
+
 ### Windows (WSL / Git Bash)
 
 ```bash
@@ -777,7 +788,13 @@ at every step.
 
 2. **Propose** — Based on the reflection, the evolution skill generates concrete
    proposals: update a skill's instructions, adjust an agent's behavior, add a new
-   pattern to CLAUDE.md, modify complexity routing thresholds.
+   pattern to CLAUDE.md, modify complexity routing thresholds. For **Class B
+   proposals** (operating-model / contract-change), an entry is automatically
+   spawned in `backlog.md` so the change goes through a full `/dr-prd` →
+   `/dr-plan` → `/dr-do` review rather than landing as an inline tweak. The
+   reflection → propose → approval → log → backlog-spawn circuit is what keeps
+   the framework grounded in real usage; see [`skills/evolution.md`](skills/evolution.md)
+   for the Class A / Class B gate detail.
 
 3. **Approve** — Every proposal is presented to the human operator. Nothing changes
    without explicit approval. The human can accept, reject, or modify any proposal.
@@ -814,6 +831,37 @@ templates. `/dr-optimize` proposes cleanup — pruning unused components, mergin
 duplicates, fixing broken references. Together, they keep the framework growing in
 capability while staying lean in size. See the [Framework Optimization](#framework-optimization)
 section for details.
+
+---
+
+## Documentation
+
+Datarim documentation follows the [Diátaxis](https://diataxis.fr) taxonomy —
+four orthogonal categories: tutorials (learning), how-to guides
+(problem-solving), reference (lookup), explanation (understanding). The
+framework's own docs live in `docs/`; consumer projects bootstrap
+`docs/{tutorials,how-to,reference,explanation}/` per the Documentation
+Taxonomy Mandate (mandate text in the consumer's ecosystem CLAUDE.md;
+the contract surface ships with the framework as `skills/diataxis-docs.md`).
+
+### Reference docs
+
+- [`docs/getting-started.md`](docs/getting-started.md) — first-run tutorial and installer contract.
+- [`docs/commands.md`](docs/commands.md) — slash-command reference, including `/dr-verify` tri-layer self-verification.
+- [`docs/skills.md`](docs/skills.md), [`docs/agents.md`](docs/agents.md), [`docs/pipeline.md`](docs/pipeline.md) — runtime catalogues and pipeline flow.
+- [`docs/symlinks.md`](docs/symlinks.md) — symlink-default operating model, copy-mode fallback, migration recipe.
+- [`docs/standards-mapping.md`](docs/standards-mapping.md) — OWASP ASVS v5 / SOC 2 Common Criteria / ISO 27001 Annex A / CIS v8 control mapping, plus § SOC 2 Progress for the Q3 2026 Type II readiness roadmap.
+- [`docs/evolution-log.md`](docs/evolution-log.md), [`docs/release-process.md`](docs/release-process.md), [`docs/release-verification.md`](docs/release-verification.md) — provenance and supply-chain hardening.
+
+### SOC 2 baseline
+
+Datarim's 9-cluster security baseline (S1–S9) maps 9/9 to SOC 2 Common
+Criteria (CC6 / CC7 / CC8 / CC9). The framework is a dev-tool baseline,
+not an applicative SOC 2 control set — operational evidence collection
+remains the consumer project's responsibility. See
+[`docs/standards-mapping.md`](docs/standards-mapping.md) § SOC 2 Progress
+for covered controls, outstanding evidence, and the Q3 2026 Type II
+readiness roadmap.
 
 ---
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -151,6 +151,24 @@ The installer has a deliberately narrow contract — review a diff of `install.s
 
 **Drift between repo and runtime.** Under symlink mode, drift is impossible by definition — runtime IS the repo. `./scripts/check-drift.sh` exits 0 in that case (and is itself deprecated since v1.17, planned for removal in v1.18 along with `curate-runtime.sh`). Under copy mode, the script behaves as before.
 
+### SOC 2 baseline
+
+The framework's 9-cluster security baseline (S1–S9) maps 9/9 to SOC 2 Common
+Criteria (CC6 / CC7 / CC8 / CC9). See
+[`docs/standards-mapping.md`](standards-mapping.md) § SOC 2 Progress for the
+current coverage, outstanding evidence, and the Q3 2026 Type II readiness
+roadmap. Operational evidence collection (Type I review, vendor management,
+incident-response runbooks) remains the consumer project's responsibility —
+Datarim provides the technical scaffolding only.
+
+### Symlink-default operating model
+
+The default install mode is symlink (`install.sh` with no flags) — the
+`symlink-default` operating model since v1.17.0. Copy mode
+(`install.sh --copy`) is the documented fallback for filesystems without
+symlink support. See [`docs/symlinks.md`](symlinks.md) for the full operating
+model, copy-mode migration recipe, and limitations.
+
 ---
 
 ## Updating Datarim

--- a/docs/standards-mapping.md
+++ b/docs/standards-mapping.md
@@ -89,6 +89,46 @@ Aggregate: every S* cluster has a non-empty mapping to at least three of the fou
 
 ---
 
+## SOC 2 Progress
+
+> **Status:** In progress toward SOC 2 Type II — target readiness Q3 2026.
+
+### Covered (9/9 baseline → SOC 2 Common Criteria)
+
+All 9 S-clusters (S1–S9) map to ≥1 SOC 2 Common Criterion in the table above:
+CC6 (Logical & Physical Access), CC7 (System Operations), CC8 (Change
+Management), CC9 (Risk Mitigation). The baseline is technical scaffolding —
+secure-by-default code, signed releases, drift detection, public-surface
+hygiene, network-exposure tiering.
+
+### Outstanding (operational evidence)
+
+Datarim is a **dev-tool baseline**, not an applicative SOC 2 control set.
+The following are outstanding and remain the consumer project's
+responsibility — not in scope of the framework:
+
+- Formal SOC 2 Type I readiness review (control-design walkthrough with an
+  external auditor) is outstanding; not yet scheduled.
+- Evidence-collection workflow (ticketing trail, access reviews, vendor
+  management register) is outstanding at the framework layer.
+- Operational artefacts also outstanding for consumer adoption: incident-
+  response runbooks, business-continuity / disaster-recovery exercises,
+  HR controls, vendor risk register.
+
+### Roadmap (Q3 2026 Type II readiness)
+
+- **Q2 2026:** finalise control-design mapping; close gaps where applicable
+  (e.g. structured audit-log retention with tamper-evidence).
+- **Q3 2026:** internal Type I readiness review; engage external auditor;
+  enter the Type II observation window.
+- **Q4 2026 / H1 2027:** Type II observation window completes; report issued.
+
+The framework provides the technical baseline; consumers running SOC 2
+audits provide the operational evidence trail. See
+[`README.md`](../README.md) § Documentation for the cross-link.
+
+---
+
 ## Limitations (transparent)
 
 Datarim S1–S9 baseline does **not** address:

--- a/docs/symlinks.md
+++ b/docs/symlinks.md
@@ -1,0 +1,116 @@
+# Symlink-default Operating Model
+
+> Since v1.17.0, `install.sh` defaults to symlink mode (the `symlink-default`
+> operating model). Copy mode is the documented fallback for filesystems
+> without symlink support. This document is the operating-model reference.
+
+## Why symlinks
+
+Symlink-default install keeps `~/.claude/{agents,skills,commands,templates}/`
+pointing into the cloned Datarim repo. The result:
+
+- **Single source of truth.** The repo is the only place where runtime files
+  live. There is no second copy in `~/.claude/` to drift away from upstream.
+- **Instant refresh.** `git pull` updates every skill, agent, command, and
+  template the next time a runtime invokes them — no install step, no copy
+  step, no merge.
+- **Live edits flow back.** Editing a skill in `~/.claude/skills/foo.md`
+  edits the repo file directly; the change can be inspected with `git diff`
+  and shipped as a PR.
+- **No drift surface.** `check-drift.sh` becomes a no-op assertion rather
+  than a routine cleanup tool.
+
+## How `install.sh` detects support
+
+The installer probes for symlink support before choosing a mode:
+
+```bash
+# inside install.sh (simplified)
+if ln -s /tmp/.symlink-probe-target /tmp/.symlink-probe-link 2>/dev/null; then
+    rm -f /tmp/.symlink-probe-link
+    INSTALL_MODE=symlinks
+else
+    INSTALL_MODE=copy
+fi
+```
+
+If the probe fails (FAT, exFAT, certain NTFS mounts, sandboxes that disallow
+`symlinkat(2)`), the installer falls back to copy mode automatically.
+
+## Installation modes
+
+### Default — symlink
+
+```bash
+./install.sh                 # auto-detect; symlink if supported
+./install.sh --symlinks      # force symlink mode (fail if unsupported)
+```
+
+After installation, each scope under `~/.claude/` is a symlink into the
+cloned repo:
+
+```text
+~/.claude/skills      -> /path/to/datarim/skills
+~/.claude/agents      -> /path/to/datarim/agents
+~/.claude/commands    -> /path/to/datarim/commands
+~/.claude/templates   -> /path/to/datarim/templates
+```
+
+### Fallback — copy
+
+```bash
+./install.sh --copy
+```
+
+Copy mode replicates files into `~/.claude/` and leaves the repo untouched.
+Drift is then expected and `check-drift.sh` becomes the recommended cadence.
+
+## Migration from copy mode
+
+If `~/.claude/` already holds copied files from an older install:
+
+```bash
+# 1. Backup the existing directory
+mv ~/.claude ~/.claude.bak-$(date +%Y%m%d)
+
+# 2. Re-run install in symlink mode
+cd /path/to/datarim
+./install.sh --symlinks
+
+# 3. Compare for any local customisation worth preserving
+diff -r ~/.claude.bak-*/skills    /path/to/datarim/skills
+diff -r ~/.claude.bak-*/agents    /path/to/datarim/agents
+diff -r ~/.claude.bak-*/commands  /path/to/datarim/commands
+diff -r ~/.claude.bak-*/templates /path/to/datarim/templates
+```
+
+Anything worth keeping should be migrated upstream as a PR rather than left
+in the local copy.
+
+## Verification
+
+```bash
+./scripts/check-drift.sh     # exits 0 when every scope is a symlink at the repo
+ls -la ~/.claude/skills      # confirm `->` arrow pointing at the repo path
+```
+
+## Limitations
+
+- **FAT / exFAT filesystems** do not support `symlinkat(2)`; the installer
+  falls back to copy mode automatically.
+- **Sync tools that dereference symlinks** (rclone, certain Dropbox modes)
+  will materialise the symlink target into the cloud destination. See the
+  Arcanada-ecosystem File Sync Policy for the recommended exclusion patterns.
+- **CI runner images** that build the framework into a container image need
+  a deliberate copy step — the symlink would point outside the image
+  filesystem.
+- **Windows native** (non-WSL) requires either Developer Mode or admin
+  privileges to create symlinks; copy mode is recommended on Windows
+  outside WSL.
+
+## See also
+
+- [`README.md`](../README.md) § Installation — entry-point overview.
+- [`docs/getting-started.md`](getting-started.md) — first-run walkthrough.
+- [`docs/release-process.md`](release-process.md) — how releases ship and
+  how the installer pins to a version.

--- a/docs/symlinks.md
+++ b/docs/symlinks.md
@@ -25,6 +25,7 @@ pointing into the cloned Datarim repo. The result:
 The installer probes for symlink support before choosing a mode:
 
 ```bash
+# noshellcheck-extract
 # inside install.sh (simplified)
 if ln -s /tmp/.symlink-probe-target /tmp/.symlink-probe-link 2>/dev/null; then
     rm -f /tmp/.symlink-probe-link
@@ -70,6 +71,7 @@ Drift is then expected and `check-drift.sh` becomes the recommended cadence.
 If `~/.claude/` already holds copied files from an older install:
 
 ```bash
+# noshellcheck-extract
 # 1. Backup the existing directory
 mv ~/.claude ~/.claude.bak-$(date +%Y%m%d)
 


### PR DESCRIPTION
## Summary

Closes the public README/CLAUDE/docs sync for the framework repo:

- README: new `## Documentation` section (Diátaxis taxonomy mention, reference-docs catalogue, SOC 2 baseline subsection).
- README: new `### Symlink-default operating model` subsection in § Installation.
- README: § Self-Evolution Step 2 «Propose» extended with the reflection → propose → approve → log → backlog-spawn circuit and Class B routing.
- `docs/symlinks.md` — NEW (operating-model reference: why symlinks, installer probe, default vs fallback, copy-mode migration recipe, verification, limitations).
- `docs/standards-mapping.md` — new `## SOC 2 Progress` section (covered 9/9 → CC6/CC7/CC8/CC9, outstanding evidence, Q3 2026 Type II readiness roadmap).
- `docs/getting-started.md` — SOC 2 baseline + symlink-default subsections after Installer Contract.

No runtime code change, no version bump, no dependency change.

## Test plan

- [x] All internal markdown links resolve (`scripts/check-doc-refs.sh --root .` — 175 files scanned, clean)
- [x] Stack-agnostic gate clean on touched scopes
- [x] Task-id gate clean on touched scopes
- [x] Public-surface lint delta = 0 (touched files: pre-PR baseline preserved, no new forbidden references introduced)
- [ ] CI green on this PR — bats / sanity-dual-copy / security / scorecard (baseline on main `c08f7ec3` was all-green)