### PR TITLE
TUNE-0210: trim playwright-qa.md description 157 → 148 chars

### DIFF
--- a/skills/playwright-qa.md
+++ b/skills/playwright-qa.md
@@ -1,6 +1,6 @@
 ---
 name: playwright-qa
-description: Browser-based QA contract for frontend-touching tasks — resolution chain CLI→MCP→env-browser, headed/headless modes, artifact layout under datarim/qa/.
+description: Browser-based QA contract for frontend tasks — resolution chain CLI→MCP→env-browser, headed/headless modes, artifact layout under datarim/qa/.
 runtime: [claude, codex]
 current_aal: 1
 target_aal: 2


### PR DESCRIPTION
## Summary

Closes the compliance note from TUNE-0210 (Datarim pipeline upgrade epic):
the new `skills/playwright-qa.md` description was 157 chars, exceeding the
framework's 155-char hard cap enforced by `tests/optimize-merge.bats`.

Edit: `"frontend-touching tasks"` → `"frontend tasks"` (-9 chars, no
semantic loss — `playwright-qa` is unambiguously a frontend QA skill).

## Validation

- `awk` extract + `wc -c` = 148 chars.
- `bats tests/optimize-merge.bats` now fails only on `skills/v-ac-axis-split.md`
  (276 chars), which is the pre-existing baseline inherited from `cdce669`
  (TUNE-0183 Class A landing) and tracked separately in workspace
  follow-up TUNE-0250.
- Net regression count for the TUNE-0210 v2.8.0 fanout = 0.

## Test plan

- [x] Description ≤ 155 chars verified mechanically
- [x] No semantic loss (frontend QA scope preserved)
- [x] No other skill description regressed