### PR TITLE
chore: update Areas/ → documentation/ paths after workspace migration

### DIFF
--- a/skills/datarim-system/task-identity-and-context.md
+++ b/skills/datarim-system/task-identity-and-context.md
@@ -64,10 +64,10 @@ When a pipeline command needs a task ID, apply this logic:
 - `## Archived Tasks` table (one row per archived task)
 
 **Prohibited content** — must go to dedicated files:
-- Credentials, secrets, access policies → `Areas/Credentials/`
+- Credentials, secrets, access policies → `documentation/credentials/`
 - Specification templates, conventions → `skills/` or `docs/`
 - Audit reports → `datarim/docs/` or `documentation/`
-- Infrastructure runbooks → `Areas/Infrastructure/`
+- Infrastructure runbooks → `documentation/infrastructure/`
 - Code blocks > 50 lines → external file with link
 
 ### File Size Guards

--- a/skills/discovery.md
+++ b/skills/discovery.md
@@ -139,7 +139,7 @@ Found: Jest (from package.json devDependencies and existing test files in __test
 
 Before proposing a port number or infra-level value, verify against existing allocations:
 
-- **Ports:** check the project's port-allocation memory or infra doc (e.g. `reference_port_allocation.md` in auto-memory, or `Areas/Infrastructure/Servers.md`). Port-conflict surprises late in deploy are expensive to unwind.
+- **Ports:** check the project's port-allocation memory or infra doc (e.g. `reference_port_allocation.md` in auto-memory, or `documentation/infrastructure/Servers.md`). Port-conflict surprises late in deploy are expensive to unwind.
 - **Subdomains:** check DNS records via `dig` or the project's DNS inventory before proposing new subdomain.
 - **Database names / schemas / namespaces:** check the project's existing resources before proposing a new one.
 

--- a/skills/file-sync-config.md
+++ b/skills/file-sync-config.md
@@ -232,7 +232,7 @@ Source: https://docs.syncthing.net/users/ignoring.html
 
 Если ты исключил `/Projects/*/code` из sync, нужен alternate update mechanism для второй ноды:
 
-1. **Cron `git pull` script** — рекомендую `Areas/Infrastructure/scripts/arcanada-pull.sh` pattern:
+1. **Cron `git pull` script** — рекомендую `documentation/infrastructure/scripts/arcanada-pull.sh` pattern:
    - `git fetch` upstream
    - skip if local==remote
    - skip if branch ≠ main/master (агент в feature ветке)
@@ -259,7 +259,7 @@ Source: https://docs.syncthing.net/users/ignoring.html
 
 ## Related
 
-- `Areas/Architecture/file-sync-policy.md` (ADR) — vault-level convention для Arcanada ecosystem
-- `Areas/Infrastructure/Syncthing.md` — Syncthing deployment runbook
-- `Areas/Infrastructure/scripts/arcanada-pull.sh` — git-pull cron с CLI Claude conflict resolver
+- `documentation/architecture/file-sync-policy.md` (ADR) — vault-level convention для Arcanada ecosystem
+- `documentation/infrastructure/Syncthing.md` — Syncthing deployment runbook
+- `documentation/infrastructure/scripts/arcanada-pull.sh` — git-pull cron с CLI Claude conflict resolver
 - `templates/cli-conflict-resolver-prompt.md` — reusable Claude promp для conflict resolution

--- a/skills/infra-automation.md
+++ b/skills/infra-automation.md
@@ -27,7 +27,7 @@ Reusable patterns for SSH-based operations across Arcana servers.
 > **Bootstrap once** (Datarim § Security Mandate S1, host-key verification):
 > add the host key to `~/.ssh/known_hosts` on the operator machine before any
 > batch SSH automation. Document the exact bootstrap event in
-> `Areas/Infrastructure/known-hosts-rotation.md`.
+> `documentation/infrastructure/known-hosts-rotation.md`.
 >
 > ```bash
 > for host in <HOST_LIST>; do

--- a/skills/research-workflow.md
+++ b/skills/research-workflow.md
@@ -40,7 +40,7 @@ Quick fixes do not need research. Skip entirely.
 | 7 | **Security Advisories** | Known CVEs, npm/pip advisories, GitHub security alerts for dependencies. | WebSearch (`"CVE" + library name`) | Full |
 | 8 | **RAG/LTM Context** | Query Scrutator LTM API for relevant experience from past tasks. | `POST /v1/ltm/recall` (if MCP/API available) | Full |
 | 9 | **Existing Codebase** | Search project for reusable components, established patterns, similar implementations. | Grep, Glob, Read | Full, Lite |
-| 10 | **Infrastructure Constraints** | Check server resources, port allocation, disk/memory limits, network topology. | Read (`Areas/Infrastructure/Servers.md`, port allocation memory) | Full |
+| 10 | **Infrastructure Constraints** | Check server resources, port allocation, disk/memory limits, network topology. | Read (`documentation/infrastructure/Servers.md`, port allocation memory) | Full |
 
 ---
 


### PR DESCRIPTION
## Summary
Updates 5 skill files to reflect the workspace migration `~/arcanada/Areas/` → `~/arcanada/documentation/`:

- `Areas/Architecture/` → `documentation/architecture/`
- `Areas/Infrastructure/` → `documentation/infrastructure/`
- `Areas/Credentials/` → `documentation/credentials/`
- `Areas/Runbooks/` → `documentation/runbooks/`

Workspace canonical migration committed at `Arcanada-one/arcanada-workspace@f4a3166`.

## Files
- `skills/datarim-system/task-identity-and-context.md`
- `skills/discovery.md`
- `skills/file-sync-config.md`
- `skills/infra-automation.md`
- `skills/research-workflow.md`

## Test plan
- [x] sed replacement only — no semantic changes
- [x] cherry-picked from local `main` (commit was clean isolated against `HEAD` ancestor)
- [x] no foreign work included