### PR TITLE
ci(INFRA-0250): migrate reusable workflows to org self-hosted runners

### DIFF
--- a/.github/workflows/network-exposure-lint.yml
+++ b/.github/workflows/network-exposure-lint.yml
@@ -58,7 +58,7 @@ permissions:
 jobs:
   lint:
     name: network-exposure-lint
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     steps:
       - name: Checkout target repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/reusable-security-audit.yml
+++ b/.github/workflows/reusable-security-audit.yml
@@ -47,7 +47,7 @@ concurrency:
 jobs:
   audit:
     name: security-audit (${{ inputs.stack }})
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, linux]
     steps:
       - name: Checkout consumer repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
## Summary
- `network-exposure-lint.yml` and `reusable-security-audit.yml` flip `runs-on: ubuntu-latest` → `[self-hosted, linux]` so org consumer CI keeps working without paid GitHub Actions billing.
- Pre-requisite: `yq` (v4.44.3) and `pnpm` (system-wide) preinstalled on `arcana-ai` and `arcana-prod` runners (`arcana-db` already had both).

## Why
Operator decision 2026-05-19 (INFRA-0250 FB-5 scope pivot): no paid GitHub-hosted minutes — all CI must run on org self-hosted runners `arcana-{ai,db,prod}`. Restoring failed billing is explicitly NOT the path.

Context: GitHub Actions billing for `Arcanada-one` org failed ~2026-05-18; consumer CI on `opsbot` and `legal-arcana` has been red since. These two reusable workflows are transitive deps for both, so they migrate first (this PR), then the consumer repos in follow-up commits.

## Test plan
- [x] `gh api orgs/Arcanada-one/actions/runners` confirms three online runners with `[self-hosted, Linux, X64]` labels
- [x] Probed each runner via SSH — Node 22, pnpm, yq, docker, python3 all present
- [ ] After merge: opsbot CI rerun must show `network-exposure` job green on a self-hosted runner
- [ ] After merge: legal-arcana CI rerun must show `security-audit (typescript_pnpm)` and `network-exposure` jobs green