### PR TITLE
TUNE-0310 Wave 2: rewrite 15 mid-density commands+skills (~100 RU-lines) + Class A inline

### DIFF
--- a/commands/dr-compliance.md
+++ b/commands/dr-compliance.md
@@ -19,7 +19,7 @@ description: Adaptive post-QA hardening. Detects task type and applies matching 
     - `$HOME/.claude/skills/compliance/SKILL.md` (Adaptive checklists)
 5.  **DETECT TASK TYPE**: Read `datarim/tasks.md` (for the resolved task) and `datarim/activeContext.md`. Determine: code, documentation, research, legal, content, infrastructure, or mixed. Additionally, read `datarim/tasks/{TASK-ID}-init-task.md` if present (mandatory per `$HOME/.claude/skills/init-task-persistence/SKILL.md`): the verbatim operator brief + every append-log block. Any divergence between the operator's stated intent and the verified output MUST be surfaced in the compliance report § Plain-language summary. Missing init-task is non-blocking — flag as advisory and continue.
 5b. **VERIFY EXPECTATIONS** (mandatory when `datarim/tasks/{TASK-ID}-expectations.md` exists per `$HOME/.claude/skills/expectations-checklist/SKILL.md`):
-    -   Re-read the file. For each item under `## Ожидания`, run its `Как проверить (success criterion)` against the implementation and append one transition line to `#### История статусов` in the canonical format `<ISO> / <local> · /dr-compliance · <prior> → <new> · reason: <one-sentence plain ru>`. Update the item's `#### Текущий статус`.
+    -   Re-read the file. For each item under `## Ожидания`, run its `Как проверить (success criterion)` against the implementation and append one transition line to `#### История статусов` in the canonical format `<ISO> / <local> · /dr-compliance · <prior> → <new> · reason: <one-sentence plain ru>`. Update the item's `#### Текущий статус`. <!-- allow-non-ascii: russian-expectations-section-and-field-names-cited-from-canonical-schema -->
     -   Invoke the routing validator:
         ```bash
         dev-tools/check-expectations-checklist.sh --verify {TASK-ID}
@@ -43,18 +43,18 @@ description: Adaptive post-QA hardening. Detects task type and applies matching 
     -   When `--decided-by agent`: `--rationale-file <path>` MUST contain ≥ 50 non-whitespace characters citing the compliance-standard rationale.
     -   On contradiction with an expectation: add `--conflict-with <wish_id>` (+ optional `--conflict-detail-file`); CTA MUST route back to `/dr-do --focus-items <wish_id>` for closure before the task can be archived.
     -   Skip if no clarification rounds occurred.
-7.  **REPORT**: Output a compliance report file using the canonical structure from `${DATARIM_RUNTIME:-$HOME/.claude}/templates/compliance-report-template.md` (frontmatter `task_id`, `date`, `verdict`, optional `scope`; four top sections in strict order — «Начальная задача», «Как решили», «Артефакты задачи», «Следующие шаги» — followed by the audit addendum under `---` carrying `### Step-by-step verdicts`, `### Remaining risks`, `### Related`).
-    -   `## Начальная задача`: one Russian sentence sourced from `tasks/{TASK-ID}-init-task.md § Operator brief (verbatim)`, compressed to a single phrase.
-    -   `## Как решили`: single-level bullet list, one item per bullet in the operator brief (original order). Each bullet: bold operator-words quotation + Russian status word («выполнено» / «частично» / «не выполнено» / «неприменимо» — never the schema enum `met`/`partial`/`missed`/`n-a`) + one or two plain-language sentences. Expectations from `tasks/{TASK-ID}-expectations.md § Ожидания` are folded into the same list with marker `(уточнение брифа)` appended to the quotation. No tables in this section.
-    -   `## Артефакты задачи`: what was verified or hardened by this compliance pass (reports, modified files, refreshed contracts). Prose + bullets allowed; no verdict tables in this top section.
-    -   `## Следующие шаги`: either «всё закрыто» or concrete `/dr-*` commands / operator actions (including `/dr-archive`).
+7.  **REPORT**: Output a compliance report file using the canonical structure from `${DATARIM_RUNTIME:-$HOME/.claude}/templates/compliance-report-template.md` (frontmatter `task_id`, `date`, `verdict`, optional `scope`; four top sections in strict order — «Начальная задача», «Как решили», «Артефакты задачи», «Следующие шаги» — followed by the audit addendum under `---` carrying `### Step-by-step verdicts`, `### Remaining risks`, `### Related`). <!-- allow-non-ascii: russian-archive-template-section-names-cited-from-template -->
+    -   `## Начальная задача`: one Russian sentence sourced from `tasks/{TASK-ID}-init-task.md § Operator brief (verbatim)`, compressed to a single phrase. <!-- allow-non-ascii: russian-archive-template-section-name-cited-from-template -->
+    -   `## Как решили`: single-level bullet list, one item per bullet in the operator brief (original order). Each bullet: bold operator-words quotation + Russian status word («выполнено» / «частично» / «не выполнено» / «неприменимо» — never the schema enum `met`/`partial`/`missed`/`n-a`) + one or two plain-language sentences. Expectations from `tasks/{TASK-ID}-expectations.md § Ожидания` are folded into the same list with marker `(уточнение брифа)` appended to the quotation. No tables in this section. <!-- allow-non-ascii: russian-archive-template-section-name-cited-from-template -->
+    -   `## Артефакты задачи`: what was verified or hardened by this compliance pass (reports, modified files, refreshed contracts). Prose + bullets allowed; no verdict tables in this top section. <!-- allow-non-ascii: russian-archive-template-section-name-cited-from-template -->
+    -   `## Следующие шаги`: either «всё закрыто» or concrete `/dr-*` commands / operator actions (including `/dr-archive`). <!-- allow-non-ascii: russian-archive-template-section-name-and-status-token-cited-from-template -->
     -   Audit addendum under `---`: `### Step-by-step verdicts` (the 7-step compliance table, wrapped in `<!-- gate:literal -->` fence to bypass the banlist on English column headings), `### Remaining risks`, `### Related`.
     -   Apply the banlist from `skills/human-summary/banlist.txt` to the prose in the top four sections; the audit addendum tables MAY use `<!-- gate:literal -->` fence when they include ASCII technical terms.
 8.  **HUMAN SUMMARY**:
     - Load `$HOME/.claude/skills/human-summary/SKILL.md`.
-    - Emit the `## Отчёт оператору` (RU) / `## Operator summary` (EN) section, with the four mandated sub-sections, between the verdict / report block and the CTA block. Language follows the most recent operator message.
+    - Emit the `## Отчёт оператору` (RU) / `## Operator summary` (EN) section, with the four mandated sub-sections, between the verdict / report block and the CTA block. Language follows the most recent operator message. <!-- allow-non-ascii: russian-operator-summary-section-name-cited-from-template -->
     - Source material: § Overview of the task description, per-step results from Step 6, and the verdict from Step 7.
-    - Runs on every verdict (COMPLIANT, COMPLIANT_WITH_NOTES, NON-COMPLIANT). On NON-COMPLIANT the «Что не получилось» sub-section carries the failure detail in plain language and «Что дальше» paraphrases the FAIL-Routing CTA without command syntax.
+    - Runs on every verdict (COMPLIANT, COMPLIANT_WITH_NOTES, NON-COMPLIANT). On NON-COMPLIANT the «Что не получилось» sub-section carries the failure detail in plain language and «Что дальше» paraphrases the FAIL-Routing CTA without command syntax. <!-- allow-non-ascii: russian-verdict-tokens-not-russian-but-line-flagged-for-utf8-quote -->
     - The summary MUST honour the banlist + whitelist + per-paragraph escape-hatch contract from the skill (`<!-- gate:literal -->` … `<!-- /gate:literal -->` for verbatim quoted blocks only; max two fenced paragraphs per summary).
     - Output: chat. If `datarim/reports/compliance-report-{task_id}.md` exists, append the same section at the end of that file.
     - Length budget: 150–400 words **total across the four sub-sections** (not per sub-section). Hard upper bound.
@@ -93,7 +93,7 @@ After verdict, the compliance agent MUST emit a CTA block per `$HOME/.claude/ski
 - NON-COMPLIANT, source unclear → primary `/dr-do {TASK-ID}` (default)
 - Loop guard: 3 same-layer fails → escalate to user
 
-The CTA block MUST follow canonical FAIL-Routing format when NON-COMPLIANT (header changes to `**Compliance NON-COMPLIANT для {TASK-ID} — earliest failed layer: Layer N (Layer name)**`). Variant B menu when >1 active tasks.
+The CTA block MUST follow canonical FAIL-Routing format when NON-COMPLIANT (header changes to `**Compliance NON-COMPLIANT для {TASK-ID} — earliest failed layer: Layer N (Layer name)**`). Variant B menu when >1 active tasks. <!-- allow-non-ascii: russian-canonical-cta-marker-tokens-cited-from-cta-format-skill -->
 
 ## Stage Snapshot Emission (Mandatory Terminal Step)
 

--- a/commands/dr-do.md
+++ b/commands/dr-do.md
@@ -112,7 +112,7 @@ description: Implement planned changes using TDD and AI quality principles
     -   Update `datarim/tasks/{TASK-ID}-task-description.md` § Implementation Notes with implementation log (or `## Decisions` for design choices). Description file frontmatter `status` stays `in_progress` until `/dr-archive`.
     -   Update `datarim/tasks.md` one-liner if status transitions (e.g. `in_progress` → `blocked`); the line itself stays in canonical thin-index format.
     -   Backlog updates if subtasks discovered (new `pending` one-liners in `datarim/backlog.md`).
-    -   **Never write `datarim/progress.md`** (abolished as of v1.19.0). Per-task notes go in the description file; cross-task completion log is `activeContext.md` § «Последние завершённые», populated by `/dr-archive`.
+    -   **Never write `datarim/progress.md`** (abolished as of v1.19.0). Per-task notes go in the description file; cross-task completion log is `activeContext.md` § «Последние завершённые», populated by `/dr-archive`. <!-- allow-non-ascii: russian-active-context-section-name-cited-from-canonical-schema -->
 
 ## Transition Checkpoint
 
@@ -131,7 +131,7 @@ When auto-mode is active (env var `DATARIM_AUTO_MODE=1` AND matching marker `dat
 
 1. Consults `${DATARIM_RUNTIME:-$HOME/.claude}/skills/autonomous-mode/SKILL.md` § Question Suppression Ladder before any `AskUserQuestion` or equivalent operator prompt at this stage.
 2. Stage-specific suppression hooks:
-   - TDD red→green transitions — design choices между equivalent implementations resolved through Ladder L1 (existing pattern grep) before L5.
+   - TDD red→green transitions — design choices among equivalent implementations resolved through Ladder L1 (existing pattern grep) before L5.
    - L1 inline gap classifier — discovered gap routed per skills/autonomous-mode/SKILL.md § L1 Inline Resolution Rule decision tree (L1 Class A → inline; L2+/B → backlog; HARD → L5).
    - Append every inline-resolved gap to `datarim/tasks/{TASK-ID}-auto-inline-log.md`.
 3. Discovered gaps → apply L1 Inline Resolution Rule per `skills/autonomous-mode/SKILL.md`; log in `datarim/tasks/{TASK-ID}-auto-inline-log.md` if applied inline.
@@ -149,7 +149,7 @@ After implementation, the developer agent MUST emit a CTA block per `$HOME/.clau
 - Checks incomplete → primary `/dr-do {TASK-ID}` (continue) + alternative `/dr-status`
 - Fundamental gap discovered (Gap Discovery escalation) → primary `/dr-prd {TASK-ID}` (revise requirements)
 
-The CTA block MUST follow the canonical format (numbered list, one `**рекомендуется**`, `---` HR wrapping, task ID included). Variant B menu when >1 active tasks.
+The CTA block MUST follow the canonical format (numbered list, one `**рекомендуется**`, `---` HR wrapping, task ID included). Variant B menu when >1 active tasks. <!-- allow-non-ascii: russian-canonical-cta-marker-tokens-cited-from-cta-format-skill -->
 
 ## Stage Snapshot Emission (Mandatory Terminal Step)
 

--- a/commands/dr-init.md
+++ b/commands/dr-init.md
@@ -14,7 +14,7 @@ description: Initialize a new Datarim task or scaffold a new project. Auto-detec
 0.  **INTENT DETECTION** — Determine whether the user wants to create a **project** or a **task**:
     - Scan the user's input for project creation signals:
       - English keywords: "create project", "new project", "init project", "scaffold project", "setup project"
-      - Russian keywords: "создай проект", "новый проект", "инициализируй проект", "создать проект"
+      - Russian keywords: "создай проект", "новый проект", "инициализируй проект", "создать проект" <!-- allow-non-ascii: russian-trigger-phrases-detected-by-the-intent-classifier -->
       - Pattern: `/dr-init create project "Name"`
       - Pattern: `/dr-init new project for <description>`
     - **If project intent detected:**
@@ -124,7 +124,7 @@ description: Initialize a new Datarim task or scaffold a new project. Auto-detec
     - Determine the source flow:
       - **Operator prompt flow** (default): the `ARGUMENTS` variable (the text the operator typed after `/dr-init`) becomes the body of `## Operator brief (verbatim)`. Frontmatter `source: /dr-init`.
       - **Backlog selection flow** (the task was picked from `backlog.md` in Step 3): copy the matched backlog item's description block verbatim into `## Operator brief (verbatim)`. Frontmatter `source: backlog`, `source_backlog_ref: backlog.md#{TASK-ID}`.
-    - Write the file with the canonical 8-field frontmatter (`task_id`, `artifact: init-task`, `schema_version: 1`, `captured_at`, `captured_by: /dr-init`, `operator`, `status: canonical`, `source`) + two mandatory headings: `## Operator brief (verbatim)` and `## Append-log (operator amendments)` (empty placeholder `_(пусто на момент создания)_`). Optional `## Source command` block above the brief is recommended when the exact invocation differs from `ARGUMENTS` raw text.
+    - Write the file with the canonical 8-field frontmatter (`task_id`, `artifact: init-task`, `schema_version: 1`, `captured_at`, `captured_by: /dr-init`, `operator`, `status: canonical`, `source`) + two mandatory headings: `## Operator brief (verbatim)` and `## Append-log (operator amendments)` (empty placeholder `_(пусто на момент создания)_`). Optional `## Source command` block above the brief is recommended when the exact invocation differs from `ARGUMENTS` raw text. <!-- allow-non-ascii: russian-literal-template-placeholder-text-cited-verbatim -->
     - Probe: `bash "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-init-task-presence.sh" --task {TASK-ID} --root "$DATARIM_ROOT"` (where `$DATARIM_ROOT` is the parent of `datarim/` and `$DATARIM_RUNTIME` is the installed runtime root; falls back to `~/.claude` for default-symlinked installs that include `dev-tools/` in `INSTALL_SCOPES`). Exit 0 = OK; non-zero = print warning and continue (operator may amend manually).
     - Skip silently when re-running `/dr-init` on an existing backlog ID whose init-task already exists — preserve the verbatim history.
 
@@ -138,11 +138,11 @@ description: Initialize a new Datarim task or scaffold a new project. Auto-detec
       - Hallucination mitigation: wish title MUST trace back to a phrase or paraphrasable concept in the brief; do NOT invent goals the operator did not state. Vague brief → use the fallback skeleton below.
     - Write the file from `${DATARIM_RUNTIME:-$HOME/.claude}/templates/expectations-template.md` with:
       - **Frontmatter (canonical):** `task_id`, `artifact: expectations`, `schema_version: 2`, `captured_at`, `captured_by: /dr-init`, `agent: planner`, `status: canonical`, `parent_init_task: {TASK-ID}-init-task.md`.
-      - **Per-wish item:** title (plain Russian, ending with «.»), `wish_id` (kebab-slug, cyrillic allowed), `Что хочу проверить:` (1-2 sentences), `Как проверить (success criterion):` (concrete signal — file path, command, visible behaviour), `Связанный AC из PRD: «—»` (no PRD yet), `evidence_type: empirical` (default), `#### История статусов` one initial line `<ISO> / <local> · /dr-init · pending → pending · reason: пункт создан при инициализации задачи`, `#### Текущий статус` followed by a single bullet line carrying the value (`pending` on first write).
-      - **Schema (mandatory).** Items MUST use the canonical bullet-list shape from `skills/expectations-checklist/SKILL.md` § Body shape — i.e. one top-level bullet per wish (`- **<N>. <Title>**`) with **nested bullets** (`  - wish_id:`, `  - Что хочу проверить:`, …) and a two-line `Текущий статус` block (`  - #### Текущий статус` followed by `    - <value>`). Do **NOT** use heading-style items (`### N. Title`) or single-line «inline» status (`#### Текущий статус: pending`) — the validator parses only the bullet-list shape, and heading-style files are rejected on the very next pipeline step (see `dev-tools/check-expectations-checklist.sh --task {TASK-ID} --report` for the exact errors emitted on schema drift).
+      - **Per-wish item:** title (plain Russian, ending with «.»), `wish_id` (kebab-slug, cyrillic allowed), `Что хочу проверить:` (1-2 sentences), `Как проверить (success criterion):` (concrete signal — file path, command, visible behaviour), `Связанный AC из PRD: «—»` (no PRD yet), `evidence_type: empirical` (default), `#### История статусов` one initial line `<ISO> / <local> · /dr-init · pending → pending · reason: пункт создан при инициализации задачи`, `#### Текущий статус` followed by a single bullet line carrying the value (`pending` on first write). <!-- allow-non-ascii: russian-expectations-field-names-and-status-history-cited-from-canonical-schema -->
+      - **Schema (mandatory).** Items MUST use the canonical bullet-list shape from `skills/expectations-checklist/SKILL.md` § Body shape — i.e. one top-level bullet per wish (`- **<N>. <Title>**`) with **nested bullets** (`  - wish_id:`, `  - Что хочу проверить:`, …) and a two-line `Текущий статус` block (`  - #### Текущий статус` followed by `    - <value>`). Do **NOT** use heading-style items (`### N. Title`) or single-line «inline» status (`#### Текущий статус: pending`) — the validator parses only the bullet-list shape, and heading-style files are rejected on the very next pipeline step (see `dev-tools/check-expectations-checklist.sh --task {TASK-ID} --report` for the exact errors emitted on schema drift). <!-- allow-non-ascii: russian-expectations-field-names-cited-from-canonical-schema -->
     - Probe: `bash "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-expectations-checklist.sh" --task {TASK-ID} --root "$DATARIM_ROOT"`. Exit 0 = OK; non-zero = print warning + continue (fail-soft — operator may amend manually).
-    - **Fallback (empty / diffuse brief or LLM extraction failure):** write 1-wish skeleton with title «Цель задачи — TBD (оператор уточняет).», `wish_id: tsel-zadachi-tbd`, `evidence_type: empirical`, and an inline HTML comment `<!-- TODO: operator fills concrete wish at next /dr-prd or /dr-plan amendment -->`. This satisfies the L1+ mandate floor and surfaces the gap to the operator at the next pipeline step.
-    - This step applies to **all complexity levels L1-L4** (mandate scope — operator decision: «жёсткое требование без исключений»).
+    - **Fallback (empty / diffuse brief or LLM extraction failure):** write 1-wish skeleton with title «Цель задачи — TBD (оператор уточняет).», `wish_id: tsel-zadachi-tbd`, `evidence_type: empirical`, and an inline HTML comment `<!-- TODO: operator fills concrete wish at next /dr-prd or /dr-plan amendment -->`. This satisfies the L1+ mandate floor and surfaces the gap to the operator at the next pipeline step. <!-- allow-non-ascii: russian-fallback-skeleton-title-cited-from-template -->
+    - This step applies to **all complexity levels L1-L4** (mandate scope — operator decision: «жёсткое требование без исключений»). <!-- allow-non-ascii: russian-operator-quoted-policy-cited-verbatim -->
 
 5.  **SUBTASK BACKLOG** (Level 3-4 only):
     - If analysis reveals distinct subtasks or phases, present them to user:
@@ -160,8 +160,8 @@ When auto-mode is active (env var `DATARIM_AUTO_MODE=1` AND matching marker `dat
 
 1. Consults `${DATARIM_RUNTIME:-$HOME/.claude}/skills/autonomous-mode/SKILL.md` § Question Suppression Ladder before any `AskUserQuestion` or equivalent operator prompt at this stage.
 2. Stage-specific suppression hooks:
-   - Step 3 backlog item selection prompt — resolve через Ladder L1 (grep backlog by description match) before AskUserQuestion.
-   - Step 4 PRD waiver gate (L3-4) — resolve через Ladder L3 (operator-preference lookup in MEMORY.md feedback).
+   - Step 3 backlog item selection prompt — resolve via Ladder L1 (grep backlog by description match) before AskUserQuestion.
+   - Step 4 PRD waiver gate (L3-4) — resolve via Ladder L3 (operator-preference lookup in MEMORY.md feedback).
 3. Discovered gaps → apply L1 Inline Resolution Rule per `skills/autonomous-mode/SKILL.md`; log in `datarim/tasks/{TASK-ID}-auto-inline-log.md` if applied inline.
 4. Hard-gated actions → escalate to operator through Ladder L5; log via `dev-tools/append-init-task-qa.sh --decided-by operator` per `skills/init-task-persistence/SKILL.md` § Q&A round-trip.
 5. Mismatch (env var set, marker absent OR marker contains different TASK-ID) → emit single-line warning, treat as non-auto (fail-safe per `skills/autonomous-mode/SKILL.md` § When this skill is active).
@@ -179,7 +179,7 @@ After completing initialization, the planner agent MUST emit a CTA block per `$H
 - Backlog had pending items shown → alternative `/dr-init {BACKLOG-ID}` for any other listed item
 - Always include `/dr-status` as escape hatch
 
-The CTA block MUST: (a) include resolved task ID, (b) mark exactly one `**рекомендуется**`, (c) list ≤5 numbered options, (d) be wrapped in `---` HR. If >1 active tasks in `datarim/activeContext.md`, append `**Другие активные задачи:**` menu (Variant B).
+The CTA block MUST: (a) include resolved task ID, (b) mark exactly one `**рекомендуется**`, (c) list ≤5 numbered options, (d) be wrapped in `---` HR. If >1 active tasks in `datarim/activeContext.md`, append `**Другие активные задачи:**` menu (Variant B). <!-- allow-non-ascii: russian-canonical-cta-marker-tokens-cited-from-cta-format-skill -->
 
 ## Stage Snapshot Emission (Mandatory Terminal Step)
 

--- a/commands/dr-optimize.md
+++ b/commands/dr-optimize.md
@@ -72,7 +72,7 @@ effort: high
     | Description budget | Any description `>160` chars or total `>8K` chars | Propose `fix-description` |
     | Selective-loading candidate | Monolithic file with mixed subdomains | Propose split into entry + supporting files |
     | Low-value provenance comments | Task-origin or migration notes that do not affect usage/policy | Propose rewrite cleanup |
-    | Diátaxis docs drift | repo with ≥3 `docs/*.md` files but missing the 4-category split (`docs/{tutorials,how-to,reference,explanation}/`) per `skills/diataxis-docs/SKILL.md` | Propose `spawn-diataxis-reorg` (creates `INFRA-* — Diátaxis docs reorg для <repo>` in backlog, soft warning only) |
+    | Diátaxis docs drift | repo with ≥3 `docs/*.md` files but missing the 4-category split (`docs/{tutorials,how-to,reference,explanation}/`) per `skills/diataxis-docs/SKILL.md` | Propose `spawn-diataxis-reorg` (creates `INFRA-* — Diátaxis docs reorg for <repo>` in backlog, soft warning only) |
 
 6a. **DIÁTAXIS DOCS DRIFT DETECTOR** (filesystem-presence + threshold, soft warning):
     - Run for the audited repo root (or for each consumer repo when scanning ecosystem-wide).
@@ -97,7 +97,7 @@ effort: high
         return 0
       }
       ```
-    - On drift: propose `spawn-diataxis-reorg` — adds `INFRA-<next-num> · pending · P4 · L2 · Diátaxis docs reorg для <repo-name>` to `datarim/backlog.md`, with `Source: TUNE-* (diataxis-drift-detector)` annotation.
+    - On drift: propose `spawn-diataxis-reorg` — adds `INFRA-<next-num> · pending · P4 · L2 · Diátaxis docs reorg for <repo-name>` to `datarim/backlog.md`, with `Source: TUNE-* (diataxis-drift-detector)` annotation.
     - **Soft only** — never block build. Hard CI gate is deferred (separate backlog item: `INFRA-* — Diátaxis CI gate enforcement`, trigger: ≥3 live consumers post-mandate). When activated, the same detector flips to `exit 1` on drift.
 
 6b. **DATARIM STATE HYGIENE** (always run):
@@ -149,4 +149,4 @@ After optimize-pass, the optimizer agent MUST emit a CTA block per `$HOME/.claud
 - Need deeper restructuring → primary `/dr-design {TASK-ID}` (consilium panel)
 - Always include `/dr-status` as escape hatch
 
-The CTA block MUST follow the canonical format (numbered, one `**рекомендуется**`, `---` HR). Variant B menu when >1 active tasks.
+The CTA block MUST follow the canonical format (numbered, one `**рекомендуется**`, `---` HR). Variant B menu when >1 active tasks. <!-- allow-non-ascii: russian-canonical-cta-marker-tokens-cited-from-cta-format-skill -->

--- a/commands/dr-prd.md
+++ b/commands/dr-prd.md
@@ -65,11 +65,11 @@ This command generates a structured Product Requirements Document (PRD) followin
     -   **Per-item shape** (Option B schema; full contract in `expectations-checklist.md`):
         - title in plain Russian, ending with a period;
         - `wish_id` = kebab-slug of the title (cyrillic allowed);
-        - `Что хочу проверить:` one or two sentences;
-        - `Как проверить (success criterion):` one concrete signal;
-        - `Связанный AC из PRD:` `V-AC-<N>` или «—»;
-        - `#### История статусов` with one initial line `<ISO> / <local> · /dr-prd · pending → pending · reason: пункт создан при формировании PRD`;
-        - `#### Текущий статус` set to `pending`.
+        - `Что хочу проверить:` one or two sentences; <!-- allow-non-ascii: russian-expectations-field-name-cited-from-canonical-schema -->
+        - `Как проверить (success criterion):` one concrete signal; <!-- allow-non-ascii: russian-expectations-field-name-cited-from-canonical-schema -->
+        - `Связанный AC из PRD:` `V-AC-<N>` или «—»; <!-- allow-non-ascii: russian-expectations-field-name-cited-from-canonical-schema -->
+        - `#### История статусов` with one initial line `<ISO> / <local> · /dr-prd · pending → pending · reason: пункт создан при формировании PRD`; <!-- allow-non-ascii: russian-status-history-section-name-cited-from-canonical-schema -->
+        - `#### Текущий статус` set to `pending`. <!-- allow-non-ascii: russian-current-status-section-name-cited-from-canonical-schema -->
     -   **Append-merge if the file already exists.** Load existing items by `wish_id`. New PRD-derived wishes whose slug does not match any existing item are appended at the bottom; existing items are not rewritten. If a previously-linked AC was renamed, append one `stage: append-merge` History line to the affected item.
     -   **Post-write validation gate.** Invoke:
         ```bash
@@ -147,7 +147,7 @@ When auto-mode is active (env var `DATARIM_AUTO_MODE=1` AND matching marker `dat
 
 1. Consults `${DATARIM_RUNTIME:-$HOME/.claude}/skills/autonomous-mode/SKILL.md` § Question Suppression Ladder before any `AskUserQuestion` or equivalent operator prompt at this stage.
 2. Stage-specific suppression hooks:
-   - Step 2 Discovery Interview — каждый Q resolved through Ladder L1-L4 before falling through to Discovery prompt; business-strategy Qs go straight to L5.
+   - Step 2 Discovery Interview — each Q resolved through Ladder L1-L4 before falling through to Discovery prompt; business-strategy Qs go straight to L5.
    - Step 4 Consult User gate — proposed approach + alternatives auto-selected if Ladder unambiguous; L5 only for true cross-cutting trade-offs.
 3. Discovered gaps → apply L1 Inline Resolution Rule per `skills/autonomous-mode/SKILL.md`; log in `datarim/tasks/{TASK-ID}-auto-inline-log.md` if applied inline.
 4. Hard-gated actions → escalate to operator through Ladder L5; log via `dev-tools/append-init-task-qa.sh --decided-by operator` per `skills/init-task-persistence/SKILL.md` § Q&A round-trip.
@@ -165,7 +165,7 @@ After PRD save, the architect agent MUST emit a CTA block per `$HOME/.claude/ski
 - Backlog items proposed and accepted → mention "N items added to backlog" + primary `/dr-plan {TASK-ID}`
 - Always include `/dr-status` as escape hatch
 
-The CTA block MUST follow the canonical format (numbered, one `**рекомендуется**`, `---` HR). Variant B menu when >1 active tasks.
+The CTA block MUST follow the canonical format (numbered, one `**рекомендуется**`, `---` HR). Variant B menu when >1 active tasks. <!-- allow-non-ascii: russian-canonical-cta-marker-tokens-cited-from-cta-format-skill -->
 
 ## Stage Snapshot Emission (Mandatory Terminal Step)
 

--- a/commands/dr-status.md
+++ b/commands/dr-status.md
@@ -25,7 +25,7 @@ Show current task and Backlog status.
    filename (strip `archive-` prefix and `.md` suffix); read first matching
    `^# Archive — {ID}` heading or first `^# ` line for `{title}`; date = mtime
    formatted `YYYY-MM-DD`. Render `{date · ID · title}`. The legacy
-   `activeContext.md § Последние завершённые` was retired in v1.19.1 — single
+   `activeContext.md § Recently completed` (legacy Russian section name «Последние завершённые») was retired in v1.19.1 — single <!-- allow-non-ascii: russian-legacy-section-name-cited-from-prior-schema -->
    source of truth = `documentation/archive/`.
 
    POSIX recipe (illustrative):
@@ -58,9 +58,9 @@ After printing status, MUST emit a CTA block per `$HOME/.claude/skills/cta-forma
 **Routing logic for `/dr-status`:**
 
 - One active task → primary command for that task's current pipeline phase (resolved from `progress.md`/`tasks.md`)
-- Multiple active tasks → CTA picks the highest-priority task as primary; surfaces all others in Variant B menu (`**Другие активные задачи:**`)
+- Multiple active tasks → CTA picks the highest-priority task as primary; surfaces all others in Variant B menu (`**Другие активные задачи:**`) <!-- allow-non-ascii: russian-canonical-cta-variant-b-menu-header-cited-from-cta-format-skill -->
 - No active tasks, backlog has items → primary `/dr-init` (pick from backlog)
 - No active tasks, empty backlog → primary `/dr-init "<description>"` (start new task)
 - Always include `/dr-help` as escape hatch (command reference)
 
-The CTA block MUST follow the canonical format (numbered, one `**рекомендуется**`, `---` HR). Variant B is mandatory for `/dr-status` whenever ≥2 active tasks exist — `/dr-status` is the discovery surface for parallel work.
+The CTA block MUST follow the canonical format (numbered, one `**рекомендуется**`, `---` HR). Variant B is mandatory for `/dr-status` whenever ≥2 active tasks exist — `/dr-status` is the discovery surface for parallel work. <!-- allow-non-ascii: russian-canonical-cta-marker-tokens-cited-from-cta-format-skill -->

--- a/commands/dr-verify.md
+++ b/commands/dr-verify.md
@@ -12,7 +12,7 @@ description: Standalone self-verification of a Datarim artifact (PRD/plan/do out
 
 
 **Stage Header (mandatory)**: Emit `**{TASK-ID} · {title}**` as the first line of your response, before any tool-call narration. The title is the verbatim one-liner field from `tasks.md` (between `L{N} · ` and ` → tasks/`). Skip this header only for `/dr-help`, `/dr-status`, `/dr-doctor`, and `/dr-init` Steps 1-3 (which emit it immediately after Step 4). See `$HOME/.claude/skills/cta-format/SKILL.md` § Stage Header.
-1. **LOAD**: Read skill file `~/.claude/skills/self-verification/SKILL.md` (symlink) или canonical `Projects/Datarim/code/datarim/skills/self-verification/SKILL.md`. Adopt orchestrator persona.
+1. **LOAD**: Read skill file `~/.claude/skills/self-verification/SKILL.md` (symlink) or canonical `Projects/Datarim/code/datarim/skills/self-verification/SKILL.md`. Adopt orchestrator persona.
 2. **RESOLVE PATH**: Walk up directories from cwd to find `datarim/`. STOP if not found, tell user to run `/dr-init`.
 3. **TASK RESOLUTION**: Apply Task Resolution Rule from `datarim-system.md`. Use resolved task ID for all subsequent steps.
 4. **ARGUMENT PARSING**:
@@ -25,7 +25,7 @@ description: Standalone self-verification of a Datarim artifact (PRD/plan/do out
    - `--runtime={claude,codex}` optional, auto-detect via env (`CODEX_RUNTIME=1` → codex, else claude); affects Layer 3 only
    - `--external-verifier=PASS` optional override (Loop Exit Criteria level 1)
    - `--cost-cap=N` optional token ceiling, default = baseline `/dr-do` tokens × 1.25
-5. **CONTEXT GATHERING**: Read артефакты per `--stage`:
+5. **CONTEXT GATHERING**: Read artifacts per `--stage`:
    - `prd` → `datarim/prd/PRD-{TASK-ID}.md` + `datarim/tasks/{TASK-ID}-task-description.md`
    - `plan` → `datarim/plans/{TASK-ID}-plan.md` + `creative/creative-{TASK-ID}-*.md` (if exist)
    - `do` → `datarim/qa/qa-report-{TASK-ID}.md` (if exists) + `datarim/tasks/{TASK-ID}-task-description.md` § Implementation Notes
@@ -43,13 +43,13 @@ description: Standalone self-verification of a Datarim artifact (PRD/plan/do out
    - **Findings dedupe across layers**: tuple `(artifact_ref, ac_criteria, category)`. First-source wins in priority order: floor → peer_review → dispatch.
 7. **ITERATE**: `max-iter` cap, stop-condition checks per Loop Exit Criteria 4-level hierarchy (skill §5).
 8. **WRITE AUDIT LOG**: Append-only file `datarim/qa/verify-{task-id}-{stage}-{iter}.md` per skill §Audit Log Writer pseudocode. Apply `chmod a-w` post-write. Include: validated findings, malformed section, verdict, raw outputs (truncated if >2k chars), and `source_layer_breakdown: {floor: N, peer_review: M, dispatch: K}` summary header field.
-9. **EMIT VERDICT**: BLOCKED / CONDITIONAL / PASS per skill §Verdict Logic. CTA per `cta-format.md` (FAIL-routing для BLOCKED).
+9. **EMIT VERDICT**: BLOCKED / CONDITIONAL / PASS per skill §Verdict Logic. CTA per `cta-format.md` (FAIL-routing for BLOCKED).
 
 ## Stages
 
 | Stage | Artifacts checked | Validation focus |
 |-------|-------------------|------------------|
-| prd | PRD + task-description | AC coverage completeness, falsifiability, ≥3 risks с mitigations |
+| prd | PRD + task-description | AC coverage completeness, falsifiability, ≥3 risks with mitigations |
 | plan | plan + creative docs | Step coverage (every AC ↔ ≥1 step), security design (STRIDE), rollback explicit |
 | do | qa-report + Implementation Notes | Evidence coverage per AC, no orphan AC items, claims supported by output |
 | all | all above + cross-artifact diff | All above + drift taxonomy (`scope_creep`, `spec_decay`, `execution_skew`, `orphaned_requirements`) |
@@ -75,15 +75,15 @@ Refer skill §Verdict Logic:
 
 **Malformed section** (if any): list of agent-emitted findings that failed schema validation, raw form preserved.
 
-**Raw outputs** (truncated if >2k chars): per-agent raw response для audit trail.
+**Raw outputs** (truncated if >2k chars): per-agent raw response for audit trail.
 
 ## Loop Guard
 
-If same finding emerges on **3 consecutive iterations** with same `artifact_ref` + `ac_criteria` + `category` — flag as `persistent_finding` и exit with `verdict=BLOCKED`. Prevents infinite-loop bug.
+If same finding emerges on **3 consecutive iterations** with same `artifact_ref` + `ac_criteria` + `category` — flag as `persistent_finding` and exit with `verdict=BLOCKED`. Prevents infinite-loop bug.
 
 ## Re-entry After Fix
 
-После `/dr-do` (or manual operator fix) addressing findings:
+After `/dr-do` (or manual operator fix) addressing findings:
 - Re-run `/dr-verify {TASK-ID} --stage=<stage>`
 - Previous audit log preserved for trail; new file gets `-v2`, `-v3` suffix
 - Findings should diminish (recall@previous-findings = how many fixed)
@@ -95,7 +95,7 @@ If same finding emerges on **3 consecutive iterations** with same `artifact_ref`
 - **Read-only** subagent tool whitelist (Read, Grep, Glob, Bash read-only). **NO** Write, Edit, NotebookEdit at all layers.
 - **Cost budget cap**: `--cost-cap=N` (default 1.25× baseline `/dr-do`). If Layer 2 + Layer 3 combined cost exceeds cap, warn operator and continue (do not auto-degrade — operator decides).
 - **Append-only audit log** (`chmod a-w` post-write).
-- **Findings-only mode**: NO automatic fix application. Operator triage all findings вручную.
+- **Findings-only mode**: NO automatic fix application. Operator triage all findings manually.
 - **`coworker --task-id <ID>` propagation MANDATORY** at Layer 2 — otherwise downstream token-cost measurement (`dev-tools/measure-invocation-token-cost.sh`) cannot filter logs by task.
 
 ## Examples
@@ -200,7 +200,7 @@ Before exiting `/dr-verify`:
 After verdict, MUST emit CTA block per `$HOME/.claude/skills/cta-format/SKILL.md`.
 
 **Routing logic for `/dr-verify`**:
-- **PASS / CONDITIONAL** → primary `/dr-compliance {TASK-ID}` (proceed to final hardening) или `/dr-archive {TASK-ID}` если already compliance done
+- **PASS / CONDITIONAL** → primary `/dr-compliance {TASK-ID}` (proceed to final hardening) or `/dr-archive {TASK-ID}` if compliance already done
 - **BLOCKED** — FAIL-Routing variant per highest-severity-category map:
 
 | Highest finding category | Return Command (primary in CTA) | Rationale |
@@ -212,8 +212,8 @@ After verdict, MUST emit CTA block per `$HOME/.claude/skills/cta-format/SKILL.md
 
 Multi-category BLOCKED: route to earliest pipeline stage affected (PRD > plan > do).
 
-The FAIL-Routing CTA header MUST read: `**Verify failed для {TASK-ID} — verdict: BLOCKED, highest severity: high, category: <X>**`.
+The FAIL-Routing CTA header MUST read: `**Verify failed for {TASK-ID} — verdict: BLOCKED, highest severity: high, category: <X>**`.
 
-Variant B menu when >1 active tasks в `activeContext.md`.
+Variant B menu when >1 active tasks in `activeContext.md`.
 
 **ARGUMENTS**: `{TASK-ID} [--stage={prd,plan,do,all}] [--max-iter=N] [--no-fix] [--runtime={claude,codex}] [--external-verifier=PASS] [--cost-cap=N]`

--- a/skills/ai-quality/deployment-patterns.md
+++ b/skills/ai-quality/deployment-patterns.md
@@ -57,15 +57,15 @@ Real incident: a plan predicted fp16 would reduce RAM from 914MB to ~450MB. Actu
 
 ## NODE_ENV in Container Environments — Anti-Pattern
 
-`NODE_ENV=development` в Docker container'е (compose, Dockerfile `ENV`, docker run `-e`) — это анти-pattern. Контейнер не знает дев-режима.
+Setting `NODE_ENV=development` inside a Docker container (compose, Dockerfile `ENV`, `docker run -e`) is an anti-pattern. The container has no notion of a developer machine — it ships a production image.
 
 ### Rule
 
-**Container default = `NODE_ENV=production`.** Dev-mode-only зависимости (pino-pretty, ts-node, source-map-support, error-stack-with-context, etc.) живут в `devDependencies`. Production Dockerfile делает `npm ci --omit=dev` → эти пакеты физически отсутствуют в image. Любой код, который их `require()` при `NODE_ENV=development`, упадёт с `Cannot find module ...` на старте.
+**Container default = `NODE_ENV=production`.** Dev-mode-only dependencies (pino-pretty, ts-node, source-map-support, error-stack-with-context, etc.) live under `devDependencies`. A production Dockerfile runs `npm ci --omit=dev`, so those packages are physically absent from the image. Any code path that `require()`s them under `NODE_ENV=development` will crash at startup with `Cannot find module ...`.
 
 ### Why
 
-Real incident: Dockerfile корректно делал `npm ci --omit=dev`, но `docker-compose.yml` выставлял `NODE_ENV=development`. Pino logger conditionally подключал `pino-pretty` транспорт при dev-режиме. Контейнер crashed at startup (`unable to determine transport target for "pino-pretty"`). 5 минут диагностики + 1 цикл compose rebuild.
+Real incident: the Dockerfile correctly ran `npm ci --omit=dev`, but `docker-compose.yml` set `NODE_ENV=development`. The Pino logger conditionally enabled the `pino-pretty` transport under dev mode. The container crashed at startup with `unable to determine transport target for "pino-pretty"`. Five minutes of diagnosis plus one compose rebuild cycle.
 
 ### Pattern
 
@@ -86,12 +86,12 @@ transport: process.env.LOG_PRETTY === '1'
   : undefined
 ```
 
-Локальный dev (host machine, `npm run start:dev`) сохраняет `NODE_ENV=development` через npm scripts — там devDeps присутствуют. Container никогда.
+Local dev on the host machine (`npm run start:dev`) keeps `NODE_ENV=development` via npm scripts — devDeps are installed there. The container, never.
 
 ### When to apply
 
-- Любой Dockerfile + docker-compose.yml для Node.js / Python / Ruby сервиса.
-- Общий принцип: «container env mirrors prod», даже если container запущен на dev-машине.
+- Any Dockerfile + docker-compose.yml for a Node.js / Python / Ruby service.
+- General principle: «container env mirrors prod», even when the container runs on a developer machine.
 
 ---
 

--- a/skills/compliance/SKILL.md
+++ b/skills/compliance/SKILL.md
@@ -211,9 +211,9 @@ Source: prior incident — a multi-repo task ran compliance v1+v2 within 23 minu
 Render the compliance report via the canonical structure declared in `${DATARIM_RUNTIME:-$HOME/.claude}/templates/compliance-report-template.md`. The report carries:
 
 - Frontmatter: `task_id`, `date`, `verdict` (COMPLIANT / COMPLIANT_WITH_NOTES / NON-COMPLIANT), optional `scope`.
-- Four operator-facing top sections in strict order — «Начальная задача», «Как решили», «Артефакты задачи», «Следующие шаги».
+- Four operator-facing top sections in strict order — «Начальная задача», «Как решили», «Артефакты задачи», «Следующие шаги». <!-- allow-non-ascii: russian-archive-template-section-names-cited-from-template -->
 - An audit addendum under a `---` horizontal rule carrying `### Step-by-step verdicts` (the 7-step per-step table), `### Remaining risks`, `### Related`.
 
-The four top sections answer «что просил оператор» and «что подтвердили / что осталось» in plain Russian — apply the banlist from `skills/human-summary/banlist.txt`. The audit addendum carries the technical surface (status table, risk list, cross-links) and MAY wrap ASCII-heavy lines in `<!-- gate:literal -->` fence.
+The four top sections answer «что просил оператор» and «что подтвердили / что осталось» in plain Russian — apply the banlist from `skills/human-summary/banlist.txt`. The audit addendum carries the technical surface (status table, risk list, cross-links) and MAY wrap ASCII-heavy lines in `<!-- gate:literal -->` fence. <!-- allow-non-ascii: russian-operator-quoted-archive-section-purpose-cited-from-template -->
 
 Save to `datarim/reports/compliance-report-{task_id}.md` if the directory exists, otherwise present in chat. Filename suffix on re-runs: `-v2`, `-v3`, … (one new file per `/dr-compliance` invocation).

--- a/skills/coworker-context/SKILL.md
+++ b/skills/coworker-context/SKILL.md
@@ -62,11 +62,11 @@ Agent-decided rounds also carry **Decision rationale** (≥ 50 non-whitespace ch
 Each operator wish becomes one item with:
 
 - `wish_id` — kebab-case slug, Cyrillic allowed.
-- `Что хочу проверить:` — plain-language operator wish.
-- `Как проверить (success criterion):` — falsifiable verification.
-- `Связанный AC из PRD:` — PRD AC reference or `—`.
-- `#### История статусов` — one line per status transition: `<ISO> / <local> · /dr-<stage> · <prior> → <new> · reason: <one sentence>`.
-- `#### Текущий статус` — one of `pending`, `met`, `partial`, `missed`, `n-a`, `deleted`.
+- `Что хочу проверить:` — plain-language operator wish. <!-- allow-non-ascii: russian-expectations-field-name-cited-from-canonical-schema -->
+- `Как проверить (success criterion):` — falsifiable verification. <!-- allow-non-ascii: russian-expectations-field-name-cited-from-canonical-schema -->
+- `Связанный AC из PRD:` — PRD AC reference or `—`. <!-- allow-non-ascii: russian-expectations-field-name-cited-from-canonical-schema -->
+- `#### История статусов` — one line per status transition: `<ISO> / <local> · /dr-<stage> · <prior> → <new> · reason: <one sentence>`. <!-- allow-non-ascii: russian-status-history-section-name-cited-from-canonical-schema -->
+- `#### Текущий статус` — one of `pending`, `met`, `partial`, `missed`, `n-a`, `deleted`. <!-- allow-non-ascii: russian-current-status-section-name-cited-from-canonical-schema -->
 - Optional `override:` line (≥ 10 chars) — escalates `partial` / `missed` to `CONDITIONAL_PASS`.
 
 ## 6. Snapshot Frontmatter (10 Mandatory Scalar Fields)

--- a/skills/datarim-doctor/SKILL.md
+++ b/skills/datarim-doctor/SKILL.md
@@ -26,7 +26,7 @@ Goals:
 - **Greppable state** — line format is machine-parseable; status changes are 1-line diffs.
 - **Idempotent migrations** — `/dr-doctor` can run any number of times without drift.
 
-`progress.md` is **abolished**, and the legacy `activeContext.md § Последние завершённые` rolling log is **abolished** as well. Completion history lives only in `documentation/archive/{area}/archive-{TASK-ID}.md` and git log.
+`progress.md` is **abolished**, and the legacy `activeContext.md § Последние завершённые` rolling log is **abolished** as well. Completion history lives only in `documentation/archive/{area}/archive-{TASK-ID}.md` and git log. <!-- allow-non-ascii: russian-legacy-section-name-cited-from-prior-schema -->
 
 ## Operational File Schema
 
@@ -73,7 +73,7 @@ YYYY-MM-DD HH:MM · short summary
 ```
 <!-- /gate:history-allowed -->
 
-The legacy `## Последние завершённые` section is **abolished** — `/dr-doctor` removes it during Pass 3. Completion history must be looked up in `documentation/archive/` or git log instead of being mirrored into a rolling section.
+The legacy `## Последние завершённые` section is **abolished** — `/dr-doctor` removes it during Pass 3. Completion history must be looked up in `documentation/archive/` or git log instead of being mirrored into a rolling section. <!-- allow-non-ascii: russian-legacy-section-name-cited-from-prior-schema -->
 
 ### `progress.md`
 
@@ -148,12 +148,12 @@ Applied by `scripts/datarim-doctor.sh --fix`. Single transactional sequence guar
 2. For each legacy block, extract the body until the next `### ID:` heading or section break.
 3. Parse known fields (case-insensitive, leading `- ` or `* ` allowed):
     - **Status / Status:** → frontmatter `status`
-    - **Priority / Приоритет:** → frontmatter `priority`
-    - **Complexity / Уровень / Level:** → frontmatter `complexity`
-    - **Type / Тип:** → frontmatter `type`
-    - **Started / Дата / Date / Date Started:** → frontmatter `started`
-    - **Parent / Родитель / Parent task:** → frontmatter `parent`
-    - **Related / Связанные:** → frontmatter `related`
+    - **Priority / Приоритет:** → frontmatter `priority` <!-- allow-non-ascii: russian-bilingual-frontmatter-key-mapping-cited-from-doctor-rule -->
+    - **Complexity / Уровень / Level:** → frontmatter `complexity` <!-- allow-non-ascii: russian-bilingual-frontmatter-key-mapping-cited-from-doctor-rule -->
+    - **Type / Тип:** → frontmatter `type` <!-- allow-non-ascii: russian-bilingual-frontmatter-key-mapping-cited-from-doctor-rule -->
+    - **Started / Дата / Date / Date Started:** → frontmatter `started` <!-- allow-non-ascii: russian-bilingual-frontmatter-key-mapping-cited-from-doctor-rule -->
+    - **Parent / Родитель / Parent task:** → frontmatter `parent` <!-- allow-non-ascii: russian-bilingual-frontmatter-key-mapping-cited-from-doctor-rule -->
+    - **Related / Связанные:** → frontmatter `related` <!-- allow-non-ascii: russian-bilingual-frontmatter-key-mapping-cited-from-doctor-rule -->
     - **PRD:** → frontmatter `prd`
     - **Plan:** → frontmatter `plan`
 4. Heading first capture group → `id`. Second capture group → `title` (truncated to 80 chars on word boundary). If title text is empty (e.g. `### PREFIX-NNNN-FOLLOWUP-slug` with no trailing text), synthesise title from the compound suffix: strip the literal `FOLLOWUP-` token, replace remaining hyphens with spaces, sentence-case the first character; append « follow-up » suffix when the literal `FOLLOWUP` appeared in the ID.
@@ -175,7 +175,7 @@ Applied by `scripts/datarim-doctor.sh --fix`. Single transactional sequence guar
 ### Pass 3 — `activeContext.md` + `progress.md` retirement
 
 11. Convert any legacy `**Current Task:** {ID}` line into `## Active Tasks` list with the corresponding one-liner; mirror is bounded to ≤ 30 lines.
-12. Strip the `## Последние завершённые` section if present (abolished — see § activeContext.md thin contract above).
+12. Strip the `## Последние завершённые` section if present (abolished — see § activeContext.md thin contract above). <!-- allow-non-ascii: russian-legacy-section-name-cited-from-prior-schema -->
 13. Delete `progress.md` if it exists.
 
 ### Pass 4 — `backlog-archive.md` migration
@@ -188,7 +188,7 @@ Applied by `scripts/datarim-doctor.sh --fix`. Single transactional sequence guar
 
 ### Pass 6 — Operational-files archive section migration
 
-Strips legacy archive sections (`## Archived` in `tasks.md` / `backlog.md`; `### Archived`, `### Recently Archived`, `## Последние завершённые` in `activeContext.md`) and migrates each archive bullet to a canonical `documentation/archive/{area}/archive-{TASK-ID}.md` doc. The canonical thin-index contract (§ activeContext.md thin contract above, § Operational File Schema) prohibits archive sections in operational files: completion history lives in `documentation/archive/`, recency hint is computed at runtime via `/dr-status --recent N`. Pass 6 enforces that contract.
+Strips legacy archive sections (`## Archived` in `tasks.md` / `backlog.md`; `### Archived`, `### Recently Archived`, `## Последние завершённые` in `activeContext.md`) and migrates each archive bullet to a canonical `documentation/archive/{area}/archive-{TASK-ID}.md` doc. The canonical thin-index contract (§ activeContext.md thin contract above, § Operational File Schema) prohibits archive sections in operational files: completion history lives in `documentation/archive/`, recency hint is computed at runtime via `/dr-status --recent N`. Pass 6 enforces that contract. <!-- allow-non-ascii: russian-legacy-archive-section-name-cited-from-prior-schema -->
 
 Four archive-bullet shapes are recognised (priority S1 → S2 → S4 → S3):
 
@@ -250,7 +250,7 @@ Log line: `Pass 7 {file}: stripped={N} preserved={M}`. **Idempotent:** second `-
 
 ### Idempotency Guard
 
-Before Pass 1: if every operational file is already in canonical shape — zero `### TASK-ID:` headings in `tasks.md` / `backlog.md`, no legacy `backlog-archive.md` (or only the `.pre-v2.bak` sidecar remains), `progress.md` does not exist, no `## Последние завершённые` section in `activeContext.md`, and every bullet line matches the canonical regex — exit 0 immediately. Cheap probe used by `/dr-init` self-heal.
+Before Pass 1: if every operational file is already in canonical shape — zero `### TASK-ID:` headings in `tasks.md` / `backlog.md`, no legacy `backlog-archive.md` (or only the `.pre-v2.bak` sidecar remains), `progress.md` does not exist, no `## Последние завершённые` section in `activeContext.md`, and every bullet line matches the canonical regex — exit 0 immediately. Cheap probe used by `/dr-init` self-heal. <!-- allow-non-ascii: russian-legacy-section-marker-cited-from-prior-schema -->
 
 ## Data-Loss Safety Contract
 

--- a/skills/datarim-system/SKILL.md
+++ b/skills/datarim-system/SKILL.md
@@ -7,8 +7,8 @@ target_aal: 2
 
 # Datarim System Rules
 
-> **Core system rules for Datarim (датарим). Always load this entry first.**
-> "Datarim" and "датарим" are the same framework. Recognize both forms in any language context.
+> **Core system rules for Datarim. Always load this entry first.** ("Datarim" transliterates to «датарим» in Russian.) <!-- allow-non-ascii: russian-transliteration-of-framework-name-which-agents-must-recognise -->
+> Recognize both spellings — Latin «Datarim» and Cyrillic «датарим» — as the same framework in any language context. <!-- allow-non-ascii: russian-transliteration-of-framework-name-which-agents-must-recognise -->
 
 ## Always-Apply Rules
 
@@ -60,7 +60,7 @@ One section only — strict mirror of `tasks.md` § Active:
 - {ID} · {status} · P{n} · L{n} · {title} → tasks/{ID}-task-description.md
 ```
 
-**Removed in v1.19.1:** `## Последние завершённые` and `## Last Updated`
+**Removed in v1.19.1:** `## Последние завершённые` and `## Last Updated` <!-- allow-non-ascii: russian-legacy-active-context-section-names-cited-from-prior-schema -->
 sections. Recency hint is now a runtime computation in `/dr-status --recent N`
 that mtime-sorts `documentation/archive/**/archive-*.md`. Single source of
 truth for completion history = `documentation/archive/`.

--- a/skills/datarim-system/backlog-and-routing.md
+++ b/skills/datarim-system/backlog-and-routing.md
@@ -141,7 +141,7 @@ Every transition listed below MUST be surfaced to the user as a canonical CTA bl
 
 ### FAIL Return Routing (FAIL-Routing CTA variant)
 
-QA BLOCKED → header `**QA failed для {TASK-ID} — earliest failed layer: Layer N (Layer name)**`, primary CTA per Layer-to-command map:
+QA BLOCKED → header `**QA failed for {TASK-ID} — earliest failed layer: Layer N (Layer name)**`, primary CTA per Layer-to-command map:
 
 | Failed Layer | Primary CTA |
 |---|---|
@@ -150,9 +150,9 @@ QA BLOCKED → header `**QA failed для {TASK-ID} — earliest failed layer: L
 | Layer 3 (Plan) | `/dr-plan {TASK-ID}` |
 | Layer 4 (Code) | `/dr-do {TASK-ID}` |
 
-Compliance NON-COMPLIANT → header `**Compliance NON-COMPLIANT для {TASK-ID} — ...**`, primary `/dr-do {TASK-ID}` (default) or earlier stage if PRD/plan gap identified.
+Compliance NON-COMPLIANT → header `**Compliance NON-COMPLIANT for {TASK-ID} — ...**`, primary `/dr-do {TASK-ID}` (default) or earlier stage if PRD/plan gap identified.
 
-After fix: resume forward, re-run QA/compliance. Loop guard: 3 same-layer fails → escalate to user via CTA option `Эскалация` (see `cta-format.md` § FAIL-Routing).
+After fix: resume forward, re-run QA/compliance. Loop guard: 3 same-layer fails → escalate to user via CTA option `Эскалация` (see `cta-format.md` § FAIL-Routing). <!-- allow-non-ascii: russian-cta-option-token-cited-from-cta-format-skill -->
 
 ### Manual Transitions
 
@@ -164,4 +164,4 @@ After fix: resume forward, re-run QA/compliance. Loop guard: 3 same-layer fails 
 
 ### Multi-task awareness (Variant B)
 
-Whenever `## Active Tasks` in `datarim/activeContext.md` lists >1 task, the CTA block MUST append a `**Другие активные задачи:**` menu listing each parallel task with its own recommended next command. This is mandatory for `/dr-status`, `/dr-next`, `/dr-archive`; agents on other commands MAY append it when context permits. See `cta-format.md` § Canonical Block — Multiple Active Tasks.
+Whenever `## Active Tasks` in `datarim/activeContext.md` lists >1 task, the CTA block MUST append a `**Другие активные задачи:**` menu listing each parallel task with its own recommended next command. This is mandatory for `/dr-status`, `/dr-next`, `/dr-archive`; agents on other commands MAY append it when context permits. See `cta-format.md` § Canonical Block — Multiple Active Tasks. <!-- allow-non-ascii: russian-cta-variant-b-menu-header-cited-from-cta-format-skill -->

--- a/skills/expectations-checklist/SKILL.md
+++ b/skills/expectations-checklist/SKILL.md
@@ -112,17 +112,17 @@ _(empty on first write)_
 - **`wish_id`** is a kebab-slug derived from the title. Cyrillic letters,
   ASCII letters, digits, and hyphens are allowed. Used as the focus key in
   FAIL-Routing CTA (`/dr-do <ID> --focus-items <wish_id_1,...,N>`).
-- **`Связанный AC из PRD`** is advisory. When the PRD has no matching AC,
+- **`Связанный AC из PRD`** is advisory. When the PRD has no matching AC, <!-- allow-non-ascii: russian-expectations-field-name-cited-from-canonical-schema -->
   use the em-dash «—». Renames in the PRD are recorded in the item's
-  История статусов with `stage: append-merge`.
+  История статусов with `stage: append-merge`. <!-- allow-non-ascii: russian-status-history-section-name-from-canonical-schema -->
 - **`override`** is plain prose, optional. When the current status is
   `partial` or `missed`, an override of fewer than 10 characters is treated
   as absent and the verify mode emits `BLOCKED`.
-- **`#### История статусов`** is append-only by convention. One line per
+- **`#### История статусов`** is append-only by convention. One line per <!-- allow-non-ascii: russian-status-history-section-name-from-canonical-schema -->
   status transition. Canonical line format:
   `<ISO> / <local> · <stage> · <prior> → <new> · reason: <plain ru>`. The
   three `·` separators and the literal `reason:` token are required.
-- **`#### Текущий статус`** carries the current enum value. Allowed values:
+- **`#### Текущий статус`** carries the current enum value. Allowed values: <!-- allow-non-ascii: russian-current-status-section-name-from-canonical-schema -->
   `pending`, `met`, `partial`, `missed`, `n-a`, `deleted`.
 - **`evidence_type`** (schema v2, required) declares what kind of evidence
   `/dr-qa` must produce for this wish at Layer 3b. Allowed enum:
@@ -168,7 +168,7 @@ Prefer one of two formulations:
   inline comparison, which stays correct under scope revisions.
 - **Re-derive at /dr-do time.** When the literal is genuinely required
   (e.g. user-visible counter on a landing page), record the actual
-  implementation count in the expectations item's История статусов as a
+  implementation count in the expectations item's История статусов as a <!-- allow-non-ascii: russian-status-history-section-name-from-canonical-schema -->
   one-line `stage: implementation-count` entry, and treat that line as
   the authoritative target. PRD-side AC remains an estimate.
 
@@ -187,9 +187,9 @@ reconcile any divergence in its own output document:
 |--------|---------------|------------------------------|
 | `/dr-design` | wish bodies | design doc § Decisions |
 | `/dr-do` | wish bodies; `--focus-items` ⇒ those wish-ids first | task-description § Implementation Notes |
-| `/dr-qa` | wish bodies; writes per-item Текущий статус | QA report § Expectations + History entries |
-| `/dr-compliance` | wish bodies; writes per-item Текущий статус | compliance report § Expectations + History entries |
-| `/dr-archive` | wish bodies; writes final per-item summary | archive doc § Выполнение ожиданий оператора |
+| `/dr-qa` | wish bodies; writes per-item Текущий статус | QA report § Expectations + History entries | <!-- allow-non-ascii: russian-current-status-field-cited-in-table-row -->
+| `/dr-compliance` | wish bodies; writes per-item Текущий статус | compliance report § Expectations + History entries | <!-- allow-non-ascii: russian-current-status-field-cited-in-table-row -->
+| `/dr-archive` | wish bodies; writes final per-item summary | archive doc § Выполнение ожиданий оператора | <!-- allow-non-ascii: russian-archive-section-name-cited-in-table-row -->
 
 ## Append-merge contract
 
@@ -203,7 +203,7 @@ an expectations file:
    - **Match** → leave the item body untouched; record a History line
      `stage: append-merge` only if the linked AC reference changed.
 3. Do not rewrite, reorder, or delete existing items. Operators control
-   pruning via explicit `Текущий статус: deleted`.
+   pruning via explicit `Текущий статус: deleted`. <!-- allow-non-ascii: russian-current-status-enum-value-cited-from-canonical-schema -->
 
 ## Multi-phase umbrellas (phase-level verify)
 
@@ -212,20 +212,20 @@ expectations file lives at the **umbrella** task ID (no separate
 `{PHASE-ID}-expectations.md` exists), `/dr-qa` and `/dr-compliance` invoked
 on the phase ID MAY legitimately:
 
-- Update `#### Текущий статус` only for wish-ids that fall in the phase's
+- Update `#### Текущий статус` only for wish-ids that fall in the phase's <!-- allow-non-ascii: russian-current-status-field-cited-in-bullet -->
   scope (e.g. flip from `pending` to `met` when the phase delivers the
   underlying success criterion).
 - Leave umbrella close-gate wish-ids and later-phase wish-ids as
   `pending`. These are not `n-a` (the wish remains in scope; it is just
   not yet verifiable) and not `partial`/`missed` (no failure to record at
   this point in the pipeline).
-- Append one `История статусов` line per touched item with `reason:` text
-  that names the phase scope explicitly (e.g. «ожидание относится к
-  фазе 3 (audit coverage); в фазе 1 не реализуется»). The phase mention
+- Append one `История статусов` line per touched item with `reason:` text <!-- allow-non-ascii: russian-status-history-section-name-cited-in-bullet -->
+  that names the phase scope explicitly (e.g. «ожидание относится к <!-- allow-non-ascii: russian-example-status-reason-illustrating-phase-scope -->
+  фазе 3 (audit coverage); в фазе 1 не реализуется»). The phase mention <!-- allow-non-ascii: russian-example-status-reason-illustrating-phase-scope -->
   in the reason is what lets the umbrella close-gate auditor distinguish
   «pending because phase X hasn't run» from «pending because no one looked».
 
-The validator still PASSes when `Текущий статус` is `pending` for these
+The validator still PASSes when `Текущий статус` is `pending` for these <!-- allow-non-ascii: russian-current-status-field-cited-in-prose -->
 items; the audit clarity comes from the History entry, not the status enum.
 On umbrella close (the last phase's `/dr-archive` or a follow-up umbrella
 QA pass), the remaining `pending` items are reconciled to `met` /

--- a/skills/init-task-persistence/SKILL.md
+++ b/skills/init-task-persistence/SKILL.md
@@ -166,6 +166,33 @@ After writing, `/dr-init` invokes
 exit as a warning (the description and operational-file work still
 continues — operator may fix the init-task manually).
 
+## Retroactive backfill (when /dr-init was skipped)
+
+If the operator skipped `/dr-init` at task start (e.g. opened with
+`/dr-plan` directly) and a later stage needs to call
+`dev-tools/append-init-task-qa.sh`, the tool exits 1 with
+`init-task file does not exist`. The agent MUST seed the file inline
+before retrying, not block on the operator. Recipe:
+
+1. Render minimal frontmatter mirroring the canonical schema, with
+   `source: retroactive-backfill` and
+   `captured_by: /dr-<current-stage> (retroactive seed)` so the
+   provenance is obvious to future readers.
+2. Compress the operator's intent to one phrase, sourced from
+   `datarim/tasks/{TASK-ID}-task-description.md § Overview`, and write it
+   as `## Operator brief (verbatim)`. The «verbatim» label survives
+   because the task-description Overview is the closest persisted record
+   of what the operator asked for.
+3. Write an empty `## Append-log (operator amendments)` placeholder so
+   `append-init-task-qa.sh` has a section to append into.
+4. Retry the original `append-init-task-qa.sh` call. The first appended
+   round documents the retroactive context.
+
+This is a write-once recovery — once the file exists, subsequent stages
+treat it as a normal canonical init-task. Do not delete it at archive
+time; the audit trail (when /dr-init was skipped, when the recovery
+happened, by which stage) is part of the task's history.
+
 ## Q&A round-trip contract
 
 The append-log captures two kinds of entries: operator-authored amendments

--- a/skills/stage-snapshot-writer/SKILL.md
+++ b/skills/stage-snapshot-writer/SKILL.md
@@ -7,36 +7,36 @@ target_aal: 2
 
 # Stage Snapshot Writer
 
-Каждая `/dr-*` команда, эмитирующая CTA-блок, как терминальный шаг пишет финальный operator-visible ответ в `datarim/snapshots/{TASK-ID}.snapshot.md`. Снапшот служит primary context-source для `/dr-next` и `/dr-orchestrate` после `/clear` или закрытия терминала.
+Every `/dr-*` command that emits a CTA block writes its final operator-visible response to `datarim/snapshots/{TASK-ID}.snapshot.md` as its terminal step. The snapshot is the primary context source for `/dr-next` and `/dr-orchestrate` after `/clear` or after the terminal is closed.
 
 ## Contract
 
 | Aspect | Value |
 |--------|-------|
-| Producer touchpoint | `skills/cta-format/SKILL.md` § Snapshot Emission (1 место, не N) |
+| Producer touchpoint | `skills/cta-format/SKILL.md` § Snapshot Emission (single producer, not N) |
 | Implementation | `scripts/lib/snapshot-writer.sh::write_stage_snapshot` |
 | Path | `datarim/snapshots/{TASK-ID}.snapshot.md` |
 | Lock | `datarim/snapshots/.lock.{TASK-ID}` (mkdir-based, reuses `acquire_plugin_lock`) |
 | Lock timeout | env `DR_SNAPSHOT_LOCK_TIMEOUT` (default 60 s) |
 | File size cap | 8192 bytes total (frontmatter + body); body truncated with marker on overflow |
-| Truncation marker | `<!-- snapshot-truncated, full ответ см. session jsonl -->` |
+| Truncation marker | `<!-- snapshot-truncated, full response in session jsonl -->` |
 | Permissions | snapshot file `chmod 600`, lock dir `chmod 700` |
-| Semantics | overwrite — повторный вызов той же стадии полностью замещает файл |
-| Kill switch | `DATARIM_DISABLE_SNAPSHOT=1` → writer становится no-op |
+| Semantics | overwrite — a second call for the same stage replaces the file in full |
+| Kill switch | `DATARIM_DISABLE_SNAPSHOT=1` → writer becomes a no-op |
 
 ## Inputs
 
-Все аргументы — named (`--flag value`):
+All arguments are named (`--flag value`):
 
 ```
 write_stage_snapshot \
-    --root <DATARIM_ROOT> \             # абсолютный путь до repo root
+    --root <DATARIM_ROOT> \             # absolute path to repo root
     --task <TASK-ID> \                  # ^[A-Z][A-Z0-9-]+-[0-9]{4,5}$
     --stage <plan|prd|do|qa|verify|...> \
-    --command </dr-name> \              # литерал «/dr-<name>»
+    --command </dr-name> \              # literal "/dr-<name>"
     --captured-by <agent|operator> \
     --recommended-next </dr-name> \     # primary CTA option, slash-prefixed
-    --options-file <path> \             # newline-separated «</dr-*> | <purpose>»
+    --options-file <path> \             # newline-separated "</dr-*> | <purpose>"
     --body-file <path> \                # rendered Summary + CTA (≤ 8 KB after trim)
     [--captured-at <ISO8601 UTC>]       # default $(date -u +%FT%TZ)
 ```
@@ -56,7 +56,7 @@ captured_at: 2026-05-21T13:45:00Z
 captured_by: agent
 recommended_next: /dr-do
 options:
-  - "/dr-do <TASK-ID> | реализация плана"
+  - "/dr-do <TASK-ID> | execute the plan"
   - "/dr-design <TASK-ID> | ratify writer API"
   - "/dr-status | escape hatch"
 size_bytes: 6432
@@ -73,7 +73,7 @@ truncated: false
 | 0 | snapshot written |
 | 1 | IO error / argument validation failure |
 | 2 | usage error (missing flag) |
-| 3 | lock-timeout (см. `DR_SNAPSHOT_LOCK_TIMEOUT`) |
+| 3 | lock-timeout (see `DR_SNAPSHOT_LOCK_TIMEOUT`) |
 
 ## Security controls (Appendix A cross-link)
 
@@ -100,8 +100,8 @@ write_stage_snapshot \
 
 ## Related
 
-- `skills/cta-format/SKILL.md` § Snapshot Emission — единственная producer touchpoint
-- `skills/dr-next-snapshot-replay/SKILL.md` — consumer-сторона
+- `skills/cta-format/SKILL.md` § Snapshot Emission — the only producer touchpoint
+- `skills/dr-next-snapshot-replay/SKILL.md` — consumer side
 - `dev-tools/check-stage-snapshot-on-exit.sh` — post-CTA advisory gate
 - `scripts/lib/plugin-system.sh::acquire_plugin_lock` — lock primitive (reused)
-- `feedback memory feedback_no_flock_on_macos` — обоснование mkdir-lock (POSIX flock ненадёжен на macOS через NFS/SMB)
+- `feedback memory feedback_no_flock_on_macos` — rationale for mkdir-lock (POSIX flock is unreliable on macOS over NFS/SMB)


### PR DESCRIPTION
## Summary
- **Wave 2 of TUNE-0308 epic** — rewrite 15 mid-density `commands/` and `skills/` files (5-20 RU-lines each, ~100 cumulative) to outsider-friendly English, matching exemplar `commands/dr-auto.md`. Allowlist mechanism from Wave 1 (per-line `<!-- allow-non-ascii: <reason ≥10ch> -->`) covered all 15 without tooling changes.
- **Three commits** group A/B/C (5 files each): `638889b` / `1bcaa68` / `2a6878e`.
- **Class A inline** (`9c0b745`): `skills/init-task-persistence/SKILL.md § Retroactive backfill` — recipe for seeding init-task when `/dr-init` was skipped, surfaced by this task's own /dr-compliance round.
- **Validator**: per-file `check-body-english.sh` exit 0 on all 15 files; cumulative `--scope commands,skills` FAIL set ⊆ Wave 3 tail (13 files / 20 lines, all Wave 3 / TUNE-0311 scope). Bats regression 22/22 PASS.
- **Operator review checkpoint** closed (`wave-2-review-verdict: pass`, seed=310, 3/15 spot-checked).

## Test plan
- [x] `bash dev-tools/check-body-english.sh --root . --scope commands,skills` — 13 FAIL (all Wave 3 tail, 0 Wave 1/Wave 2 regressions)
- [x] `bats tests/check-body-english.bats` — 15/15 PASS
- [x] `bats tests/check-frontmatter-english.bats` — 7/7 PASS
- [x] Per-file probe over each of 15 Wave 2 files — exit 0 each
- [x] Operator spot-check 3/15 vs `commands/dr-auto.md` exemplar — tone match confirmed

Refs: parent epic TUNE-0308 · predecessor TUNE-0309 (Wave 1) · successor TUNE-0311 (Wave 3 tail + agents + root + fail-hard flip)