### PR TITLE
TUNE-0313 Class A: hot-fix branch ID-collision pre-probe

### DIFF
--- a/skills/dr-init-id-collision-window/SKILL.md
+++ b/skills/dr-init-id-collision-window/SKILL.md
@@ -39,7 +39,7 @@ This skill is invoked by:
   the full canonical set in § Detection BEFORE running
   `git checkout -b <candidate>-...`. If any artifact or backlog entry exists
   for the candidate ID, the candidate is reserved — pick the next free ID
-  (highest ID in workspace + 1, skipping the `TASK-9999` sentinel) and proceed.
+  (highest existing ID in workspace + 1, skipping reserved sentinel values) and proceed.
   Catches the false-free case where the ID looks unused in the agent's
   conversation context but is actually already filed in `backlog.md` as a
   follow-up from a sibling task.

--- a/skills/dr-init-id-collision-window/SKILL.md
+++ b/skills/dr-init-id-collision-window/SKILL.md
@@ -32,7 +32,17 @@ This skill is invoked by:
   collision before any artifact is written;
 - `/dr-archive` Step 0.x detection branch — when archive doc already exists at
   the target path under a different task title (parallel session got there
-  first).
+  first);
+- **Hot-fix branch naming (no `/dr-init`).** When an operator-initiated hot-fix
+  bypasses `/dr-init` and the agent picks a candidate `TASK-PREFIX-NNNN` for
+  the branch + commit message + PR title, the candidate MUST be probed against
+  the full canonical set in § Detection BEFORE running
+  `git checkout -b <candidate>-...`. If any artifact or backlog entry exists
+  for the candidate ID, the candidate is reserved — pick the next free ID
+  (highest ID in workspace + 1, skipping the `TASK-9999` sentinel) and proceed.
+  Catches the false-free case where the ID looks unused in the agent's
+  conversation context but is actually already filed in `backlog.md` as a
+  follow-up from a sibling task.
 
 ## Detection — probe scope
 


### PR DESCRIPTION
Class A inline from reflection-TUNE-0313.md. Adds hot-fix branch naming as a third invocation point of the dr-init-id-collision-window skill — agent MUST probe the candidate TASK-PREFIX-NNNN against the full canonical set BEFORE `git checkout -b`. Source: this very archive cycle (TUNE-0313 branch collided with an already-filed TUNE-0312 follow-up backlog entry, caught only at /dr-archive).