### PR TITLE
docs(coworker-delegation): document --append in canonical fragment

### DIFF
--- a/templates/coworker-delegation-fragment.md
+++ b/templates/coworker-delegation-fragment.md
@@ -122,6 +122,19 @@ operator-facing reference: `documentation/infrastructure/Coworker.md`
 - When exact line numbers are needed for `Edit` (coworker summaries lose
   them).
 - Reasoning about user intent.
+- **Appending to an existing file via `coworker write --target Y` without
+  `--append`.** Bare `coworker write --target Y` truncate-writes Y
+  (`Path.write_text()`, Python `'w'` mode). A spec like `--spec "append
+  section X to file Y" --target Y` overwrites Y with only the new section
+  and destroys everything else (frontmatter, prior sections). Since
+  coworker v0.4.0 the canonical fix is the `--append` flag:
+  `coworker write --append --target Y --spec "..."` — opens Y in `'a'`
+  mode, inserts a separator newline if Y's tail is non-terminated, falls
+  back to write when Y does not yet exist, and is mutually exclusive with
+  `--stdout`. Reach for the legacy workarounds only when the target's
+  byte-exact tail matters: (1) `--stdout` and concatenate captured body
+  manually; (2) feed Y as `--context` and write to a fresh `--target`;
+  (3) native surgical edit.
 
 ## Failure modes
 

--- a/templates/coworker-delegation.mdc
+++ b/templates/coworker-delegation.mdc
@@ -72,6 +72,7 @@ Enable when bulk reads regularly exceed ~5k tokens (logs, code dumps, long diffs
 - Architectural decisions and trade-offs.
 - When exact line numbers are needed for Edit (coworker summaries lose them).
 - Reasoning about user intent.
+- Appending to an existing file via `coworker write --target Y` without `--append`. Bare `coworker write --target Y` truncate-writes Y (Python `'w'` mode) — a spec like `--spec "append section X to file Y" --target Y` overwrites Y with only the new section and destroys everything else (frontmatter, prior sections). Since coworker v0.4.0 the canonical fix is the `--append` flag: `coworker write --append --target Y --spec "..."` (mutually exclusive with `--stdout`, falls back to write if Y does not yet exist, inserts separator newline when needed). Legacy workarounds (`--stdout` + manual concat, or feed Y as `--context` to a fresh `--target`, or native surgical edit) only when byte-exact tail handling matters.
 
 ## Failure modes
 


### PR DESCRIPTION
## Summary

`coworker write --append` shipped in v0.4.0 (2026-05-27, TUNE-0319 fold-in) but the canonical delegation fragment still described the workaround as "until an --append flag lands upstream". Same drift in the Cursor `.mdc` mirror.

This PR rewrites the "Do NOT delegate" bullet in both files to document `coworker write --append --target Y` as the canonical path and demotes the three legacy workarounds to "only when byte-exact tail handling matters".

## Origin

Caught by operator during TUNE-0317 v0.5.0 follow-through cleanup — two `templates/` files had uncommitted hunks left over from earlier TUNE-0312 / TUNE-0319 work that never made it into a commit, AND their content was stale relative to coworker v0.4.0+ behaviour.

## Downstream re-sync

`~/.claude/CLAUDE.md` and `~/.codex/AGENTS.override.md` mirror this canonical fragment per the preamble's "do NOT hand-edit downstream copies" notice; both are per-machine personal files, hand-synced after this merges.

## Test plan

- [x] `templates/coworker-delegation-fragment.md` describes `--append` as the canonical fix.
- [x] `templates/coworker-delegation.mdc` mirrors the same updated wording.
- [x] Branch-protection required checks (shellcheck, gitleaks, bandit, osv-scanner, trufflehog, diff-mirrored-scopes) pass.