### PR TITLE
docs(skill): verify-push-by-state rule (Layer 4 of signal-vs-bulk RTK fix)

### DIFF
--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -145,6 +145,23 @@ EOF
 
 **Do NOT clean up worktree** — user needs it alive to iterate on PR feedback.
 
+##### Verify push by state, not by stdout
+
+After `git push`, the canonical `To <repo>\n  abc..def main -> main` line in stdout is a contract surface that hook wrappers (token reducers, lint filters, terminal multiplexers) frequently rewrite or truncate. Never gate next-step decisions on the stdout text — verify the push succeeded by comparing local HEAD against the upstream tracking ref:
+
+```bash
+# nosec-extract
+git push -u origin <feature-branch>
+local_sha=$(git rev-parse HEAD)
+upstream_sha=$(git rev-parse "@{u}")
+if [ "$local_sha" != "$upstream_sha" ]; then
+    echo "push verification failed: HEAD=$local_sha @{u}=$upstream_sha" >&2
+    exit 1
+fi
+```
+
+The same SHA-equality check applies to `git pull` and `git fetch`. If the upstream tracking ref is not configured (first push of a new branch), use `git ls-remote origin <branch>` to read the remote SHA directly and compare against `git rev-parse HEAD`. Source: agents repeatedly waited 15+ minutes on already-successful pushes because a hook truncated the canonical marker; SHA-equality is invariant under any stdout transformation.
+
 #### Option 3: Keep As-Is
 
 Report: "Keeping branch <name>. Worktree preserved at <path>."

--- a/tests/skill-finishing-branch-verify-by-state.bats
+++ b/tests/skill-finishing-branch-verify-by-state.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+#
+# Regression: skills/finishing-a-development-branch/SKILL.md MUST carry the
+# verify-by-state rule for git push — SHA-equality of local HEAD vs upstream
+# tracking ref, not stdout text parsing.
+#
+# Class of incident: hook wrappers (token reducers, lint filters, terminal
+# multiplexers) frequently truncate the canonical `To <repo>` push marker in
+# stdout. Agents that gate next-step decisions on the marker text wait on
+# already-successful pushes. SHA-equality is invariant under stdout transforms.
+
+SKILL="${BATS_TEST_DIRNAME}/../skills/finishing-a-development-branch/SKILL.md"
+
+@test "skill file exists" {
+    [ -f "$SKILL" ]
+}
+
+@test "skill carries rev-parse @{u} verify-by-state rule" {
+    run grep -cE 'rev-parse "?@\{u\}"?' "$SKILL"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+}
+
+@test "skill carries local HEAD vs upstream SHA comparison" {
+    run grep -cE 'rev-parse HEAD' "$SKILL"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+}
+
+@test "skill warns against gating on stdout text" {
+    run grep -cE 'stdout|To <repo>' "$SKILL"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+}


### PR DESCRIPTION
## Summary
- Add «Verify push by state, not by stdout» subsection to `skills/finishing-a-development-branch/SKILL.md`
- After `git push`, compare `git rev-parse HEAD` vs `git rev-parse "@{u}"` instead of parsing stdout text
- Hook wrappers (RTK, lint reducers, multiplexers) routinely rewrite/truncate the canonical `To <repo>` marker
- 4/4 bats green: `tests/skill-finishing-branch-verify-by-state.bats`

## Context
Layer 4 of the RTK signal-vs-bulk classification fix. Parent incident: agent saw truncated `git push` stdout, decided push hung, re-pushed in background for 15+ minutes against already-successful push.

Other layers shipped separately: Layer 1 (PreToolUse guard) shipped 2026-05-27 via `~/.local/bin/rtk-signal-guard.sh`; Layer 2 (canonical `coworker rtk` plugin) shipped in `Arcanada-one/coworker@b30ed16`; Layer 3 (upstream proposal) tracked as `rtk-ai/rtk#2121`.

## Test plan
- [x] `bats tests/skill-finishing-branch-verify-by-state.bats` — 4/4 PASS locally
- [ ] CI green (required status checks)