### PR TITLE
fix(install): block implicit claude fanout on --with-cursor + harden bats

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1138,8 +1138,13 @@ project_install() {
 
 parse_args "$@"
 
-# Backwards-compat: legacy flags without explicit --with-claude imply claude
-if [ "$FANOUT_CLAUDE" = false ] && [ "$FANOUT_CODEX" = false ] && [ -z "$PROJECT_DIR" ]; then
+# Backwards-compat: legacy flags without explicit --with-claude imply claude.
+# Guard against silent claude fanout when ANY explicit runtime flag is given —
+# `--with-cursor --yes` should ONLY touch the cursor scope, not also reach
+# into $CLAUDE_DIR. Without the FANOUT_CURSOR guard the conditional triggered
+# implicit FANOUT_CLAUDE=true, which fanned the operator's real ~/.claude/*
+# scopes onto a test-fixture tmp source dir and broke runtime on teardown.
+if [ "$FANOUT_CLAUDE" = false ] && [ "$FANOUT_CODEX" = false ] && [ "$FANOUT_CURSOR" = false ] && [ -z "$PROJECT_DIR" ]; then
     if [ "$FORCE" = true ] || [ "$FORCE_COPY" = true ] || [ "$ASSUME_YES" = true ]; then
         FANOUT_CLAUDE=true
         echo "WARN: implicit --with-claude for legacy flags (deprecated: use --with-claude)" >&2

--- a/tests/install-cursor-runtime.bats
+++ b/tests/install-cursor-runtime.bats
@@ -22,6 +22,13 @@ INSTALL_SH="${BATS_TEST_DIRNAME}/../install.sh"
 setup() {
     TMPSRC="$(mktemp -d)"
     TMPCURSOR="$(mktemp -d)"
+    # Defense-in-depth: redirect HOME + CLAUDE_DIR to fake paths so any
+    # accidental fanout into the claude scope cannot touch the operator's
+    # real ~/.claude. Mirrors the contract in tests/install-tune-0114.bats
+    # and tests/install.bats (helpers/install_fixture.bash).
+    FAKE_HOME="$TMPSRC/fake-home"
+    FAKE_CLAUDE="$TMPSRC/fake-claude"
+    mkdir -p "$FAKE_HOME" "$FAKE_CLAUDE"
     # Minimal source tree: two migrated skills + one .system skill.
     mkdir -p "$TMPSRC/skills/alpha" "$TMPSRC/skills/beta" "$TMPSRC/skills/.system/bundled"
     cat >"$TMPSRC/skills/alpha/SKILL.md" <<'EOF'
@@ -55,7 +62,7 @@ teardown() {
 }
 
 @test "T47: --with-cursor --dry-run reports planned paths, writes nothing" {
-    CURSOR_DIR="$TMPCURSOR" run "$TMPSRC/install.sh" --with-cursor --dry-run
+    run env HOME="$FAKE_HOME" CLAUDE_DIR="$FAKE_CLAUDE" CURSOR_DIR="$TMPCURSOR" "$TMPSRC/install.sh" --with-cursor --dry-run
     [ "$status" -eq 0 ]
     [[ "$output" == *"cursor"* ]] || [[ "$output" == *"Cursor"* ]]
     # Target untouched.
@@ -63,7 +70,7 @@ teardown() {
 }
 
 @test "T48: --with-cursor creates flat .md mirrors of each skill" {
-    CURSOR_DIR="$TMPCURSOR" run "$TMPSRC/install.sh" --with-cursor --yes
+    run env HOME="$FAKE_HOME" CLAUDE_DIR="$FAKE_CLAUDE" CURSOR_DIR="$TMPCURSOR" "$TMPSRC/install.sh" --with-cursor --yes
     [ "$status" -eq 0 ]
     [ -f "$TMPCURSOR/skills/alpha.md" ]
     [ -f "$TMPCURSOR/skills/beta.md" ]
@@ -73,18 +80,18 @@ teardown() {
 }
 
 @test "T48b: --with-cursor excludes skills/.system/ namespace (C3)" {
-    CURSOR_DIR="$TMPCURSOR" run "$TMPSRC/install.sh" --with-cursor --yes
+    run env HOME="$FAKE_HOME" CLAUDE_DIR="$FAKE_CLAUDE" CURSOR_DIR="$TMPCURSOR" "$TMPSRC/install.sh" --with-cursor --yes
     [ "$status" -eq 0 ]
     [ ! -f "$TMPCURSOR/skills/bundled.md" ]
     [ ! -d "$TMPCURSOR/skills/.system" ]
 }
 
 @test "T49: --with-cursor is idempotent (re-run produces no diff)" {
-    CURSOR_DIR="$TMPCURSOR" "$TMPSRC/install.sh" --with-cursor --yes >/dev/null
+    env HOME="$FAKE_HOME" CLAUDE_DIR="$FAKE_CLAUDE" CURSOR_DIR="$TMPCURSOR" "$TMPSRC/install.sh" --with-cursor --yes >/dev/null
     sha1_first=$(find "$TMPCURSOR/skills" -type f -exec sha1sum {} \; 2>/dev/null | \
                  sort | sha1sum 2>/dev/null || \
                  find "$TMPCURSOR/skills" -type f -exec shasum {} \; | sort | shasum)
-    CURSOR_DIR="$TMPCURSOR" "$TMPSRC/install.sh" --with-cursor --yes >/dev/null
+    env HOME="$FAKE_HOME" CLAUDE_DIR="$FAKE_CLAUDE" CURSOR_DIR="$TMPCURSOR" "$TMPSRC/install.sh" --with-cursor --yes >/dev/null
     sha1_second=$(find "$TMPCURSOR/skills" -type f -exec sha1sum {} \; 2>/dev/null | \
                   sort | sha1sum 2>/dev/null || \
                   find "$TMPCURSOR/skills" -type f -exec shasum {} \; | sort | shasum)
@@ -92,7 +99,26 @@ teardown() {
 }
 
 @test "T50: --help advertises --with-cursor flag" {
-    run "$TMPSRC/install.sh" --help
+    run env HOME="$FAKE_HOME" CLAUDE_DIR="$FAKE_CLAUDE" "$TMPSRC/install.sh" --help
     [ "$status" -eq 0 ]
     [[ "$output" == *"--with-cursor"* ]]
+}
+
+@test "T51 regression: --with-cursor --yes does not fanout into \$CLAUDE_DIR" {
+    # Operator-reported regression — the backwards-compat block in install.sh
+    # implicitly enabled FANOUT_CLAUDE=true on --yes/--force without checking
+    # FANOUT_CURSOR. Combined with the missing HOME isolation that this file
+    # carried before this commit, it left the operator's real ~/.claude
+    # symlinks pointing at the deleted bats tmp source dir.
+    #
+    # Contract: --with-cursor [--yes] MUST leave $CLAUDE_DIR untouched.
+    run env HOME="$FAKE_HOME" CLAUDE_DIR="$FAKE_CLAUDE" CURSOR_DIR="$TMPCURSOR" \
+        "$TMPSRC/install.sh" --with-cursor --yes
+    [ "$status" -eq 0 ]
+    # Cursor side did its job.
+    [ -f "$TMPCURSOR/skills/alpha.md" ]
+    # Claude side must be untouched — no symlinks, no real dirs.
+    for scope in agents skills commands templates scripts tests dev-tools; do
+        [ ! -e "$FAKE_CLAUDE/$scope" ]
+    done
 }


### PR DESCRIPTION
## Summary

Operator hit a hard regression mid-task: `~/.claude/{skills,agents,commands,templates,scripts,tests,dev-tools}` symlinks all pointed to a deleted `/var/folders/.../T/tmp.XXXXXXXXXX/` source dir; every slash command and skill disappeared. Root cause is `tests/install-cursor-runtime.bats` clobbering the real runtime when invoked on a live install.

Two independent defects, either fix alone breaks the chain — both applied defense-in-depth.

**(a) `install.sh` lines 1141-1149 backwards-compat block.** Auto-enables `FANOUT_CLAUDE=true` when `--yes` / `--force` / `--force-copy` is passed without an explicit `--with-claude`, but the conditional did not consider `FANOUT_CURSOR`. So `install.sh --with-cursor --yes` silently fanned-out into the claude scope. Fix: add `[ "$FANOUT_CURSOR" = false ]` to the outer check + inline comment.

**(b) `tests/install-cursor-runtime.bats` setup().** Wired `CURSOR_DIR` isolation but left `HOME` + `CLAUDE_DIR` pointing at the operator's real paths. With defect (a) live, the implicit fanout targeted real `~/.claude`. Fix: redirect `HOME` + `CLAUDE_DIR` to `FAKE_HOME` / `FAKE_CLAUDE` under `$TMPSRC` (mirrors the contract used by `install.bats` and `install-tune-0114.bats`).

**New T51 regression test** asserts `--with-cursor --yes` leaves `$CLAUDE_DIR` untouched (no symlinks, no real dirs in any of the 7 scopes).

## Test plan

- [x] `bats tests/install-cursor-runtime.bats` — 6/6 green (T47-T50 unchanged + T51 new).
- [x] Counter-check: revert install.sh patch only → T51 FAILS (regression caught).
- [x] Apply install.sh patch again → T51 PASSES.
- [x] Pre/post run of full bats file with stashed install.sh fix: real `~/.claude/skills` symlink target string UNCHANGED (canonical `code/datarim/skills` both times — no clobber).
- [x] No other test in `tests/` invokes `install.sh --with-cursor`, so blast radius is bounded.

Backlog item: TUNE-0329 (workspace backlog).