### PR TITLE
fix(snapshot): add auto stage to writer enum (TUNE-0330)

### DIFF
--- a/commands/dr-auto.md
+++ b/commands/dr-auto.md
@@ -90,6 +90,17 @@ Even under `/dr-auto`, the following actions never run automatically. They come 
 - High-risk changes to the framework's operating model, where each stage gate is genuinely a decision point that needs the operator present.
 - Coordinating work across multiple repositories. Use `/dr-orchestrate` for that — it is built for parallel multi-task execution and `/dr-auto` is not.
 
+## Stage Snapshot Emission (Mandatory Terminal Step)
+
+At the terminal cleanup step (step 9 above), after emitting the CTA block, the agent MUST perform snapshot emission ([definition](../skills/stage-snapshot-writer/SKILL.md)) per `$HOME/.claude/skills/cta-format/SKILL.md` § Snapshot Emission. Parameters bound for this command:
+
+- `stage`: `auto`
+- `command`: `/dr-auto`
+- `captured-by`: `agent`
+- `recommended-next`: primary CTA option (slash-prefixed `/dr-*` form)
+
+This snapshot overwrites the last delegated sub-stage snapshot — the intended behaviour: it records the autonomous run as the canonical resume point. Fail-closed: on non-zero writer exit, emit a single stderr warning line and continue (V-AC-7 contract). Kill switch `DATARIM_DISABLE_SNAPSHOT=1` is handled inside the library; under the switch the writer is a no-op without warning.
+
 ## Related
 
 - Skill: `skills/autonomous-mode/SKILL.md` — the operating rules every stage loads.

--- a/scripts/lib/snapshot-writer.sh
+++ b/scripts/lib/snapshot-writer.sh
@@ -15,7 +15,7 @@ SNAPSHOT_WRITER_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "${SNAPSHOT_WRITER_LIB_DIR}/plugin-system.sh"
 
 readonly SNAPSHOT_TASK_ID_RE='^[A-Z][A-Z0-9-]+-[0-9]{4,5}$'
-readonly SNAPSHOT_STAGE_RE='^(init|prd|plan|design|do|qa|verify|compliance|archive|edit|publish|write|dream|doctor|optimize)$'
+readonly SNAPSHOT_STAGE_RE='^(init|prd|plan|design|do|qa|verify|compliance|archive|edit|publish|write|dream|doctor|optimize|auto)$'
 readonly SNAPSHOT_MAX_BYTES=8192
 readonly SNAPSHOT_TRUNCATION_MARKER='<!-- snapshot-truncated, full ответ см. session jsonl -->'
 

--- a/skills/stage-snapshot-writer/SKILL.md
+++ b/skills/stage-snapshot-writer/SKILL.md
@@ -32,7 +32,7 @@ All arguments are named (`--flag value`):
 write_stage_snapshot \
     --root <DATARIM_ROOT> \             # absolute path to repo root
     --task <TASK-ID> \                  # ^[A-Z][A-Z0-9-]+-[0-9]{4,5}$
-    --stage <plan|prd|do|qa|verify|...> \
+    --stage <plan|prd|do|qa|verify|auto|...> \
     --command </dr-name> \              # literal "/dr-<name>"
     --captured-by <agent|operator> \
     --recommended-next </dr-name> \     # primary CTA option, slash-prefixed

--- a/tests/stage-snapshot-auto-stage.bats
+++ b/tests/stage-snapshot-auto-stage.bats
@@ -1,0 +1,50 @@
+#!/usr/bin/env bats
+#
+# stage-snapshot writer: `auto` stage acceptance + dr-auto.md ↔ enum guard.
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+WRITER_LIB="${REPO_ROOT}/scripts/lib/snapshot-writer.sh"
+DR_AUTO_MD="${REPO_ROOT}/commands/dr-auto.md"
+
+setup() {
+    export TMPROOT="$BATS_TEST_TMPDIR/fake-repo"
+    mkdir -p "$TMPROOT/datarim"
+    export OPTIONS="$BATS_TEST_TMPDIR/options.txt"
+    cat > "$OPTIONS" <<'OPT'
+/dr-status | escape hatch
+OPT
+    export BODY="$BATS_TEST_TMPDIR/body.txt"
+    printf 'autonomous terminal snapshot body\n' > "$BODY"
+    # shellcheck source=/dev/null
+    . "$WRITER_LIB"
+}
+
+# Case A — the writer accepts `--stage auto` and records it in frontmatter.
+@test "auto stage accepted: exit 0 + frontmatter carries stage: auto" {
+    run write_stage_snapshot \
+        --root "$TMPROOT" \
+        --task TUNE-0330 \
+        --stage auto \
+        --command /dr-auto \
+        --captured-by agent \
+        --recommended-next /dr-archive \
+        --options-file "$OPTIONS" \
+        --body-file "$BODY"
+    [ "$status" -eq 0 ]
+    local snap="$TMPROOT/datarim/snapshots/TUNE-0330.snapshot.md"
+    [ -f "$snap" ]
+    grep -q '^stage: auto$' "$snap"
+    grep -q '^command: /dr-auto$' "$snap"
+}
+
+# Case B — consistency guard: the stage that commands/dr-auto.md declares it
+# emits MUST belong to SNAPSHOT_STAGE_RE. Catches the original drift class
+# (a command emitting a stage the writer's enum does not list).
+@test "guard: stage declared in dr-auto.md belongs to SNAPSHOT_STAGE_RE" {
+    [ -f "$DR_AUTO_MD" ]
+    local stage_token
+    stage_token="$(grep -oE '`stage`: `[a-z]+`' "$DR_AUTO_MD" \
+        | head -1 | sed -E 's/.*`([a-z]+)`$/\1/')"
+    [ -n "$stage_token" ]
+    [[ "$stage_token" =~ $SNAPSHOT_STAGE_RE ]]
+}


### PR DESCRIPTION
## Summary
- `/dr-auto` emits a terminal stage snapshot with `stage: auto`, but `SNAPSHOT_STAGE_RE` lacked `auto` → writer rejected every autonomous run (`invalid stage auto` / exit 1, fail-closed warn+continue). The enum is keyed by command suffix and already lists edit/publish/write/dream/doctor/optimize — `auto` was simply omitted when the command was added.
- Add `|auto` to `SNAPSHOT_STAGE_RE` (single source of truth, `scripts/lib/snapshot-writer.sh`).
- Add a `## Stage Snapshot Emission` section to `commands/dr-auto.md` binding `stage=auto` / `command=/dr-auto` (mirrors `dr-init.md`).
- New `tests/stage-snapshot-auto-stage.bats`: accept+write case + a consistency guard tying `dr-auto.md`'s declared stage to the enum.
- Mention `auto` in `stage-snapshot-writer` SKILL Inputs.

## Test plan
- [x] `bats tests/stage-snapshot-auto-stage.bats` → 2/2
- [x] `bats tests/stage-snapshot-*.bats` → 41/41 (was 39)
- [x] live wrapper `--stage auto` → exit 0 + `stage: auto` written (original bug reproduced→fixed)
- [x] shellcheck `-S warning` clean; stack-agnostic / task-id / english-only gates PASS