### PR TITLE
fix(doc-refs): prune vendored skills/.system/ from check-doc-refs scan

### DIFF
--- a/scripts/check-doc-refs.sh
+++ b/scripts/check-doc-refs.sh
@@ -111,13 +111,18 @@ matches_baseline() {
 # --- file enumeration ---------------------------------------------------------
 # We scan ROOT/CLAUDE.md plus ROOT/{skills,agents,commands,templates,docs}/**/*.md.
 # Other dirs (tests/, scripts/, documentation/) are out-of-scope per plan.
+# `skills/.system/` is vendored external content (e.g. OpenAI reference docs
+# shipped for Codex parity, marked by `.codex-system-skills.marker`); Datarim
+# does not author or maintain those files, and their absolute API-path links
+# (`/api/docs/...`) are not file references — pruned to keep the linter scoped
+# to Datarim's own shipped surface.
 SCAN_TARGETS=()
 [ -f "$ROOT/CLAUDE.md" ] && SCAN_TARGETS+=("$ROOT/CLAUDE.md")
 for _sub in skills agents commands templates docs; do
     if [ -d "$ROOT/$_sub" ]; then
         while IFS= read -r _f; do
             SCAN_TARGETS+=("$_f")
-        done < <(find "$ROOT/$_sub" -type f -name '*.md' 2>/dev/null)
+        done < <(find "$ROOT/$_sub" -type d -name '.system' -prune -o -type f -name '*.md' -print 2>/dev/null)
     fi
 done
 

--- a/tests/check-doc-refs.bats
+++ b/tests/check-doc-refs.bats
@@ -134,3 +134,19 @@ EOF
     run "$SCRIPT" --root nonexistent-dir --no-baseline
     [ "$status" -eq 2 ]
 }
+
+# T11 scope: vendored skills/.system/ content is not scanned → exit 0
+@test "T11 skills/.system/ vendored content pruned from scan → exit 0" {
+    mkdir -p tree/skills/.system/openai-docs
+    # Vendored doc with an absolute API-path link that would trip the
+    # path-traversal guard if scanned. It must be pruned, not flagged.
+    cat > tree/skills/.system/openai-docs/guide.md <<'EOF'
+# Vendored OpenAI reference.
+See [the guide](/api/docs/guides/prompting) for details.
+Bare mention skills/does-not-exist.md should also be ignored here.
+EOF
+    run "$SCRIPT" --root tree --no-baseline
+    [ "$status" -eq 0 ]
+    # No error/orphan referencing the vendored file.
+    ! echo "$output" | grep -qE '\.system'
+}


### PR DESCRIPTION
## Summary
- `check-doc-refs.sh` exited 2 (path-traversal) on 9 absolute API-path links (`/api/docs/...`) inside vendored OpenAI reference docs under `skills/.system/openai-docs/`.
- That content is external (marked by `.codex-system-skills.marker`), not authored by Datarim; its API-path links are not file references.
- The path-traversal guard fires before the `.docrefignore` baseline, so the links cannot be whitelisted — correct fix is to skip vendored `.system/` trees from the scan entirely.
- Linter now scopes to Datarim's own shipped surface and exits 0 (198 files scanned, clean).

## Test plan
- [x] `bash scripts/check-doc-refs.sh --root code/datarim/` → exit 0
- [x] `bats tests/check-doc-refs.bats` → 11/11 (new T11 covers `.system/` prune)
- [x] `shellcheck -S warning scripts/check-doc-refs.sh` → clean