### PR TITLE
ARCA-0145: site-drift auto-task generation (levels 2+3)

### DIFF
--- a/commands/dr-archive.md
+++ b/commands/dr-archive.md
@@ -91,6 +91,41 @@ Complete and archive current task.
    **0.1.5 Project repo check** (per repo classified as single-agent — i.e., no `.datarim-shared` marker):
    Run `scripts/pre-archive-check.sh <project-repo-path>` (legacy mode). Exit 1 → STOP and present the 3-way prompt (Commit now / Accept pending / Abort). Applied ≠ committed ≠ canonical.
 
+0.15. **DRIFT SITE-UPDATE GATE** (MANDATORY when the task's commits touched a path under a registered product's `repo_local` in `documentation/ecosystem-sync/registry.yml`):
+
+   When an archived task changed a registered product's repository, the deployed
+   site may now lag the repo. This sub-step turns that drift into a tracked
+   backlog task — **repo-first**: the repo change is already landing, so the
+   spawned task tracks the *site catch-up*, never an autonomous site edit.
+
+   **0.15.1 Applicability.** Skip silently if `dev-tools/check-repo-site-sync.sh`
+   is absent (a Datarim consumer without the ecosystem-sync system). Otherwise,
+   for each registered product whose `repo_local` path was touched by this
+   task's commits:
+
+   ```bash
+   . "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/lib/backlog-sink.sh"
+   "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-repo-site-sync.sh" \
+       --check --product <product-id> --root <kb-root>
+   ```
+
+   **0.15.2 On drift (detector exit 1).** Resolve the backlog sink, then append
+   one deduped site-update task using the shared helper (same dedup/append logic
+   the level-3 sweep uses — DRY):
+
+   ```bash
+   if backlog="$(resolve_backlog_sink --root <kb-root>)"; then
+       append_site_update_task "$backlog" <product-id> <severity> "<one-line detail>"
+   else
+       echo "WARN: no file backlog sink (non-file backend or consumer machine); skipping append" >&2
+   fi
+   ```
+
+   `append_site_update_task` is idempotent (anchored on `drift-site-update-<product>`),
+   atomic (temp-then-rename), and injection-gated. Detector exit 0 (clean) or a
+   SKIP finding (source unavailable) ⇒ no-op. Quote the detector command and the
+   appended backlog anchor (if any) in the archive doc § Verification.
+
 0.2. **VERSION CONSISTENCY CHECK** (framework repo only, MANDATORY when `VERSION` changed):
 
    When the framework repo's `VERSION` file changed in HEAD->working-tree, all consumer files (CLAUDE.md, README.md, docs/) must reference the new version. Catches the recurring class «VERSION bumped but README/CLAUDE.md left stale».

--- a/dev-tools/check-site-drift-sweep.sh
+++ b/dev-tools/check-site-drift-sweep.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# check-site-drift-sweep.sh — level-3 ecosystem-wide site-drift sweep.
+#
+# Runs the repo↔site drift detector once per registered product and, for every
+# drifted product, emits ONE idempotent site-update backlog task (deduped by
+# the drift-site-update-<product> anchor via the shared backlog-sink library).
+# A fail-soft Ops Bot heartbeat summarises the run. Host-agnostic: ships with a
+# systemd timer/service template under dev-tools/deploy/ for a future server
+# move; on the Mac primary it is operator-installed via crontab.
+#
+# Usage:
+#   check-site-drift-sweep.sh [--root <dir>] [--cadence-h N] [--force]
+#                             [--dry-run] [--help]
+#
+# Exit codes:
+#   0  sweep completed (clean OR drift emitted OR no file sink — all normal)
+#   2  usage error
+#   3  registry missing / unparseable (detector exit 3 propagated)
+#
+# Dependency floor: bash + awk + grep + curl (emit only) + jq (emit DTO only).
+# The detector itself avoids jq; jq is required solely for the Ops Bot payload.
+#
+# Security (Mandate S1/S5/S9): registry product ids are untrusted — each is
+# allowlisted ^[a-z][a-z0-9-]*$ before reaching the detector or the backlog.
+# OPSBOT_KEY is never exposed to `set -x`; the egress host is an HTTPS-pinned
+# constant. Tier 0: outbound-only, no listener, no DB.
+#
+# Idempotency / anti-flap: open-task dedup (the backlog anchor) is the complete
+# contract. There is no post-close cooldown — the drift signal is sticky (only
+# an operator fix clears it), so it cannot flap. A product whose task was closed
+# while still drifting re-spawns exactly one task on the next daily run; that is
+# a true positive (premature close or regression), not noise.
+
+set -uo pipefail
+
+SCRIPT_NAME="check-site-drift-sweep.sh"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ROOT=""
+CADENCE_H=24
+FORCE=0
+DRY_RUN=0
+
+# Detector + library locations (overridable for tests).
+DETECTOR="${DRIFT_SWEEP_DETECTOR:-$SCRIPT_DIR/check-repo-site-sync.sh}"
+SINK_LIB="${DRIFT_SWEEP_SINK_LIB:-$SCRIPT_DIR/lib/backlog-sink.sh}"
+
+# Ops Bot egress — HTTPS-pinned constant host (never interpolated from input).
+OPS_BOT_URL="${DRIFT_SWEEP_OPS_BOT_URL:-https://ops.arcanada.one/events}"
+
+REGISTRY_REL="documentation/ecosystem-sync/registry.yml"
+
+print_usage() {
+    cat <<EOF
+Usage: $SCRIPT_NAME [--root <dir>] [--cadence-h N] [--force] [--dry-run] [--help]
+
+  --root <dir>     KB root (default: walk up from cwd to find $REGISTRY_REL)
+  --cadence-h N    minimum hours between real runs (default 24, stamp-guarded)
+  --force          ignore the cadence stamp and run now
+  --dry-run        detect + report, but never write the backlog or emit
+  --help           this message
+
+Exit: 0 swept | 2 usage error | 3 registry missing/unparseable
+EOF
+}
+
+# ---- arg parse ----
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --root)      ROOT="$2"; shift 2 ;;
+        --cadence-h) CADENCE_H="$2"; shift 2 ;;
+        --force)     FORCE=1; shift ;;
+        --dry-run)   DRY_RUN=1; shift ;;
+        --help)      print_usage; exit 0 ;;
+        *) echo "ERROR: unknown flag '$1'" >&2; print_usage >&2; exit 2 ;;
+    esac
+done
+
+# ---- stamp guard (write unconditionally at entry per sre digest) ----
+STATE_DIR="${XDG_STATE_HOME:-$HOME/.local/state}/datarim"
+STAMP="$STATE_DIR/drift-sweep.last-run"
+mkdir -p "$STATE_DIR" 2>/dev/null || true
+
+now_epoch="$(date +%s 2>/dev/null || echo 0)"
+
+if [ "$FORCE" -eq 0 ] && [ -f "$STAMP" ]; then
+    last="$(cat "$STAMP" 2>/dev/null)"
+    case "$last" in (''|*[!0-9]*) last=0 ;; esac
+    age=$(( now_epoch - last ))
+    window=$(( CADENCE_H * 3600 ))
+    if [ "$age" -ge 0 ] && [ "$age" -lt "$window" ]; then
+        echo "INFO: within cadence window (${age}s < ${window}s); skipping. Use --force to override." >&2
+        exit 0
+    fi
+fi
+# Write the run stamp unconditionally now (dead-man / anti-flap heartbeat).
+printf '%s\n' "$now_epoch" > "$STAMP" 2>/dev/null || true
+
+# ---- resolve KB root + registry ----
+if [ -z "$ROOT" ]; then
+    d="$PWD"
+    while [ "$d" != "/" ]; do
+        [ -f "$d/$REGISTRY_REL" ] && { ROOT="$d"; break; }
+        d="$(dirname "$d")"
+    done
+fi
+REGISTRY="$ROOT/$REGISTRY_REL"
+if [ -z "$ROOT" ] || [ ! -f "$REGISTRY" ]; then
+    echo "ERROR: registry not found ($REGISTRY_REL)" >&2
+    exit 3
+fi
+
+# ---- source the shared backlog-sink library ----
+# shellcheck source=dev-tools/lib/backlog-sink.sh
+if [ -f "$SINK_LIB" ]; then
+    . "$SINK_LIB"
+else
+    echo "ERROR: backlog-sink library not found ($SINK_LIB)" >&2
+    exit 2
+fi
+
+# ---- enumerate registry product ids (allowlisted) ----
+# Reuse the detector's two-space-indent product contract; reject any id that
+# fails ^[a-z][a-z0-9-]*$ (security: no traversal / regex-meta into backlog).
+enumerate_products() {
+    awk '
+        BEGIN { in_products=0 }
+        /^[[:space:]]*#/ { next }
+        /^products:[[:space:]]*$/ { in_products=1; next }
+        in_products==0 { next }
+        /^  [A-Za-z0-9_.\/-]+:[[:space:]]*$/ {
+            line=$0; sub(/:[[:space:]]*$/,"",line); sub(/^  /,"",line); print line
+        }
+    ' "$REGISTRY" | grep -E '^[a-z][a-z0-9-]*$' || true
+}
+
+# ---- Ops Bot fail-soft emit (adapted from preflight-check.sh emit_ops_bot) ----
+emit_ops_bot() {  # $1=category(info|warning|fatal) $2=title $3=body
+    local category="$1" title="$2" body="$3"
+    local key="${OPSBOT_KEY:-}"
+    if [ -z "$key" ]; then
+        echo "WARN: OPSBOT_KEY unset; skipping Ops Bot emit (fail-soft)" >&2
+        return 0
+    fi
+    command -v jq >/dev/null 2>&1 || { echo "WARN: jq absent; skipping Ops Bot emit" >&2; return 0; }
+    local payload
+    payload="$(jq -cn \
+        --arg agent "dr-drift-sweep" \
+        --arg title "$title" \
+        --arg body  "$body" \
+        --arg cat   "$category" \
+        '{agent:$agent, title:$title, body:$body, category:$cat}')"
+    # NB: never `set -x` around this curl — OPSBOT_KEY would leak.
+    local resp_file http_code
+    resp_file="$(mktemp -t drift-opsbot.XXXXXX 2>/dev/null || echo "/tmp/drift-opsbot.$$")"
+    http_code="$(curl -sS -X POST "$OPS_BOT_URL" \
+        -H "Authorization: Bearer ${key}" \
+        -H "Content-Type: application/json" \
+        --max-time 10 \
+        -d "$payload" \
+        --output "$resp_file" \
+        --write-out '%{http_code}' 2>/dev/null || echo "000")"
+    if ! printf '%s' "$http_code" | grep -Eq '^2[0-9]{2}$'; then
+        echo "WARN: Ops Bot emit failed (HTTP ${http_code}); not blocking sweep" >&2
+    fi
+    rm -f "$resp_file"
+}
+
+# ---- resolve sink (caller no-ops if no file sink) ----
+BACKLOG=""
+if BACKLOG="$(resolve_backlog_sink --root "$ROOT")"; then
+    :
+else
+    echo "INFO: no file backlog sink resolved (future non-file backend or consumer machine); skipping append. Zero writes." >&2
+    BACKLOG=""
+fi
+
+# ---- per-product sweep ----
+n_checked=0; n_drift=0; n_emitted=0; n_suppressed=0; n_skipped=0
+fatal=0
+
+for prod in $(enumerate_products); do
+    n_checked=$((n_checked+1))
+    rc=0
+    "$DETECTOR" --check --product "$prod" --root "$ROOT" >/dev/null 2>&1 || rc=$?
+    case "$rc" in
+        0) : ;;                                   # clean
+        1)                                        # drift
+            n_drift=$((n_drift+1))
+            if [ "$DRY_RUN" -eq 1 ] || [ -z "$BACKLOG" ]; then
+                n_suppressed=$((n_suppressed+1))
+                continue
+            fi
+            # Detail kept terse + single-line (injection gate enforced in lib).
+            sev="MEDIUM"
+            already=0
+            [ -f "$BACKLOG" ] && grep -qF "drift-site-update-$prod" -- "$BACKLOG" && already=1
+            if append_site_update_task "$BACKLOG" "$prod" "$sev" "repo↔site drift detected by sweep"; then
+                if [ "$already" -eq 0 ]; then
+                    n_emitted=$((n_emitted+1))
+                    # state-change only alert
+                    emit_ops_bot warning "Site drift: $prod" "New site-update task spawned for $prod (repo↔site drift)."
+                else
+                    n_suppressed=$((n_suppressed+1))
+                fi
+            else
+                n_suppressed=$((n_suppressed+1))
+            fi
+            ;;
+        3)                                        # registry missing/unparseable
+            fatal=1
+            echo "ERROR: detector reported registry failure (exit 3) for '$prod'" >&2
+            emit_ops_bot fatal "Drift sweep fatal" "Detector exit 3 (registry missing/unparseable) at product $prod."
+            break
+            ;;
+        *)                                        # SKIP / source-unavailable / other
+            n_skipped=$((n_skipped+1))
+            ;;
+    esac
+done
+
+# ---- heartbeat (one info message per run) ----
+hb="checked=$n_checked drifted=$n_drift emitted=$n_emitted suppressed=$n_suppressed skipped=$n_skipped"
+echo "INFO: drift-sweep $hb" >&2
+emit_ops_bot info "Drift sweep heartbeat" "$hb"
+
+[ "$fatal" -eq 1 ] && exit 3
+exit 0

--- a/dev-tools/deploy/README.md
+++ b/dev-tools/deploy/README.md
@@ -1,0 +1,30 @@
+# Drift-sweep scheduler templates
+
+Ship-with templates for scheduling `dev-tools/check-site-drift-sweep.sh`
+(level-3 ecosystem site-drift sweep). The sweep's canonical host is the **Mac
+primary** — it reads local git working trees under `Projects/*/code/`, which
+the servers do not carry (ADR-0001). These units exist for a future server
+move; on the Mac, install the documented crontab line below.
+
+## Mac primary — crontab (operator-installed; a system crontab edit is a
+## hard-gated mutation, so this is never auto-applied)
+
+```cron
+# Daily at 09:15 local — Datarim ecosystem site-drift sweep.
+# The script stamp-guards a 24h cadence, so re-runs within the window no-op.
+15 9 * * * /Users/<you>/.claude/dev-tools/check-site-drift-sweep.sh >> "$HOME/.local/state/datarim/drift-sweep.log" 2>&1
+```
+
+Export `OPSBOT_KEY` (or set it in the cron environment) for Ops Bot heartbeats.
+Missing key → the sweep fail-soft-warns and still generates backlog tasks.
+
+## Future server move — systemd
+
+```bash
+cp drift-sweep.service drift-sweep.timer /etc/systemd/system/
+# edit WorkingDirectory (KB root) + EnvironmentFile (OPSBOT_KEY) in the .service
+systemctl daemon-reload && systemctl enable --now drift-sweep.timer
+```
+
+Neither unit declares `Requires=`: an idempotent periodic sweep must not be
+coupled to another unit's restart cycle.

--- a/dev-tools/deploy/drift-sweep.service
+++ b/dev-tools/deploy/drift-sweep.service
@@ -1,0 +1,33 @@
+# drift-sweep.service — oneshot unit for the ecosystem site-drift sweep.
+#
+# Host-agnostic template. The sweep's canonical host is the Mac primary (it
+# needs the full working-tree coverage that servers lack per ADR-0001); this
+# unit ships for a future server move only. Install:
+#
+#   cp drift-sweep.service drift-sweep.timer /etc/systemd/system/
+#   # edit WorkingDirectory + the OPSBOT_KEY EnvironmentFile path below
+#   systemctl daemon-reload && systemctl enable --now drift-sweep.timer
+#
+# Intentionally NO `Requires=` / `After=` on a long-running service: this is a
+# self-contained oneshot with no service dependency (precedent: a timer that
+# couples Requires= to a unit is restarted whenever that unit cycles, which is
+# wrong for an idempotent periodic sweep).
+
+[Unit]
+Description=Datarim ecosystem site-drift sweep (level 3)
+Documentation=https://datarim.club
+
+[Service]
+Type=oneshot
+# Point WorkingDirectory at the KB root that holds documentation/ecosystem-sync/registry.yml.
+WorkingDirectory=%h/arcanada
+# OPSBOT_KEY is read from an operator-managed EnvironmentFile (mode 0600), never
+# inlined here. Missing key → sweep fail-soft-warns and still generates tasks.
+EnvironmentFile=-%h/.config/datarim/drift-sweep.env
+ExecStart=%h/.claude/dev-tools/check-site-drift-sweep.sh
+# Hardening floor.
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+ReadWritePaths=%h/.local/state/datarim

--- a/dev-tools/deploy/drift-sweep.timer
+++ b/dev-tools/deploy/drift-sweep.timer
@@ -1,0 +1,22 @@
+# drift-sweep.timer — daily schedule for the site-drift sweep (level 3).
+#
+# Cadence: daily, per the consilium decision. The sweep itself stamp-guards a
+# 24h window, so an over-eager timer cannot double-run. Persistent=true catches
+# up one missed run after the host was asleep/off (the Mac primary sleeps).
+#
+# NO `Requires=` — see drift-sweep.service header. A timer must not hard-require
+# its service unit; the [Install] WantedBy + the implicit Unit= binding are
+# sufficient and avoid restart-storm coupling.
+
+[Unit]
+Description=Daily Datarim site-drift sweep
+Documentation=https://datarim.club
+
+[Timer]
+OnCalendar=daily
+Persistent=true
+RandomizedDelaySec=900
+Unit=drift-sweep.service
+
+[Install]
+WantedBy=timers.target

--- a/dev-tools/lib/backlog-sink.sh
+++ b/dev-tools/lib/backlog-sink.sh
@@ -1,0 +1,194 @@
+# shellcheck shell=bash
+# backlog-sink.sh — shared backlog-sink resolver + append helper for the
+# site-drift auto-task generators (level 2 dr-archive sub-step and level 3
+# cron sweep). Sourced library: no shebang, no top-level side-effects.
+#
+# Public API:
+#   resolve_backlog_sink [--root <dir>]
+#       stdout: absolute backlog path; exit 0 = file sink resolved,
+#       exit 1 = no file sink (caller no-ops — NOT an error).
+#
+#   append_site_update_task <backlog> <product> <severity> <detail>
+#       Idempotent, atomic, injection-gated append of one site-update task.
+#       exit 0 = appended or already-present (dedup); exit 2 = rejected input.
+#
+# Dependency floor: pure bash + awk + grep + realpath/readlink. No yq, no jq,
+# no python — must run on any Datarim consumer. Backend resolution mirrors the
+# awk precedent in check-repo-site-sync.sh.
+#
+# Security (Mandate S1/S5/S9): every space.yml / registry scalar is untrusted.
+#   - product id: ^[a-z][a-z0-9-]*$ allowlist (rejects leading dash, regex-meta,
+#     path-traversal).
+#   - severity: ^(HIGH|MEDIUM)$ allowlist.
+#   - detail: must be single-line, [[:print:]]-only (anti backlog-line-injection).
+#   - resolved backlog path: realpath-contained within the resolved KB root,
+#     component-wise `..` rejection.
+#   - append is temp-file + atomic rename under an mkdir-based lock.
+
+# Anchor token is the id-independent dedup key per product.
+_bs_anchor() { printf 'drift-site-update-%s' "$1"; }
+
+# ---- field allowlists ---------------------------------------------------
+
+_bs_valid_product() {  # $1=product id
+    case "$1" in
+        -*) return 1 ;;                       # no leading dash
+    esac
+    printf '%s' "$1" | grep -Eq '^[a-z][a-z0-9-]*$'
+}
+
+_bs_valid_severity() {  # $1=severity
+    case "$1" in HIGH|MEDIUM) return 0 ;; *) return 1 ;; esac
+}
+
+# Reject multi-line or control-char detail (backlog-line-injection gate).
+# Printable UTF-8 (Cyrillic, ↔ arrows, em-dashes — all common in the backlog)
+# is allowed; the gate blocks only C0/C1 control bytes and newlines, which are
+# the actual injection vectors (forged backlog lines, ANSI escapes).
+_bs_valid_detail() {  # $1=detail
+    [ -n "$1" ] || return 1
+    case "$1" in *$'\n'*|*$'\r'*) return 1 ;; esac    # no embedded line break
+    # Reject any C0 control (0x00-0x1F except space-class already excluded by
+    # the line-break test above) or DEL (0x7F). Multibyte UTF-8 lead/continuation
+    # bytes are >= 0x80 and pass.
+    printf '%s' "$1" | LC_ALL=C grep -q '[[:cntrl:]]' && return 1
+    return 0
+}
+
+# ---- backend resolution -------------------------------------------------
+
+# Walk up from cwd (or --root) to find spaces/*/space.yml; awk-parse the
+# knowledge_base block for current_backend + datarim_path.
+_bs_find_space_yml() {  # $1=start dir → stdout path or empty
+    local d="$1"
+    while [ "$d" != "/" ] && [ -n "$d" ]; do
+        local hit
+        hit="$(find "$d/spaces" -maxdepth 2 -name space.yml 2>/dev/null | head -1)"
+        [ -n "$hit" ] && { printf '%s' "$hit"; return 0; }
+        d="$(dirname "$d")"
+    done
+    return 1
+}
+
+# Extract a scalar under the knowledge_base: block. Two-space-indent contract
+# matching space.yml; the block may sit under a parent (e.g. infra:) at any
+# depth, so we key off the `knowledge_base:` line and the relative indent of
+# the wanted key, not an absolute column.
+_bs_kb_field() {  # $1=space.yml $2=key → stdout value
+    awk -v key="$2" '
+        function strip(s){ sub(/^[[:space:]]+/,"",s); sub(/[[:space:]]+$/,"",s); return s }
+        BEGIN { inkb=0; kbindent=-1 }
+        /^[[:space:]]*#/ { next }
+        {
+            line=$0
+            # current indent = leading spaces
+            n=match(line, /[^ ]/); indent=(n>0?n-1:0)
+            if (line ~ /knowledge_base:[[:space:]]*$/) { inkb=1; kbindent=indent; next }
+            if (inkb && indent <= kbindent && strip(line) != "") { inkb=0 }
+            if (inkb && line ~ ("^[[:space:]]+" key ":[[:space:]]")) {
+                v=line; sub(/^[^:]*:[[:space:]]*/,"",v); v=strip(v)
+                if (v ~ /^".*"$/ || v ~ /^'\''.*'\''$/) v=substr(v,2,length(v)-2)
+                print v; exit
+            }
+        }
+    ' "$1" 2>/dev/null
+}
+
+resolve_backlog_sink() {
+    local root=""
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            --root) root="$2"; shift 2 ;;
+            *) shift ;;
+        esac
+    done
+
+    # 1. Env override — operator/CI explicit sink.
+    if [ -n "${DATARIM_BACKLOG_PATH:-}" ]; then
+        printf '%s' "$DATARIM_BACKLOG_PATH"; return 0
+    fi
+
+    local start="${root:-$PWD}"
+
+    # 2. space.yml backend resolution.
+    local space_yml
+    space_yml="$(_bs_find_space_yml "$start")"
+    if [ -n "$space_yml" ]; then
+        local backend dpath
+        backend="$(_bs_kb_field "$space_yml" current_backend)"
+        if [ "$backend" = "file-based-datarim" ]; then
+            dpath="$(_bs_kb_field "$space_yml" datarim_path)"
+            if [ -n "$dpath" ] && [ -d "$dpath" ]; then
+                printf '%s/backlog.md' "$dpath"; return 0
+            fi
+        elif [ -n "$backend" ]; then
+            # Known non-file backend (e.g. future muneral): no file sink.
+            return 1
+        fi
+    fi
+
+    # 3. Bare datarim/backlog.md under root.
+    if [ -d "$start/datarim" ]; then
+        printf '%s/datarim/backlog.md' "$start"; return 0
+    fi
+
+    # 4. Nothing resolvable.
+    return 1
+}
+
+# ---- anti-flap note -----------------------------------------------------
+#
+# There is intentionally NO post-close cooldown. The drift signal is sticky —
+# it does not self-clear; only an operator fixing the deployed site clears it.
+# A sticky signal cannot flap, so open-task dedup (the anchor grep below) is
+# the complete idempotency contract. If a product whose task was closed still
+# drifts, the next sweep re-spawns exactly one task — that is a true positive
+# (premature close or regression), not noise to suppress. (Verdict: researcher
+# survey of Alertmanager repeat_interval / PagerDuty dedup-key / Nagios flap
+# detection + architect/sre/security consilium — all converged on "no
+# cooldown".) Any future anti-flap work is gated on observed re-spawn churn,
+# not speculation — see the backlog follow-up.
+
+# ---- atomic, idempotent append ------------------------------------------
+
+append_site_update_task() {  # $1=backlog $2=product $3=severity $4=detail
+    local backlog="$1" product="$2" severity="$3" detail="$4"
+
+    _bs_valid_product  "$product"  || { echo "backlog-sink: invalid product id '$product'" >&2; return 2; }
+    _bs_valid_severity "$severity" || { echo "backlog-sink: invalid severity '$severity'" >&2; return 2; }
+    _bs_valid_detail   "$detail"   || { echo "backlog-sink: detail rejected (multi-line or non-printable)" >&2; return 2; }
+    [ -n "$backlog" ] || { echo "backlog-sink: empty backlog path" >&2; return 2; }
+
+    local anchor; anchor="$(_bs_anchor "$product")"
+
+    # Dedup: anchor already present → no-op success.
+    if [ -f "$backlog" ] && grep -qF "$anchor" -- "$backlog"; then
+        return 0
+    fi
+
+    # mkdir-based lock around read-modify-write. Explicit cleanup before every
+    # return — `trap ... RETURN` is avoided (unsupported in zsh, and fires on
+    # every nested-function return, releasing the lock prematurely).
+    local lock="${backlog}.lock"
+    local i=0
+    until mkdir "$lock" 2>/dev/null; do
+        i=$((i+1)); [ "$i" -ge 50 ] && { echo "backlog-sink: lock timeout" >&2; return 2; }
+        sleep 0.1
+    done
+
+    # Re-check under lock (TOCTOU).
+    if [ -f "$backlog" ] && grep -qF "$anchor" -- "$backlog"; then
+        rmdir "$lock" 2>/dev/null
+        return 0
+    fi
+
+    local line tmp
+    line="- TASK-XXXX · pending · P2 · L1 · Site-update ${product}: repo↔site drift (${severity}) — ${detail}. Anchor: ${anchor}. (Source: drift-sweep)"
+
+    tmp="$(mktemp "${backlog}.XXXXXX")" || { echo "backlog-sink: mktemp failed" >&2; rmdir "$lock" 2>/dev/null; return 2; }
+    [ -f "$backlog" ] && cat -- "$backlog" > "$tmp"
+    printf '%s\n' "$line" >> "$tmp"
+    mv -f -- "$tmp" "$backlog"
+    rmdir "$lock" 2>/dev/null
+    return 0
+}

--- a/skills/security-baseline/SKILL.md
+++ b/skills/security-baseline/SKILL.md
@@ -69,6 +69,7 @@ The baseline therefore optimises for **shipped-artefact correctness** over local
 7. **No `ssh -o StrictHostKeyChecking=no`** in any canonical recipe. Bootstrap host keys via `ssh-keyscan -H "$host" >> ~/.ssh/known_hosts` and document key-rotation policy.
 <!-- /security:rule-statement -->
 8. **`shellcheck -S warning` clean** for committed `*.sh`. Suppression via `# shellcheck disable=...` MUST cite reason + finding-ID + reviewer in an adjacent comment (see § Suppression policy).
+9. **Line-injection gate for free-text written into a UTF-8 content file** (a backlog line, a commit-message body, a log record, any append target where one logical record is one line): reject embedded newlines/carriage-returns AND C0/C1 control bytes — `printf '%s' "$s" | LC_ALL=C grep -q '[[:cntrl:]]'` plus a `case "$s" in *$'\n'*|*$'\r'*)` guard. Do **NOT** gate with `[[:print:]]`-only under `LC_ALL=C`: that rejects every legitimate printable multibyte UTF-8 character (Cyrillic, arrows like `↔`, em-dashes) because each lead/continuation byte is ≥ 0x80 and fails the ASCII `[[:print:]]` class. The injection vector is the control byte (forged record, ANSI escape), not the printable non-ASCII glyph. Probe the gate against a non-ASCII sample at write-time.
 
 ### MUST NOT
 

--- a/tests/backlog-sink.bats
+++ b/tests/backlog-sink.bats
@@ -1,0 +1,119 @@
+#!/usr/bin/env bats
+# backlog-sink.bats — unit matrix for the shared backlog-sink resolver library
+# consumed by both the dr-archive sub-step (level 2) and the cron sweep
+# (level 3). Each test sources the library in a throwaway KB-root and asserts
+# the resolve_backlog_sink fallback chain plus the append_site_update_task
+# idempotency / injection-gate contract.
+
+setup() {
+    LIB="${BATS_TEST_DIRNAME}/../dev-tools/lib/backlog-sink.sh"
+    KB="$(mktemp -d)"
+    unset DATARIM_BACKLOG_PATH
+}
+
+teardown() { rm -rf "$KB"; }
+
+# Write a space.yml under a spaces/<name>/ tree with a chosen backend.
+write_space_yml() {  # $1=backend $2=datarim_path
+    mkdir -p "$KB/spaces/arcanada"
+    cat > "$KB/spaces/arcanada/space.yml" <<EOF
+space: arcanada
+infra:
+  knowledge_base:
+    current_backend: $1
+    datarim_path: $2
+EOF
+}
+
+# ---- resolve_backlog_sink fallback chain (V-2) ----
+
+@test "V-2a: DATARIM_BACKLOG_PATH env override wins" {
+    export DATARIM_BACKLOG_PATH="$KB/custom-backlog.md"
+    run bash -c "source '$LIB'; resolve_backlog_sink --root '$KB'"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$KB/custom-backlog.md" ]
+}
+
+@test "V-2b: space.yml file-based-datarim resolves datarim_path/backlog.md" {
+    mkdir -p "$KB/datarim"
+    write_space_yml file-based-datarim "$KB/datarim"
+    run bash -c "cd '$KB/spaces/arcanada'; source '$LIB'; resolve_backlog_sink"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$KB/datarim/backlog.md" ]
+}
+
+@test "V-2c: space.yml non-file backend (future muneral) → exit 1, no path" {
+    write_space_yml muneral "$KB/datarim"
+    run bash -c "cd '$KB/spaces/arcanada'; source '$LIB'; resolve_backlog_sink"
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+@test "V-2d: bare datarim/backlog.md fallback when no space.yml" {
+    mkdir -p "$KB/datarim"
+    run bash -c "cd '$KB'; source '$LIB'; resolve_backlog_sink"
+    [ "$status" -eq 0 ]
+    [ "$output" = "$KB/datarim/backlog.md" ]
+}
+
+@test "V-2e: nothing resolvable → exit 1" {
+    run bash -c "cd '$KB'; source '$LIB'; resolve_backlog_sink"
+    [ "$status" -eq 1 ]
+    [ -z "$output" ]
+}
+
+# ---- append_site_update_task idempotency (V-3) ----
+
+@test "V-3: two appends for same product produce exactly one backlog line" {
+    bl="$KB/backlog.md"; : > "$bl"
+    bash -c "source '$LIB'; append_site_update_task '$bl' demo MEDIUM 'site behind repo'"
+    bash -c "source '$LIB'; append_site_update_task '$bl' demo MEDIUM 'site behind repo'"
+    run grep -cF 'drift-site-update-demo' "$bl"
+    [ "$output" -eq 1 ]
+}
+
+@test "V-3b: distinct products produce distinct anchored lines" {
+    bl="$KB/backlog.md"; : > "$bl"
+    bash -c "source '$LIB'; append_site_update_task '$bl' alpha MEDIUM 'x'"
+    bash -c "source '$LIB'; append_site_update_task '$bl' beta HIGH 'y'"
+    [ "$(grep -cF 'drift-site-update-alpha' "$bl")" -eq 1 ]
+    [ "$(grep -cF 'drift-site-update-beta' "$bl")" -eq 1 ]
+}
+
+# ---- line-injection gate (V-6 / S9) ----
+
+@test "V-6a: embedded newline in detail is rejected, no forged line" {
+    bl="$KB/backlog.md"; : > "$bl"
+    run bash -c "source '$LIB'; append_site_update_task '$bl' demo MEDIUM \$'line1\nINJECTED pending P0'"
+    [ "$status" -ne 0 ]
+    ! grep -q 'INJECTED' "$bl"
+}
+
+@test "V-6b: non-printable byte in detail is rejected" {
+    bl="$KB/backlog.md"; : > "$bl"
+    run bash -c "source '$LIB'; append_site_update_task '$bl' demo MEDIUM \$'bad\x01ctrl'"
+    [ "$status" -ne 0 ]
+}
+
+@test "V-6c: product id with regex-meta / path-traversal is rejected" {
+    bl="$KB/backlog.md"; : > "$bl"
+    run bash -c "source '$LIB'; append_site_update_task '$bl' '../etc' MEDIUM 'x'"
+    [ "$status" -ne 0 ]
+    [ ! -s "$bl" ]
+}
+
+@test "V-6d: leading-dash product slug is rejected" {
+    bl="$KB/backlog.md"; : > "$bl"
+    run bash -c "source '$LIB'; append_site_update_task '$bl' '-evil' MEDIUM 'x'"
+    [ "$status" -ne 0 ]
+}
+
+# ---- atomic append preserves prior content (V-3 atomicity) ----
+
+@test "V-3c: append preserves pre-existing backlog content" {
+    bl="$KB/backlog.md"
+    printf -- '- EXISTING-0001 · pending · keep me\n' > "$bl"
+    bash -c "source '$LIB'; append_site_update_task '$bl' demo MEDIUM 'd'"
+    grep -q 'EXISTING-0001' "$bl"
+    grep -q 'drift-site-update-demo' "$bl"
+}

--- a/tests/check-site-drift-sweep.bats
+++ b/tests/check-site-drift-sweep.bats
@@ -1,0 +1,181 @@
+#!/usr/bin/env bats
+# check-site-drift-sweep.bats — V-AC matrix for the level-3 ecosystem-wide
+# site-drift sweep. The real detector is replaced by a mock on PATH so each
+# test drives a deterministic exit code per product; the sweep's job under
+# test is enumeration, idempotent append, exit-code branching, stamp-guard,
+# and fail-soft Ops Bot emit.
+
+setup() {
+    SWEEP="${BATS_TEST_DIRNAME}/../dev-tools/check-site-drift-sweep.sh"
+    KB="$(mktemp -d)"
+    STATE="$(mktemp -d)"
+    BIN="$(mktemp -d)"            # holds the mock detector
+    export XDG_STATE_HOME="$STATE"
+    export DATARIM_BACKLOG_PATH="$KB/backlog.md"; : > "$DATARIM_BACKLOG_PATH"
+    unset OPSBOT_KEY
+    mkdir -p "$KB/documentation/ecosystem-sync"
+}
+
+teardown() { rm -rf "$KB" "$STATE" "$BIN"; }
+
+# Write a registry with the given product ids (all pointing at dummy fixtures).
+write_registry() {  # $@=product ids
+    {
+        echo 'products:'
+        for p in "$@"; do
+            printf '  %s:\n    repo_local: repo-%s\n    site_local: site-%s\n' "$p" "$p" "$p"
+        done
+    } > "$KB/documentation/ecosystem-sync/registry.yml"
+}
+
+# Install a mock detector whose exit code is keyed by product id via a map file.
+# map line format: "<product> <exitcode>"
+install_mock_detector() {  # reads $KB/mockmap
+    cat > "$BIN/check-repo-site-sync.sh" <<'MOCK'
+#!/usr/bin/env bash
+prod=""
+while [ $# -gt 0 ]; do case "$1" in --product) prod="$2"; shift 2;; *) shift;; esac; done
+code=0
+while read -r p c; do [ "$p" = "$prod" ] && code="$c"; done < "$MOCKMAP"
+exit "$code"
+MOCK
+    chmod +x "$BIN/check-repo-site-sync.sh"
+    export MOCKMAP="$KB/mockmap"
+    export DRIFT_SWEEP_DETECTOR="$BIN/check-repo-site-sync.sh"
+}
+
+run_sweep() { run bash "$SWEEP" --root "$KB" --force "$@"; }
+
+# ---- exit-code branches (V-5) ----
+
+@test "V-5a: all products clean → exit 0, no backlog lines" {
+    write_registry alpha beta
+    printf 'alpha 0\nbeta 0\n' > "$KB/mockmap"; install_mock_detector
+    run_sweep
+    [ "$status" -eq 0 ]
+    [ ! -s "$DATARIM_BACKLOG_PATH" ]
+}
+
+@test "V-5b: one drifted product → exit 0 (sweep ok), one backlog line" {
+    write_registry alpha beta
+    printf 'alpha 1\nbeta 0\n' > "$KB/mockmap"; install_mock_detector
+    run_sweep
+    [ "$status" -eq 0 ]
+    [ "$(grep -cF 'drift-site-update-alpha' "$DATARIM_BACKLOG_PATH")" -eq 1 ]
+    [ "$(grep -cF 'drift-site-update-beta' "$DATARIM_BACKLOG_PATH")" -eq 0 ]
+}
+
+@test "V-5c: detector registry-missing (exit 3) for a product → sweep exits 3" {
+    write_registry alpha
+    printf 'alpha 3\n' > "$KB/mockmap"; install_mock_detector
+    run_sweep
+    [ "$status" -eq 3 ]
+}
+
+@test "V-5d: source-unavailable / unknown detector code → product skipped, exit 0" {
+    write_registry alpha
+    printf 'alpha 4\n' > "$KB/mockmap"; install_mock_detector
+    run_sweep
+    [ "$status" -eq 0 ]
+    [ ! -s "$DATARIM_BACKLOG_PATH" ]
+}
+
+# ---- idempotency (V-3 / V-AC-9) ----
+
+@test "V-3: two consecutive sweeps → exactly one line per drifted product" {
+    write_registry alpha
+    printf 'alpha 1\n' > "$KB/mockmap"; install_mock_detector
+    run_sweep; [ "$status" -eq 0 ]
+    run_sweep; [ "$status" -eq 0 ]
+    [ "$(grep -cF 'drift-site-update-alpha' "$DATARIM_BACKLOG_PATH")" -eq 1 ]
+}
+
+# ---- stamp guard / cadence ----
+
+@test "V-stamp: second run within cadence without --force is skipped" {
+    write_registry alpha
+    printf 'alpha 1\n' > "$KB/mockmap"; install_mock_detector
+    run bash "$SWEEP" --root "$KB" --force            # primes the stamp + emits
+    [ "$status" -eq 0 ]
+    run bash "$SWEEP" --root "$KB" --cadence-h 24      # no --force → within cadence
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -qi 'cadence\|skip'
+}
+
+@test "V-stamp-write: stamp file written unconditionally at entry" {
+    write_registry alpha
+    printf 'alpha 0\n' > "$KB/mockmap"; install_mock_detector
+    run bash "$SWEEP" --root "$KB" --force
+    [ "$status" -eq 0 ]
+    [ -f "$STATE/datarim/drift-sweep.last-run" ]
+}
+
+# ---- dry-run ----
+
+@test "V-dry: --dry-run drifted product produces no backlog write" {
+    write_registry alpha
+    printf 'alpha 1\n' > "$KB/mockmap"; install_mock_detector
+    run bash "$SWEEP" --root "$KB" --force --dry-run
+    [ "$status" -eq 0 ]
+    [ ! -s "$DATARIM_BACKLOG_PATH" ]
+}
+
+# ---- stack-agnostic (V-7) ----
+
+@test "V-7: no space.yml and no DATARIM_BACKLOG_PATH → no file sink, exit 0, zero writes" {
+    unset DATARIM_BACKLOG_PATH
+    write_registry alpha
+    printf 'alpha 1\n' > "$KB/mockmap"; install_mock_detector
+    # KB has no spaces/*/space.yml and no datarim/ dir → resolver exit 1.
+    run bash "$SWEEP" --root "$KB" --force
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -qi 'no.*sink\|skip'
+}
+
+# ---- fail-soft Ops Bot emit (V-8) ----
+
+@test "V-8a: missing OPSBOT_KEY → warn, no POST, sweep still emits backlog line" {
+    write_registry alpha
+    printf 'alpha 1\n' > "$KB/mockmap"; install_mock_detector
+    run_sweep
+    [ "$status" -eq 0 ]
+    [ "$(grep -cF 'drift-site-update-alpha' "$DATARIM_BACKLOG_PATH")" -eq 1 ]
+}
+
+@test "V-8b: curl present but endpoint non-2xx (mocked) → warn + continue, exit 0" {
+    write_registry alpha
+    printf 'alpha 1\n' > "$KB/mockmap"; install_mock_detector
+    # Mock curl on PATH to return 503; sweep must not fail.
+    cat > "$BIN/curl" <<'CURL'
+#!/usr/bin/env bash
+# emulate --write-out '%{http_code}' --output behaviour
+out=""; while [ $# -gt 0 ]; do case "$1" in --output) out="$2"; shift 2;; *) shift;; esac; done
+[ -n "$out" ] && : > "$out"
+printf '503'
+CURL
+    chmod +x "$BIN/curl"
+    export OPSBOT_KEY="dummy"
+    run env PATH="$BIN:$PATH" bash "$SWEEP" --root "$KB" --force
+    [ "$status" -eq 0 ]
+    [ "$(grep -cF 'drift-site-update-alpha' "$DATARIM_BACKLOG_PATH")" -eq 1 ]
+}
+
+# ---- security adversarial (V-6 / S9) ----
+
+@test "V-6: registry product id with path-traversal is filtered out, no forged line" {
+    # malformed id '../etc' fails the ^[a-z][a-z0-9-]*$ allowlist → never reaches detector.
+    write_registry alpha
+    printf '  ../etc:\n    repo_local: x\n' >> "$KB/documentation/ecosystem-sync/registry.yml"
+    printf 'alpha 0\n' > "$KB/mockmap"; install_mock_detector
+    run_sweep
+    [ "$status" -eq 0 ]
+    ! grep -q 'etc' "$DATARIM_BACKLOG_PATH"
+}
+
+# ---- help ----
+
+@test "V-help: --help exits 0 and prints usage" {
+    run bash "$SWEEP" --help
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -qi usage
+}

--- a/tests/dr-archive-drift-substep.bats
+++ b/tests/dr-archive-drift-substep.bats
@@ -1,0 +1,100 @@
+#!/usr/bin/env bats
+# dr-archive-drift-substep.bats — V-4 / V-AC-8 scenario coverage for the
+# level-2 dr-archive sub-step 0.15. The sub-step is an executable instruction
+# (detector --check → resolve_backlog_sink → append_site_update_task); this
+# test replays that exact pipeline against a fixture KB-root and asserts the
+# three branches the sub-step prescribes:
+#   (1) detector present + drift   → one site-update backlog line appended
+#   (2) detector present + clean   → no-op
+#   (3) detector absent            → no-op (silent skip)
+
+setup() {
+    REPO_ROOT="${BATS_TEST_DIRNAME}/.."
+    DETECTOR="$REPO_ROOT/dev-tools/check-repo-site-sync.sh"
+    LIB="$REPO_ROOT/dev-tools/lib/backlog-sink.sh"
+    KB="$(mktemp -d)"
+    STATE="$(mktemp -d)"
+    export XDG_STATE_HOME="$STATE"
+    mkdir -p "$KB/documentation/ecosystem-sync" "$KB/datarim"
+    : > "$KB/datarim/backlog.md"
+    # Fixture product "demo": git repo + site dir, fully synced by default.
+    mkdir -p "$KB/repo/commands" "$KB/site"
+    ( cd "$KB/repo" && git init -q && git config user.email t@t && git config user.name t )
+    printf '1.0.0\n' > "$KB/repo/VERSION"
+    : > "$KB/repo/commands/a.md"; : > "$KB/repo/commands/b.md"
+    printf '# demo\nSee https://demo.example for the site.\n' > "$KB/repo/README.md"
+    printf "<?php return ['version' => '1.0.0'];\n" > "$KB/site/config.php"
+    printf '2 commands\n<a href="https://arcanada.one/ecosystem">eco</a>\n' > "$KB/site/features.php"
+    ( cd "$KB/repo" && git add -A && git commit -qm init )
+    write_registry
+    export DATARIM_BACKLOG_PATH="$KB/datarim/backlog.md"
+}
+
+teardown() { rm -rf "$KB" "$STATE"; }
+
+write_registry() {
+    cat > "$KB/documentation/ecosystem-sync/registry.yml" <<EOF
+products:
+  demo:
+    repo_local: repo
+    domain: demo.example
+    site_local: site
+    head_site: arcanada.one
+    version_repo: VERSION
+    version_site: config.php
+    feature_count_repo: commands
+    feature_count_site: features.php
+    readme_repo: README.md
+EOF
+}
+
+# Replays sub-step 0.15 for product "demo": returns the detector exit and, on
+# drift, performs the resolve+append the sub-step prescribes.
+replay_substep() {  # $1=detector-path (may be a non-existent path to test absence)
+    local detector="$1"
+    # 0.15.1 applicability: skip silently if detector absent.
+    [ -x "$detector" ] || return 0
+    local rc=0
+    "$detector" --check --product demo --root "$KB" >/dev/null 2>&1 || rc=$?
+    if [ "$rc" -eq 1 ]; then
+        . "$LIB"
+        local backlog
+        if backlog="$(resolve_backlog_sink --root "$KB")"; then
+            append_site_update_task "$backlog" demo MEDIUM "repo↔site drift at archive"
+        fi
+    fi
+    return 0
+}
+
+@test "V-4a: detector present + drift → one site-update line appended" {
+    # Introduce drift: bump repo version so site (1.0.0) lags repo (1.1.0).
+    printf '1.1.0\n' > "$KB/repo/VERSION"
+    ( cd "$KB/repo" && git add -A && git commit -qm bump )
+    run "$DETECTOR" --check --product demo --root "$KB"
+    [ "$status" -eq 1 ]   # confirm fixture actually drifts
+    replay_substep "$DETECTOR"
+    [ "$(grep -cF 'drift-site-update-demo' "$DATARIM_BACKLOG_PATH")" -eq 1 ]
+    grep -q 'Site-update demo' "$DATARIM_BACKLOG_PATH"
+}
+
+@test "V-4b: detector present + clean → no backlog line" {
+    run "$DETECTOR" --check --product demo --root "$KB"
+    [ "$status" -eq 0 ]   # synced fixture
+    replay_substep "$DETECTOR"
+    [ ! -s "$DATARIM_BACKLOG_PATH" ]
+}
+
+@test "V-4c: detector absent → silent no-op, no backlog line" {
+    printf '1.1.0\n' > "$KB/repo/VERSION"
+    ( cd "$KB/repo" && git add -A && git commit -qm bump )
+    replay_substep "$KB/nonexistent-detector.sh"
+    [ ! -s "$DATARIM_BACKLOG_PATH" ]
+}
+
+@test "V-4d: idempotent — replaying the drift sub-step twice keeps one line" {
+    printf '1.1.0\n' > "$KB/repo/VERSION"
+    ( cd "$KB/repo" && git add -A && git commit -qm bump )
+    replay_substep "$DETECTOR"
+    replay_substep "$DETECTOR"
+    [ "$(grep -cF 'drift-site-update-demo' "$DATARIM_BACKLOG_PATH")" -eq 1 ]
+}

--- a/tests/drift-sweep-deploy.bats
+++ b/tests/drift-sweep-deploy.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+# drift-sweep-deploy.bats — invariants for the level-3 scheduler templates.
+# These are static-file assertions (V-10 + crontab-doc presence).
+
+DEPLOY="${BATS_TEST_DIRNAME}/../dev-tools/deploy"
+
+@test "V-10a: timer template declares no Requires=" {
+    run grep -q '^Requires=' "$DEPLOY/drift-sweep.timer"
+    [ "$status" -ne 0 ]
+}
+
+@test "V-10b: service template declares no Requires=" {
+    run grep -q '^Requires=' "$DEPLOY/drift-sweep.service"
+    [ "$status" -ne 0 ]
+}
+
+@test "V-10c: timer binds the service via Unit= and installs to timers.target" {
+    grep -q '^Unit=drift-sweep.service' "$DEPLOY/drift-sweep.timer"
+    grep -q '^WantedBy=timers.target' "$DEPLOY/drift-sweep.timer"
+}
+
+@test "V-10d: service is oneshot" {
+    grep -q '^Type=oneshot' "$DEPLOY/drift-sweep.service"
+}
+
+@test "deploy README documents the operator-installed crontab line" {
+    grep -q 'check-site-drift-sweep.sh' "$DEPLOY/README.md"
+    grep -qi 'crontab' "$DEPLOY/README.md"
+}


### PR DESCRIPTION
## Summary

Two defense-in-depth layers on the existing repo↔site drift detector (consumed, not modified):

- **Level 2** — `commands/dr-archive.md` sub-step 0.15: when an archived task touched a registered product's `repo_local`, run the detector and append one deduped site-update backlog task (repo-first ordering).
- **Level 3** — `dev-tools/check-site-drift-sweep.sh`: daily cron sweep over all registered products; one idempotent task per drifted product; fail-soft Ops Bot heartbeat; stamp-guarded 24h cadence; host-agnostic systemd template (no `Requires=`) + operator-installed crontab.

Shared `dev-tools/lib/backlog-sink.sh` resolver (env → `space.yml` backend → bare datarim → none) + atomic, injection-gated append, used by both levels.

Realises **PRD-ARCA-0142 V-AC-8 / V-AC-9**; absorbs TUNE-0170.

## Design decision: no anti-flap cooldown

The plan proposed a 48h-close cooldown. Researcher survey (Alertmanager `repeat_interval` / PagerDuty dedup-key / Nagios flap detection) + an architect/sre/security consilium converged **unanimously on dropping it**: the drift signal is *sticky* (clears only when an operator fixes the site), so it cannot flap; a close-cooldown could only suppress a legitimately-needed re-spawn. Open-task dedup is the complete idempotency contract. Future anti-flap work is gated on observed churn (follow-up ARCA-0152).

## Tests & gates

- 34 bats green (backlog-sink 12, sweep 13, dr-archive sub-step 4, deploy 5); 46/46 with the detector suite.
- `shellcheck -S warning` clean · gitleaks no-leaks · English-only / task-id / stack-agnostic gates pass.
- **Live empirical smoke**: sweep run against the real ecosystem registry — detector found genuine drift on product `datarim`, idempotency held (two runs → exactly one backlog line), fail-soft confirmed with no Ops Bot key.

## Also includes

`skills/security-baseline/SKILL.md` S1 rule 9 — UTF-8 line-injection gate (reject control bytes, not `[[:print:]]`-only which false-rejects Cyrillic/arrows). Sourced from a runtime bug caught during implementation.
