### PR TITLE
feat(release): G0 manifest-version assert in release-gate.sh (bump-before-tag, fail-closed)

### DIFF
--- a/dev-tools/release-gate.sh
+++ b/dev-tools/release-gate.sh
@@ -9,6 +9,8 @@
 # tag so the operator can roll back (the publish already fired).
 #
 # Gates (fail-closed — any red aborts before the tag):
+#   G0 manifest version == --version (bump must precede the tag; mirrors the CI
+#      version-assert locally so an unbumped manifest fails here, not after the tag)
 #   G1 CI green on the default branch
 #   G2 /dr-qa ALL_PASS
 #   G3 signed pipeline present (release.yml with attest-build-provenance)
@@ -45,6 +47,18 @@ usage() {
     exit 2
 }
 die_gate() { echo "GATE FAILED: $1" >&2; exit 1; }
+
+# Resolve the manifest version (pyproject first, then VERSION). Mirrors the same
+# resolution order as release-classify.sh resolve_version() so the gate and the
+# classifier agree on which file is authoritative.
+resolve_manifest_version() {
+    local repo="$1" v=""
+    if [ -f "$repo/pyproject.toml" ]; then
+        v="$(sed -n 's/^version *= *"\([0-9][0-9.]*\).*/\1/p' "$repo/pyproject.toml" | head -1)"
+    fi
+    [ -z "$v" ] && [ -f "$repo/VERSION" ] && v="$(tr -d ' \t\n' < "$repo/VERSION")"
+    printf '%s' "$v"
+}
 
 # --- external-gate hooks (env override first, else live probe) ------------------
 probe_ci_status() {
@@ -117,7 +131,15 @@ main() {
     [ "$cur_branch" = "$allow_branch" ] || die_gate "G4 branch '$cur_branch' != '$allow_branch'"
     [ "$(probe_version_published)" = false ] || die_gate "G5 version $version already published"
 
-    local gates="G1,G2,G3,G4,G5,G6"
+    # G0 manifest-version assert: the built artifact will be named from the repo
+    # manifest, so the manifest version MUST already equal --version before we tag.
+    # This mirrors the CI release.yml version-assert locally so an unbumped manifest
+    # fails HERE (no tag) instead of after the tag fires in CI. Run `bump` first:
+    # bump pyproject.toml / VERSION + CHANGELOG to <version>, then invoke this gate.
+    local manifest_ver; manifest_ver="$(resolve_manifest_version "$repo")"
+    [ "$manifest_ver" = "$version" ] || die_gate "G0 manifest version '$manifest_ver' != --version '$version' — bump pyproject.toml / VERSION (and CHANGELOG) to $version before tagging"
+
+    local gates="G0,G1,G2,G3,G4,G5,G6"
     if [ "$dry_run" = true ]; then
         echo "DRY-RUN: all gates green for v${version} (bump=${bump}); no tag created."
         exit 0

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -24,8 +24,12 @@ consumer-facing verification recipe lives in
 > **Autonomous patch/minor (v2.27.0+).** For Arcanada-owned packages the agent
 > MAY drive a `patch`/`minor` release end-to-end without an operator prompt when
 > every fail-closed gate is green — `dev-tools/release-classify.sh` (verdict
-> `escalate=false`) then `dev-tools/release-gate.sh` (CI green / `/dr-qa`
-> ALL_PASS / signed pipeline / branch == main / version not published). The
+> `escalate=false`) then `dev-tools/release-gate.sh` (manifest version ==
+> target / CI green / `/dr-qa` ALL_PASS / signed pipeline / branch == main /
+> version not published). The bump (`pyproject.toml` / `VERSION` + CHANGELOG)
+> MUST land before the gate runs — `release-gate.sh` fails closed (no tag) if the
+> manifest version does not already equal the target, so an unbumped manifest is
+> caught locally instead of after the tag fires in CI. The
 > annotated tag carries the bump level; the `release.yml` `classify` job
 > re-verifies in CI and routes a `major` bump to the `release-manual` environment
 > (operator approval). `major` and any `0.x` breaking change always escalate. See

--- a/tests/release-gate.bats
+++ b/tests/release-gate.bats
@@ -14,7 +14,10 @@ setup() {
     git -C "$REPO" config commit.gpgsign false
     git -C "$REPO" config tag.gpgsign false
     git -C "$REPO" branch -m main
-    echo "0.6.3" > "$REPO/VERSION"
+    # Manifest version starts at the release target 0.6.4 — i.e. the realistic
+    # post-bump state the gate expects (G0 version-assert). Tests that exercise a
+    # different --version flip the manifest via _set_manifest_version.
+    echo "0.6.4" > "$REPO/VERSION"
     # A signed-pipeline marker the gate greps for (G3).
     mkdir -p "$REPO/.github/workflows"
     printf 'jobs:\n  release:\n    steps:\n      - uses: actions/attest-build-provenance@x\n' \
@@ -36,6 +39,7 @@ teardown() { rm -rf "$REPO"; }
 
 _run_gate() { run "$SCRIPT" --repo "$REPO" --version "${1:-0.6.4}" --registry pypi "${@:2}"; }
 _tag_exists() { git -C "$REPO" tag -l "v${1}" | grep -q "v${1}"; }
+_set_manifest_version() { echo "$1" > "$REPO/VERSION"; }
 
 @test "all gates green + patch bump -> tag created, exit 0, audit record written" {
     _run_gate 0.6.4
@@ -116,4 +120,35 @@ _tag_exists() { git -C "$REPO" tag -l "v${1}" | grep -q "v${1}"; }
 @test "missing --repo exits 2" {
     run "$SCRIPT" --version 0.6.4 --registry pypi
     [ "$status" -eq 2 ]
+}
+
+@test "G0 manifest version != --version -> exit 1, NO tag, clear message (the dogfood loop)" {
+    _set_manifest_version 0.6.3        # manifest stale, requesting 0.6.4
+    _run_gate 0.6.4
+    [ "$status" -eq 1 ]
+    ! _tag_exists 0.6.4
+    echo "$output" | grep -qiE "version mismatch|bump .*pyproject|manifest"
+}
+
+@test "G0 fires BEFORE the tag side-effect (no tag on mismatch even with all gates green)" {
+    _set_manifest_version 0.5.0
+    _run_gate 0.6.4
+    [ "$status" -eq 1 ]
+    ! _tag_exists 0.6.4
+    [ ! -d "$AUDIT_DIR" ] || ! grep -rq "0.6.4" "$AUDIT_DIR"   # no audit record either
+}
+
+@test "G0 reads pyproject.toml when present (takes precedence over VERSION)" {
+    printf '[project]\nname = "x"\nversion = "0.6.4"\n' > "$REPO/pyproject.toml"
+    _set_manifest_version 0.1.0         # VERSION stale, but pyproject matches
+    _run_gate 0.6.4
+    [ "$status" -eq 0 ]
+    _tag_exists 0.6.4
+}
+
+@test "G0 passes when manifest matches --version (normal post-bump path)" {
+    _set_manifest_version 0.6.4
+    _run_gate 0.6.4
+    [ "$status" -eq 0 ]
+    _tag_exists 0.6.4
 }


### PR DESCRIPTION
## What & why

`release-gate.sh` created the release tag from whatever HEAD pointed at, **without checking that the repo manifest version equals `--version`**. An unbumped `pyproject.toml`/`VERSION` therefore produced a tag whose build failed the CI version-assert **after** the tag had already fired — observed live on the first autonomous `coworker-cli` publish (tag `0.7.0` vs built `0.6.3`), forcing a re-tag.

## Fix (fail-fast, not gate-does-bump)

New **G0** gate, fail-closed, runs before any tag side-effect:
- `resolve_manifest_version()` reads `pyproject.toml` first, then `VERSION` (same order as `release-classify.sh`).
- If it ≠ `--version` → exit 1, **no tag**, message: `G0 manifest version 'X' != --version 'Y' — bump pyproject.toml / VERSION (and CHANGELOG) to Y before tagging`.

Chose **fail-fast** over having the gate perform the bump + open a PR: keeps the script's least-privilege contract (its only side-effect stays the tag — no manifest mutation or PR orchestration inside the gate). The bump-via-PR-then-tag flow on a protected `main` is unchanged; G0 just makes a skipped bump fail locally instead of in CI.

## Tests

- +4 bats: manifest mismatch → exit 1 no tag; G0 fires before the tag side-effect (no audit record either); `pyproject.toml` precedence over `VERSION`; matching-manifest happy path.
- Existing 12 gate tests updated to the realistic post-bump manifest state (setup writes the manifest at the release version).
- Full rails suite **32/32 green** (release-classify 16 + release-gate 16). shellcheck clean (the one SC2012 info-note is pre-existing on `probe_qa_verdict`).
- Integration smoke: the exact dogfood scenario (request 0.7.0, manifest 0.6.3) now blocks at G0 with no tag.

Docs: `docs/release-process.md` autonomous-flow callout notes the bump-before-tag requirement + gate enforcement.

Closes the rails defect surfaced by the TUNE-0351 live dogfood.
