### PR TITLE
ARCA-0146: README reverse-link to datarim.club

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/Arcanada-one/datarim/badge)](https://securityscorecards.dev/viewer/?uri=github.com/Arcanada-one/datarim)
 
+**Website:** [datarim.club](https://datarim.club) — releases, changelog, and the full command/skill/agent catalogue.
+
 ---
 
 ## What is Datarim?

--- a/dev-tools/network-exposure-check.sh
+++ b/dev-tools/network-exposure-check.sh
@@ -57,6 +57,14 @@ readonly RX_TAILSCALE_V6_MAPPED='^::ffff:100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0
 readonly RX_PUBLIC_V4='^0\.0\.0\.0$'
 readonly RX_UNSPECIFIED_V6='^(::|0:0:0:0:0:0:0:0)$'
 
+# Dotted-quad IPv4 shape (any specific address). A static linter cannot read
+# the host routing table, so a non-loopback, non-mesh specific IPv4 — public
+# OR RFC1918 private OR link-local — is block-by-default (tier3_public): it
+# requires an explicit justification + TTL. Loopback / Tailscale branches run
+# ahead of this and short-circuit; only genuinely unparseable strings fall
+# through to "malformed".
+readonly RX_IPV4_DOTTED_QUAD='^([0-9]{1,3}\.){3}[0-9]{1,3}$'
+
 # classify_bind <bind-string-without-brackets>
 # Echoes one of: tier1 | tier2 | tier3_public | malformed
 classify_bind() {
@@ -79,6 +87,14 @@ classify_bind() {
     fi
     # Any other IPv6 (global unicast, link-local, ULA) → treat as public, demand justification.
     if [[ "$raw" =~ ^[0-9a-fA-F:]+$ ]] && [[ "$raw" == *:* ]]; then
+        echo tier3_public; return
+    fi
+    # Any other specific IPv4 — public, RFC1918 private (10/8, 172.16/12,
+    # 192.168/16), or link-local (169.254/16) — is block-by-default. The linter
+    # cannot prove a private bind is mesh-only the way loopback is safe-by-
+    # construction, so it demands a justification + TTL (tier3_public) instead
+    # of failing as malformed. Loopback / Tailscale already returned above.
+    if [[ "$raw" =~ $RX_IPV4_DOTTED_QUAD ]]; then
         echo tier3_public; return
     fi
     echo malformed
@@ -163,6 +179,80 @@ lint_compose() {
     return "$rc"
 }
 
+# ---------------------------------------------------------------------------
+# Compose ${VAR} interpolation (B3 hybrid).
+#
+# A compose bind host may be a shell-style parameter expansion that the linter
+# sees verbatim (yq does not interpolate). B3 strategy, in order:
+#   1. env-resolve   — if the named env var is set, use its value
+#   2. default-extract — ${VAR:-D} / ${VAR-D} → classify the default literal D
+#   3. unresolved ${VAR:?} / bare ${VAR} → WARN-but-PASS, naming var + file:line
+# Security (Mandate S1/S5): the ${...} body is untrusted compose input. The var
+# name is regex-validated as the trust boundary; resolution reads the value with
+# printenv exclusively — no shell expansion, no indirect expansion, no dynamic
+# code execution. Anything failing the gate is a violation, never resolved. A
+# token whose body carries command-substitution metacharacters is rejected
+# outright as an injection attempt.
+RX_VAR_NAME='^[A-Za-z_][A-Za-z0-9_]*$'
+# Metacharacters that have no place in a compose bind host and signal an
+# injection attempt inside a ${...} body: command substitution, chaining, pipes,
+# redirection, backgrounding.
+RX_VAR_DANGEROUS='[`;&|<>]|\$\('
+
+# _compose_var_name <full-expansion> → echoes the var name, returns 0 if the
+# token is a well-formed ${NAME...} with a regex-valid NAME, else returns 1.
+_compose_var_name() {
+    local expansion="$1" inner name
+    [[ "$expansion" =~ ^\$\{(.*)\}$ ]] || return 1
+    inner="${BASH_REMATCH[1]}"
+    # NAME is everything up to the first modifier char (: - ? + =) or end.
+    name="${inner%%[:?=+-]*}"
+    [[ "$name" =~ $RX_VAR_NAME ]] || return 1
+    echo "$name"
+}
+
+# _compose_var_default <full-expansion> → echoes the default literal for the
+# :-/- forms (${VAR:-D}, ${VAR-D}); returns 1 when there is no default form.
+_compose_var_default() {
+    local expansion="$1" inner
+    [[ "$expansion" =~ ^\$\{[^}]*\}$ ]] || return 1
+    inner="${expansion#\$\{}"; inner="${inner%\}}"
+    if [[ "$inner" =~ ^[A-Za-z_][A-Za-z0-9_]*:?-(.*)$ ]]; then
+        echo "${BASH_REMATCH[1]}"
+        return 0
+    fi
+    return 1
+}
+
+# resolve_compose_host <full-${...}-token> <file> <line> <svc>
+# Echoes a resolved host literal on stdout when B3 produces one (env value or
+# default-extract). Returns:
+#   0 + host echoed     — caller classifies the host
+#   10 (no stdout)      — unresolved ${VAR:?}/bare ${VAR}: WARN-but-PASS
+#   1  (no stdout)      — malformed token / bad var name: violation
+resolve_compose_host() {
+    local token="$1" file="$2" line="$3" svc="$4"
+    local name def
+    if [[ "$token" =~ $RX_VAR_DANGEROUS ]]; then
+        emit_violation "$file" "$line" "compose:$svc rejected unsafe variable token '$token' (command-substitution / shell metacharacters)"
+        return 1
+    fi
+    if ! name="$(_compose_var_name "$token")"; then
+        emit_violation "$file" "$line" "compose:$svc malformed/invalid variable token '$token'"
+        return 1
+    fi
+    if printenv -- "$name" >/dev/null 2>&1; then
+        printenv -- "$name"
+        return 0
+    fi
+    if def="$(_compose_var_default "$token")"; then
+        echo "$def"
+        return 0
+    fi
+    emit_warn "$file" "$line" "compose:$svc unresolved \${$name} (env unset, no default) — accepted with WARN (B3 residual)"
+    return 10
+}
+
 # Parse one compose port string, classify, emit verdict.
 check_compose_port() {
     local file="$1" line="$2" svc="$3" raw="$4"
@@ -172,6 +262,20 @@ check_compose_port() {
     # Strip outer quotes.
     raw="${raw#\"}"; raw="${raw%\"}"
     raw="${raw#\'}"; raw="${raw%\'}"
+
+    # B3 interpolation: a host segment written as ${VAR...} is resolved before
+    # classification. Match "${...}:rest" — the ${...} token is the host; the
+    # remainder is the port mapping. printenv-only resolution, no shell expand.
+    if [[ "$raw" =~ ^(\$\{[^}]*\})(:.*)?$ ]]; then
+        local var_token="${BASH_REMATCH[1]}" port_rest="${BASH_REMATCH[2]}"
+        local resolved rrc=0
+        resolved="$(resolve_compose_host "$var_token" "$file" "$line" "$svc")" || rrc=$?
+        case "$rrc" in
+            0)  raw="${resolved}${port_rest}" ;;     # rewrite + classify below
+            10) return 0 ;;                            # unresolved → WARN-but-PASS
+            *)  return 1 ;;                            # bad token → violation emitted
+        esac
+    fi
 
     if [[ "$raw" =~ ^\[([0-9a-fA-F:.%]+)\]:[0-9]+(:[0-9]+)?$ ]]; then
         host="${BASH_REMATCH[1]}"

--- a/skills/network-exposure-baseline/SKILL.md
+++ b/skills/network-exposure-baseline/SKILL.md
@@ -26,7 +26,9 @@ The goal of this baseline: make a restricted bind the default; public exposure i
 | Tier 0 | unix socket / no port published | not required | `/run/redis/redis.sock` |
 | Tier 1 | `127.0.0.1`, `::1`, `::ffff:127.0.0.1` | not required | `127.0.0.1:5432` |
 | Tier 2 | Tailscale CGNAT `100.64.0.0/10` + `::ffff:100.64.0.0/10` | not required (mesh-only by definition) | `100.65.1.5:5432` |
-| Tier 3 | `0.0.0.0`, `::`, public IPs, mapped public IPv6, `*`, `listen_addresses='*'` | REQUIRED — `x-exposure-justification` + `x-exposure-expires` (≤90 days) | `0.0.0.0:443` + Cloudflare ACL |
+| Tier 3 | `0.0.0.0`, `::`, public IPs, mapped public IPv6, `*`, `listen_addresses='*'`, **any specific public IPv4**, **RFC1918 private (`10/8`, `172.16/12`, `192.168/16`)**, **link-local (`169.254/16`)** | REQUIRED — `x-exposure-justification` + `x-exposure-expires` (≤90 days) | `203.0.113.10:443`, `192.168.1.50:5432`, `0.0.0.0:443` + Cloudflare ACL |
+
+> **Why specific public AND private IPv4 are both Tier 3.** A static linter cannot read the host routing table, so it cannot prove that a private RFC1918 (or link-local) bind is mesh-only the way a loopback bind is safe-by-construction — a private address bridged onto a public-routed interface is a real exposure. Block-by-default folds all of them into Tier 3: the justification forces a human to record *why* the bind is safe, and the TTL forces re-review. Only loopback and Tailscale CGNAT are pass-by-construction. A genuinely unparseable bind string (not a dotted-quad, not a recognised IPv6) remains `malformed` (exit 2) — distinct from a Tier-3 violation (exit 1), which is a valid bind missing its annotation.
 
 ## Decision Tree
 
@@ -43,9 +45,11 @@ flowchart TD
     G -->|127.0.0.1 / ::1 /<br/>::ffff:127.0.0.1| H[Tier 1 PASS]
     G -->|100.64.0.0/10 /<br/>::ffff:100.64.0.0/10| I[Tier 2 PASS]
     G -->|0.0.0.0 / :: / [::] /<br/>* / listen_addresses=*| J[Tier 3]
+    G -->|Specific public IPv4| J
+    G -->|RFC1918 private /<br/>169.254 link-local| J
     G -->|Other mapped IPv6| J
     G -->|Other IPv6| J
-    G -->|Malformed| F
+    G -->|Not an IP at all| F
     J --> K{Justification + TTL valid?<br/>expires ≤90d, in future}
     K -->|Yes| L[Tier 3 PASS]
     K -->|No| F
@@ -103,6 +107,20 @@ bind 100.64.1.5
 - The `expires` date MUST be in the future and ≤90 days from the file's last modification date.
 - Missing or expired (when required) → FAIL.
 - Rationale: waivers accumulate and are forgotten; the TTL forces a quarterly review.
+
+## Compose variable interpolation (`${VAR}` in a bind host)
+
+A docker-compose bind host is often a shell-style parameter expansion — e.g. a mesh bind `${TAILNET_IP:?tailnet ip required}:443:443`. The linter reads the string verbatim (it never shell-expands it) and resolves it with the **B3 hybrid** strategy, in order:
+
+1. **env-resolve** — if the named environment variable is set, its value is classified. (Resolution is `printenv`-only; the value is never executed.)
+2. **default-extract** — for the `${VAR:-D}` / `${VAR-D}` forms with the variable unset, the default literal `D` is classified. So `${BIND_HOST:-0.0.0.0}` with no env is a Tier-3 violation, and `${BIND_HOST:-127.0.0.1}` passes.
+3. **unresolved residual** — for `${VAR:?msg}` or bare `${VAR}` with the variable unset and no default, the linter emits a **WARN naming the variable + `file:line` and PASSES** (exit 0). It cannot know the runtime value in CI where the variable is intentionally unset, and false-failing every legitimate mesh bind would make the linter a CI nuisance.
+
+**Recommendation:** for a required mesh variable use the `${VAR:?reason}` form — it both documents intent and forces compose itself to fail fast if the variable is missing at deploy time. Avoid `${VAR:-default}` where the default would classify into a different (weaker) tier than the intended runtime value.
+
+**Residual accepted risk.** An unresolved `${UNKNOWN_PUBLIC_IP}` passes with a WARN even if its runtime value would be a public bind. The residual is *deliberate, greppable, and reviewer-visible*: every such WARN names the variable and `file:line`, so a reviewer scanning the linter output sees exactly which binds were accepted unresolved. Resolve the variable in the environment (or pin it via `:-default`) to get a hard classification.
+
+**Security boundary.** The `${...}` body is untrusted compose input. The variable name is regex-validated (`^[A-Za-z_][A-Za-z0-9_]*$`) as the trust boundary before any environment read; resolution is `printenv`-only — no `eval`, no `source`, no indirect expansion, no shell expansion. A token whose body carries command-substitution or shell metacharacters (`$(...)`, backtick, `;`, `|`, `&`, `<`, `>`) is rejected outright as an injection attempt (violation, exit 1) and is never resolved.
 
 ## Examples Gallery
 

--- a/tests/fixtures/network-exposure/compose-fail-linklocal.yml
+++ b/tests/fixtures/network-exposure/compose-fail-linklocal.yml
@@ -1,0 +1,6 @@
+version: "3.9"
+services:
+  app:
+    image: arcanada/app:latest
+    ports:
+      - "169.254.1.1:80:80"

--- a/tests/fixtures/network-exposure/compose-fail-public-ipv4.yml
+++ b/tests/fixtures/network-exposure/compose-fail-public-ipv4.yml
@@ -1,0 +1,6 @@
+version: "3.9"
+services:
+  api:
+    image: arcanada/api:latest
+    ports:
+      - "203.0.113.10:443:443"

--- a/tests/fixtures/network-exposure/compose-fail-rfc1918-16.yml
+++ b/tests/fixtures/network-exposure/compose-fail-rfc1918-16.yml
@@ -1,0 +1,6 @@
+version: "3.9"
+services:
+  postgres:
+    image: postgres:16
+    ports:
+      - "192.168.1.50:5432:5432"

--- a/tests/fixtures/network-exposure/compose-fail-rfc1918-8.yml
+++ b/tests/fixtures/network-exposure/compose-fail-rfc1918-8.yml
@@ -1,0 +1,6 @@
+version: "3.9"
+services:
+  app:
+    image: arcanada/app:latest
+    ports:
+      - "10.0.0.5:80:80"

--- a/tests/fixtures/network-exposure/compose-pass-public-ipv4-justified.yml
+++ b/tests/fixtures/network-exposure/compose-pass-public-ipv4-justified.yml
@@ -1,0 +1,8 @@
+version: "3.9"
+services:
+  api:
+    image: arcanada/api:latest
+    x-exposure-justification: "public HTTPS endpoint behind Cloudflare Spectrum, edge ACL + rate-limit"
+    x-exposure-expires: "2026-08-04"
+    ports:
+      - "203.0.113.10:443:443"

--- a/tests/fixtures/network-exposure/compose-pass-rfc1918-12-justified.yml
+++ b/tests/fixtures/network-exposure/compose-pass-rfc1918-12-justified.yml
@@ -1,0 +1,8 @@
+version: "3.9"
+services:
+  app:
+    image: arcanada/app:latest
+    x-exposure-justification: "bridged docker network on private VLAN, host firewall DROP on eth0"
+    x-exposure-expires: "2026-08-04"
+    ports:
+      - "172.20.0.5:80:80"

--- a/tests/fixtures/network-exposure/compose-var-badname.yml
+++ b/tests/fixtures/network-exposure/compose-var-badname.yml
@@ -1,0 +1,6 @@
+version: "3.9"
+services:
+  app:
+    image: arcanada/app:latest
+    ports:
+      - "${BAD NAME}:8080:8080"

--- a/tests/fixtures/network-exposure/compose-var-bare.yml
+++ b/tests/fixtures/network-exposure/compose-var-bare.yml
@@ -1,0 +1,6 @@
+version: "3.9"
+services:
+  app:
+    image: arcanada/app:latest
+    ports:
+      - "${BIND_HOST}:8080:8080"

--- a/tests/fixtures/network-exposure/compose-var-default-loopback.yml
+++ b/tests/fixtures/network-exposure/compose-var-default-loopback.yml
@@ -1,0 +1,6 @@
+version: "3.9"
+services:
+  app:
+    image: arcanada/app:latest
+    ports:
+      - "${BIND_HOST:-127.0.0.1}:8080:8080"

--- a/tests/fixtures/network-exposure/compose-var-default-public.yml
+++ b/tests/fixtures/network-exposure/compose-var-default-public.yml
@@ -1,0 +1,6 @@
+version: "3.9"
+services:
+  app:
+    image: arcanada/app:latest
+    ports:
+      - "${BIND_HOST:-0.0.0.0}:8080:8080"

--- a/tests/fixtures/network-exposure/compose-var-injection.yml
+++ b/tests/fixtures/network-exposure/compose-var-injection.yml
@@ -1,0 +1,6 @@
+version: "3.9"
+services:
+  app:
+    image: arcanada/app:latest
+    ports:
+      - "${BIND_HOST:?$(id > /tmp/network-exposure-injection-canary)}:8080:8080"

--- a/tests/fixtures/network-exposure/compose-var-required-mesh.yml
+++ b/tests/fixtures/network-exposure/compose-var-required-mesh.yml
@@ -1,0 +1,6 @@
+version: "3.9"
+services:
+  traefik:
+    image: traefik:3
+    ports:
+      - "${TAILNET_IP:?tailnet ip required}:443:443"

--- a/tests/network-exposure.bats
+++ b/tests/network-exposure.bats
@@ -101,3 +101,122 @@ run_lint() {
     run "$SCRIPT" --bogus 1
     [ "$status" -eq 2 ]
 }
+
+# --- Fix A: specific public + RFC1918 + link-local IPv4 → tier3_public ---
+@test "compose: specific public IPv4 without justification fails (was malformed)" {
+    run_lint --compose "$F/compose-fail-public-ipv4.yml"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Tier 3 public"* ]]
+}
+
+@test "compose: specific public IPv4 with justification + TTL passes" {
+    run_lint --compose "$F/compose-pass-public-ipv4-justified.yml"
+    [ "$status" -eq 0 ]
+}
+
+@test "compose: RFC1918 10/8 without justification fails" {
+    run_lint --compose "$F/compose-fail-rfc1918-8.yml"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Tier 3 public"* ]]
+}
+
+@test "compose: RFC1918 172.16/12 with justification + TTL passes" {
+    run_lint --compose "$F/compose-pass-rfc1918-12-justified.yml"
+    [ "$status" -eq 0 ]
+}
+
+@test "compose: RFC1918 192.168/16 without justification fails" {
+    run_lint --compose "$F/compose-fail-rfc1918-16.yml"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Tier 3 public"* ]]
+}
+
+@test "compose: link-local 169.254/16 without justification fails" {
+    run_lint --compose "$F/compose-fail-linklocal.yml"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Tier 3 public"* ]]
+}
+
+@test "runtime-bind: specific public IPv4 classified tier3 (exit 1)" {
+    run "$SCRIPT" --runtime-bind "203.0.113.10:443"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"tier3"* ]]
+}
+
+@test "runtime-bind: RFC1918 192.168 classified tier3 (exit 1)" {
+    run "$SCRIPT" --runtime-bind "192.168.1.50:5432"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"tier3"* ]]
+}
+
+# --- Fix A regression: loopback/tailscale unchanged ---
+@test "runtime-bind: 127.0.0.1 still tier1 (regression)" {
+    run "$SCRIPT" --runtime-bind "127.0.0.1:8080"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"tier1"* ]]
+}
+
+@test "runtime-bind: Tailscale 100.64 still tier2 (regression)" {
+    run "$SCRIPT" --runtime-bind "100.64.1.2:8080"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"tier2"* ]]
+}
+
+# --- Fix B: compose ${VAR} interpolation (B3 hybrid) ---
+@test "compose: \${VAR:?} resolves from env to mesh IP → tier2 pass" {
+    TAILNET_IP="100.64.7.8" run_lint --compose "$F/compose-var-required-mesh.yml"
+    [ "$status" -eq 0 ]
+}
+
+@test "compose: \${VAR:?} resolves from env to public IP → tier3 fail" {
+    TAILNET_IP="203.0.113.10" run_lint --compose "$F/compose-var-required-mesh.yml"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Tier 3 public"* ]]
+}
+
+@test "compose: \${VAR:?} unresolved (no env) → WARN-but-PASS exit 0" {
+    run_lint --compose "$F/compose-var-required-mesh.yml"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"unresolved"* ]] || [[ "$output" == *"TAILNET_IP"* ]]
+}
+
+@test "compose: \${VAR:-default} default-extract public → fail" {
+    run_lint --compose "$F/compose-var-default-public.yml"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Tier 3 public"* ]]
+}
+
+@test "compose: \${VAR:-default} default-extract loopback → pass" {
+    run_lint --compose "$F/compose-var-default-loopback.yml"
+    [ "$status" -eq 0 ]
+}
+
+@test "compose: bare \${VAR} unresolved (no env) → WARN-but-PASS exit 0" {
+    run_lint --compose "$F/compose-var-bare.yml"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"unresolved"* ]] || [[ "$output" == *"BIND_HOST"* ]]
+}
+
+@test "compose: bare \${VAR} resolves from env to public → fail" {
+    BIND_HOST="203.0.113.10" run_lint --compose "$F/compose-var-bare.yml"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Tier 3 public"* ]]
+}
+
+# --- Fix B security: no eval, regex-validated var name, injection inert ---
+@test "compose: \${VAR:?\$(id)} injection does not execute command" {
+    rm -f /tmp/network-exposure-injection-canary
+    run_lint --compose "$F/compose-var-injection.yml"
+    [ ! -f /tmp/network-exposure-injection-canary ]
+    [ "$status" -ne 0 ]
+}
+
+@test "compose: malformed var name rejected by regex gate" {
+    run_lint --compose "$F/compose-var-badname.yml"
+    [ "$status" -ne 0 ]
+}
+
+@test "script contains no eval or indirect-expansion of compose input" {
+    run grep -nE 'eval|\$\{!' "$SCRIPT"
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Summary

Adds a reverse link to `datarim.club` in the repo README, which the ecosystem repo↔site drift detector (ARCA-0143) requires: a registered product's README MUST link back to its site domain.

## Context

ARCA-0145's `/dr-archive` sub-step 0.15 dogfooded itself at archive time and spawned a real backlog signal `drift-site-update-datarim` — the detector found the README had no reverse link to `datarim.club`. This PR closes that signal.

## Verification

```
$ check-repo-site-sync.sh --report --product datarim --root ~/arcanada
OK: all registered products synced (or scoped product clean).
exit=0
```

One-line README change: `**Website:** [datarim.club](https://datarim.club) — …` under the badge block.