### PR TITLE
fix(network-exposure): add infra token to hard_block set alongside infrastructure

### DIFF
--- a/dev-tools/network-exposure-gate.sh
+++ b/dev-tools/network-exposure-gate.sh
@@ -32,6 +32,7 @@ SCRIPT_NAME="network-exposure-gate.sh"
 SEC_INFRA_TYPES=(
     security-incident
     infrastructure
+    infra
     framework-hardening
     security-baseline
     auth-mandate

--- a/skills/network-exposure-baseline/SKILL.md
+++ b/skills/network-exposure-baseline/SKILL.md
@@ -184,7 +184,7 @@ Pipeline commands read the task-description frontmatter and pick one of three de
 | Priority | Type                                                                                    | Network surface touched? | Decision        |
 |----------|-----------------------------------------------------------------------------------------|--------------------------|-----------------|
 | `P0`     | (any)                                                                                   | (any)                    | `hard_block`    |
-| `P1`     | `security-incident` / `infrastructure` / `framework-hardening` / `security-baseline` / `auth-mandate` | (any)         | `hard_block`    |
+| `P1`     | `security-incident` / `infrastructure` / `infra` / `framework-hardening` / `security-baseline` / `auth-mandate` | (any)         | `hard_block`    |
 | `P1`     | others                                                                                  | (any)                    | `advisory_warn` |
 | `P2`/`P3`| (any)                                                                                   | yes                      | `advisory_warn` |
 | `P2`/`P3`| (any)                                                                                   | no                       | `skip`          |

--- a/tests/fixtures/network-exposure-gate/p1-infra.md
+++ b/tests/fixtures/network-exposure-gate/p1-infra.md
@@ -1,0 +1,10 @@
+---
+id: SAMPLE-0014
+title: 'P1 infra'
+status: in_progress
+priority: P1
+type: infra
+project: SampleProject
+---
+
+P1 + infra: hard_block.

--- a/tests/network-exposure-gate.bats
+++ b/tests/network-exposure-gate.bats
@@ -35,6 +35,12 @@ setup() {
     [ "$output" = "hard_block" ]
 }
 
+@test "gate: P1 + infra -> hard_block" {
+    run "$SCRIPT" --task-description "$F/p1-infra.md" --quiet
+    [ "$status" -eq 0 ]
+    [ "$output" = "hard_block" ]
+}
+
 @test "gate: P1 + framework-hardening -> hard_block" {
     run "$SCRIPT" --task-description "$F/p1-framework-hardening.md" --quiet
     [ "$status" -eq 0 ]


### PR DESCRIPTION
## Summary

Fixes a fail-open in the tiered network-exposure gate. A `P1` task with
`type: infra` and a real Tier-3 networking surface was downgrading to
`advisory_warn` instead of `hard_block`, because the gate's `SEC_INFRA_TYPES`
set listed only the long form `infrastructure`. `infra` is the
ecosystem-dominant short form (5.7× more frequent as a `type:` value across
task-descriptions).

## Changes

- Add `infra` to `SEC_INFRA_TYPES` in `dev-tools/network-exposure-gate.sh`.
- Sync the SKILL decision-table P1 sec/infra row (`skills/network-exposure-baseline/SKILL.md`) — contract surface, kept in lock-step with the script.
- Add fixture `tests/fixtures/network-exposure-gate/p1-infra.md` + bats case asserting both `infra` and `infrastructure` resolve to `hard_block` (regression guard).

## Verification

- Full gate bats suite: 20/20 green (RED→GREEN confirmed: P1+infra was `advisory_warn`, now `hard_block`).
- `shellcheck -S warning` clean.
- Fix is fail-safe-toward-blocking — can only widen what the gate blocks, never narrow it.
- Type-token audit recorded in the task description: only `infra` is a real gap; `framework` and `ops` deliberately left out with reasons.
