### PR TITLE
fix(network-exposure): protocol suffix + long-form port objects

### DIFF
--- a/dev-tools/network-exposure-check.sh
+++ b/dev-tools/network-exposure-check.sh
@@ -167,8 +167,30 @@ lint_compose() {
         local ports_count
         ports_count="$(yq -r ".services.\"$svc\".ports // [] | length" "$file" 2>/dev/null)"
         while (( idx < ports_count )); do
-            local raw line
-            raw="$(yq -r ".services.\"$svc\".ports[$idx]" "$file" 2>/dev/null)"
+            local raw line ptype
+            # docker-compose `config` expands ports into long-form mapping
+            # objects ({mode, host_ip, target, published, protocol}); yq dumps
+            # them as multi-line YAML, which check_compose_port cannot parse.
+            # Detect the mapping (yq prints "!!map") and reconstruct the
+            # canonical host:port:port[/proto] string before classification.
+            ptype="$(yq -r ".services.\"$svc\".ports[$idx] | type" "$file" 2>/dev/null)"
+            if [[ "$ptype" == "!!map" || "$ptype" == "map" ]]; then
+                local host_ip published target proto
+                host_ip="$(yq -r ".services.\"$svc\".ports[$idx].host_ip // \"\"" "$file" 2>/dev/null)"
+                published="$(yq -r ".services.\"$svc\".ports[$idx].published // \"\"" "$file" 2>/dev/null)"
+                target="$(yq -r ".services.\"$svc\".ports[$idx].target // \"\"" "$file" 2>/dev/null)"
+                proto="$(yq -r ".services.\"$svc\".ports[$idx].protocol // \"\"" "$file" 2>/dev/null)"
+                [[ "$host_ip" == "null" ]] && host_ip=""
+                [[ "$proto" == "null" || "$proto" == "tcp" ]] && proto=""
+                if [[ -n "$host_ip" ]]; then
+                    raw="${host_ip}:${published}:${target}"
+                else
+                    raw="${published}:${target}"
+                fi
+                [[ -n "$proto" ]] && raw="${raw}/${proto}"
+            else
+                raw="$(yq -r ".services.\"$svc\".ports[$idx]" "$file" 2>/dev/null)"
+            fi
             line="$(grep -nF -- "$raw" "$file" | head -1 | cut -d: -f1)"
             line="${line:-0}"
             check_compose_port "$file" "$line" "$svc" "$raw" "$has_justification" "$ttl_ok" "$ttl_reason" || rc=1
@@ -277,11 +299,14 @@ check_compose_port() {
         esac
     fi
 
-    if [[ "$raw" =~ ^\[([0-9a-fA-F:.%]+)\]:[0-9]+(:[0-9]+)?$ ]]; then
+    # Optional /(udp|tcp|sctp) protocol suffix on long-form host:port:port
+    # binds (compose ports may carry a protocol, e.g. "100.64.1.5:53:53/udp");
+    # captured into a trailing group so BASH_REMATCH[1] (host) is unaffected.
+    if [[ "$raw" =~ ^\[([0-9a-fA-F:.%]+)\]:[0-9]+(:[0-9]+)?(/(udp|tcp|sctp))?$ ]]; then
         host="${BASH_REMATCH[1]}"
-    elif [[ "$raw" =~ ^([0-9.]+):[0-9]+:[0-9]+$ ]]; then
+    elif [[ "$raw" =~ ^([0-9.]+):[0-9]+:[0-9]+(/(udp|tcp|sctp))?$ ]]; then
         host="${BASH_REMATCH[1]}"
-    elif [[ "$raw" =~ ^[0-9]+:[0-9]+$ ]] || [[ "$raw" =~ ^[0-9]+$ ]]; then
+    elif [[ "$raw" =~ ^[0-9]+:[0-9]+(/(udp|tcp|sctp))?$ ]] || [[ "$raw" =~ ^[0-9]+(/(udp|tcp|sctp))?$ ]]; then
         host=""  # short-form ⇒ implicit 0.0.0.0
     else
         emit_warn "$file" "$line" "compose:$svc unrecognized port form: '$raw'"

--- a/tests/fixtures/network-exposure/compose-fail-longform-no-hostip.yml
+++ b/tests/fixtures/network-exposure/compose-fail-longform-no-hostip.yml
@@ -1,0 +1,9 @@
+version: "3.9"
+services:
+  redis:
+    image: redis:7-alpine
+    ports:
+      - mode: ingress
+        target: 6379
+        published: "26379"
+        protocol: tcp

--- a/tests/fixtures/network-exposure/compose-pass-coredns-proto.yml
+++ b/tests/fixtures/network-exposure/compose-pass-coredns-proto.yml
@@ -1,0 +1,7 @@
+version: "3.9"
+services:
+  coredns:
+    image: coredns/coredns:1.14.3
+    ports:
+      - "100.106.20.101:53:53/udp"
+      - "100.106.20.101:53:53/tcp"

--- a/tests/fixtures/network-exposure/compose-pass-longform-justified.yml
+++ b/tests/fixtures/network-exposure/compose-pass-longform-justified.yml
@@ -1,0 +1,12 @@
+version: "3.9"
+services:
+  traefik:
+    image: traefik
+    x-exposure-justification: "public HTTPS edge behind Cloudflare WAF + mesh-host pinning"
+    x-exposure-expires: "2026-08-04"
+    ports:
+      - mode: ingress
+        host_ip: "178.105.250.27"
+        target: 80
+        published: "80"
+        protocol: tcp

--- a/tests/fixtures/network-exposure/compose-pass-longform-loopback.yml
+++ b/tests/fixtures/network-exposure/compose-pass-longform-loopback.yml
@@ -1,0 +1,10 @@
+version: "3.9"
+services:
+  traefik:
+    image: traefik
+    ports:
+      - mode: ingress
+        host_ip: "127.0.0.1"
+        target: 8080
+        published: "28080"
+        protocol: tcp

--- a/tests/network-exposure.bats
+++ b/tests/network-exposure.bats
@@ -220,3 +220,25 @@ run_lint() {
     run grep -nE 'eval|\$\{!' "$SCRIPT"
     [ "$status" -ne 0 ]
 }
+
+# --- Fix B: protocol suffix (/udp /tcp /sctp) on long-form host:port:port ---
+@test "compose: Tailscale-IP DNS with /udp /tcp suffix passes tier2" {
+    run_lint --compose "$F/compose-pass-coredns-proto.yml"
+    [ "$status" -eq 0 ]
+}
+
+# --- Fix C: long-form port object (docker compose config shape) ---
+@test "compose: long-form object loopback passes tier1" {
+    run_lint --compose "$F/compose-pass-longform-loopback.yml"
+    [ "$status" -eq 0 ]
+}
+
+@test "compose: long-form object public + justification passes" {
+    run_lint --compose "$F/compose-pass-longform-justified.yml"
+    [ "$status" -eq 0 ]
+}
+
+@test "compose: long-form object without host_ip fails (implicit 0.0.0.0)" {
+    run_lint --compose "$F/compose-fail-longform-no-hostip.yml"
+    [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
Datarim checker parser fixes (SPACE-0012).

**Fix 1** — `check_compose_port` accepts optional `/(udp|tcp|sctp)` suffix on long-form host:port:port binds (a Tailscale-IP DNS bind like `100.x:53:53/udp` was false-WARNed as unrecognized).

**Fix 2** — `lint_compose` detects long-form port mapping objects (the shape `docker compose config` emits) and reconstructs the canonical `host_ip:published:target[/proto]` string before classification — so a merged compose render lints correctly.

+4 bats tests, +4 fixtures. shellcheck + semgrep clean. 40/40 suite, 0 regressions across 4 network-exposure bats files.