### PR TITLE
ci(security-audit): provision Rust toolchain for rust_cargo on self-hosted runner

### DIFF
--- a/.github/workflows/reusable-security-audit.yml
+++ b/.github/workflows/reusable-security-audit.yml
@@ -79,6 +79,15 @@ jobs:
             echo "accepted-risk.yml not present at $ACCEPTED_RISK_PATH — skipping schema validation"
           fi
 
+      # Self-hosted runners do not ship a Rust toolchain the way GitHub-hosted
+      # images did, so the rust_cargo branch below would fail with
+      # "cargo: command not found" (exit 127). Provision the toolchain in-workflow
+      # for the rust_cargo profile only — other profiles rely on node/pnpm/python,
+      # which are present on the runner.
+      - name: Setup Rust toolchain (rust_cargo profile only)
+        if: inputs.stack == 'rust_cargo'
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+
       - name: Run stack-specific audit
         env:
           STACK: ${{ inputs.stack }}


### PR DESCRIPTION
## Problem

After the runner migration (`ubuntu-latest` → org self-hosted), the `security-audit` reusable workflow fails for every Rust ecosystem repo with `cargo: command not found` (exit 127). GitHub-hosted images shipped a Rust toolchain; self-hosted runners (arcana-prod) do not.

The `rust_cargo` branch calls `cargo install --locked cargo-audit cargo-deny` directly with no toolchain provisioning. Confirmed live: `arcana-agent-system` main red, run with `STACK: rust_cargo` → `line 12: cargo: command not found`.

Runner toolchain inventory (arcana-prod): node/pnpm/corepack/python3/pip/shellcheck present; **cargo absent**. So only the `rust_cargo` profile is affected; typescript_pnpm / python / framework rely on tools already present.

## Fix

Add a conditional step `Setup Rust toolchain (rust_cargo profile only)` gated on `inputs.stack == 'rust_cargo'`, using `dtolnay/rust-toolchain@stable` (SHA-pinned, consistent with this file's action-pinning convention). +9 lines, no other profile touched.

## Validation

- `actionlint` exit 0
- `python yaml.safe_load` OK
- `tests/security-policy.bats` 15/15 green
- diff: +9 lines only

## Post-merge verification (required before closing the tracking task)

Dispatch `tests/security-policy/rust_cargo.yml` on the self-hosted runner (or re-run `arcana-agent-system` ci) and confirm `cargo audit`/`cargo deny` execute, no exit 127.