### PR TITLE
TUNE-0372: exempt architecture creative-docs from coworker delegation gate

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Shell scripts and data files shipped to consumers must use LF line endings.
+# On Windows (Git Bash / MSYS2) a CRLF shebang breaks the interpreter line and
+# CRLF in `case` glob operands breaks pattern matching in coworker-hook-guard.sh.
+*.sh text eol=lf
+*.bats text eol=lf
+*.patterns text eol=lf

--- a/dev-tools/coworker-delegation-exempt.patterns
+++ b/dev-tools/coworker-delegation-exempt.patterns
@@ -1,0 +1,26 @@
+# coworker-delegation exempt patterns
+#
+# A creative-*.md whose BASENAME matches ANY glob below is written DIRECTLY by
+# the agent (NOT delegated to `coworker write`), per the global delegation rule
+# "Do NOT delegate -> Architectural decisions and trade-offs"
+# (~/.claude/CLAUDE.md § Coworker Delegation).
+#
+# These docs are judgment-heavy (threat models, ADRs, design contracts) where a
+# cheap external LLM both fails to save tokens and tends to fabricate. The hook
+# (coworker-hook-guard.sh) reads this file at Write time and silently allows a
+# matching creative-doc instead of denying it.
+#
+# Format: one shell glob per line, matched case-insensitively against the
+# lowercased basename. Lines starting with '#' and blank lines are ignored.
+# Patterns are used ONLY as `case` glob operands -- never eval'd or sourced.
+#
+# Per-project: append your own patterns here, or point the hook at a different
+# file via the COWORKER_GUARD_EXEMPT_FILE env var. Missing file = no exemptions
+# (every creative-doc stays gated -- the prior behaviour).
+#
+# Default architecture-document globs:
+creative-*architecture*.md
+creative-*algorithm*.md
+creative-*-design*.md
+creative-*threat-model*.md
+creative-*-adr*.md

--- a/dev-tools/coworker-hook-guard.sh
+++ b/dev-tools/coworker-hook-guard.sh
@@ -26,6 +26,7 @@
 #     install.sh fanout_runtime.
 #
 # Backwards-compat: KIMI_GUARD_* env vars still honoured as fallback.
+# shellcheck shell=bash
 set -euo pipefail
 
 # --- KB pre-overwrite backup side-effect -------------------------------------
@@ -126,6 +127,48 @@ emit_session_message() {
 # Protected: wiki/*, Social Media/*, prd-*.md, plan-*.md, creative-*.md,
 # *-task-description.md. Exempt by omission: archive-*.md, reflection-*.md
 # (operator decision 2026-05-24 — see CLAUDE.md § Exempt).
+# Resolve the exempt-patterns allowlist path. Default: sibling of this script's
+# real path (works under symlink/copy/project-install — _GUARD_SRC is already
+# readlink-resolved above). Per-project override via COWORKER_GUARD_EXEMPT_FILE.
+exempt_file_path() {
+  if [ -n "${COWORKER_GUARD_EXEMPT_FILE:-}" ]; then
+    printf '%s' "$COWORKER_GUARD_EXEMPT_FILE"
+  else
+    printf '%s' "$(dirname "$_GUARD_SRC")/coworker-delegation-exempt.patterns"
+  fi
+}
+
+# Returns 0 if <basename> matches an exempt glob in the allowlist (the doc is an
+# architectural decision the global rule says to write directly, NOT delegate).
+# Returns 1 otherwise — including when the allowlist is absent/unreadable
+# (fail-soft toward the gate: no file ⇒ no exemptions ⇒ prior deny behaviour).
+#
+# S1: pattern lines are used ONLY as `case` glob operands. Never eval'd, never
+# sourced, never command-substituted. Matching is case-insensitive via tr
+# (portable to macOS bash 3.2 — no `shopt nocasematch`, no `${var,,}`).
+is_delegation_exempt() {
+  local base="$1" ef lc_base lc_pat line
+  ef=$(exempt_file_path)
+  [ -f "$ef" ] && [ -r "$ef" ] || return 1
+  lc_base=$(printf '%s' "$base" | tr '[:upper:]' '[:lower:]')
+  while IFS= read -r line || [ -n "$line" ]; do
+    # trim leading/trailing whitespace
+    line="${line#"${line%%[![:space:]]*}"}"
+    line="${line%"${line##*[![:space:]]}"}"
+    case "$line" in ''|'#'*) continue ;; esac
+    lc_pat=$(printf '%s' "$line" | tr '[:upper:]' '[:lower:]')
+    # SC2254 intentionally NOT silenced by quoting: $lc_pat MUST expand as a
+    # glob pattern (e.g. creative-*architecture*.md), not match literally. The
+    # value is an allowlist glob, never user file content, and is used only as a
+    # case operand — never eval'd/sourced (S1). Quoting it would break the gate.
+    # shellcheck disable=SC2254
+    case "$lc_base" in
+      $lc_pat) return 0 ;;
+    esac
+  done < "$ef"
+  return 1
+}
+
 check_write_protected() {
   local f="$1"
   [ -n "$f" ] || return 1
@@ -136,7 +179,12 @@ check_write_protected() {
     */wiki/*|*/Social\ Media/*) return 0 ;;
   esac
   case "$base" in
-    prd-*.md|plan-*.md|creative-*.md|*-task-description.md) return 0 ;;
+    prd-*.md|plan-*.md|*-task-description.md) return 0 ;;
+    creative-*.md)
+      # Architectural creative-docs are exempt from delegation (write directly).
+      is_delegation_exempt "$base" && return 1
+      return 0
+      ;;
   esac
   return 1
 }
@@ -145,7 +193,7 @@ emit_write_deny() {
   local f="$1"
   local base
   base=$(basename "$f")
-  emit_deny "Создаёшь $base — это документационный артефакт. Per CLAUDE.md MANDATORY: первый draft через coworker write --profile datarim --spec \"...\" --context <refs> --target \"$f\", потом surgical edits. Approve только если уже сгенерирован coworker'ом."
+  emit_deny "Создаёшь $base — это документационный артефакт. Per CLAUDE.md MANDATORY: первый draft через coworker write --profile datarim --spec \"...\" --context <refs> --target \"$f\", потом surgical edits. Approve только если уже сгенерирован coworker'ом. Если это АРХИТЕКТУРНОЕ решение (ADR / threat-model / design) — global rule «Do NOT delegate → Architectural decisions» разрешает писать напрямую: добавь glob имени в coworker-delegation-exempt.patterns (рядом с хуком) ИЛИ пиши через Bash heredoc (хук не гейтит Bash). Делегируй coworker'у только настоящие черновики, НЕ имитируй compliance пустышкой."
 }
 
 # Read-branch deny wording, bound to the crossed token threshold. The wording

--- a/tests/test-coworker-hook-guard-write-protected.bats
+++ b/tests/test-coworker-hook-guard-write-protected.bats
@@ -1,0 +1,120 @@
+#!/usr/bin/env bats
+#
+# Write-protected delegation gate + architecture-doc exemption.
+#
+# The PreToolUse guard denies the first Write of a documentation artefact
+# (prd-*.md / plan-*.md / creative-*.md / *-task-description.md) to nudge the
+# agent toward `coworker write`. The global delegation policy
+# (~/.claude/CLAUDE.md § Coworker Delegation -> Do NOT delegate) EXEMPTS
+# architectural decisions. The guard reconciles the two: a creative-doc whose
+# basename matches an exempt glob (architecture / algorithm / design /
+# threat-model / adr) is silently allowed (agent writes it directly). The
+# exempt globs live in an external sibling file, fail-soft when absent.
+#
+# Cases mirror the task-description Validation Checklist V-1..V-8.
+
+HOOK="${HOOK:-$HOME/.local/bin/coworker-hook-guard}"
+
+setup() {
+    [ -x "$HOOK" ] || skip "coworker-hook-guard not executable at $HOOK"
+    command -v jq >/dev/null || skip "jq required"
+    TMP_DOC_DIR=$(mktemp -d "${BATS_TMPDIR:-/tmp}/dr-do-wp.XXXXXX")
+}
+
+teardown() {
+    [ -n "${TMP_DOC_DIR:-}" ] && rm -rf "$TMP_DOC_DIR"
+}
+
+# Invoke the hook with a PreToolUse Write payload for file_path $1.
+# Optional $2 overrides COWORKER_GUARD_EXEMPT_FILE (allowlist path).
+run_hook_write() {
+    local fp="$1" exempt="${2:-}"
+    local payload
+    payload=$(jq -nc --arg f "$fp" '{
+        hook_event_name: "PreToolUse",
+        tool_name: "Write",
+        tool_input: { file_path: $f }
+    }')
+    if [ -n "$exempt" ]; then
+        printf '%s' "$payload" | COWORKER_GUARD_EXEMPT_FILE="$exempt" "$HOOK"
+    else
+        printf '%s' "$payload" | "$HOOK"
+    fi
+}
+
+# --- V-2 (AC-2): non-architecture creative-doc still denied ----------------
+@test "V-2 non-architecture creative-doc -> deny (delegation preserved)" {
+    run run_hook_write "$TMP_DOC_DIR/creative-database-schema.md"
+    [ "$status" -eq 0 ]
+    decision=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+# --- V-1 (AC-1): architecture creative-doc -> silent allow ------------------
+@test "V-1 architecture creative-doc -> silent allow (write directly)" {
+    run run_hook_write "$TMP_DOC_DIR/creative-DEV-1462-self-healing-reviewer-architecture.md"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "V-1b algorithm creative-doc -> silent allow" {
+    run run_hook_write "$TMP_DOC_DIR/creative-algorithm-design-uuid48.md"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+@test "V-1c threat-model creative-doc -> silent allow" {
+    run run_hook_write "$TMP_DOC_DIR/creative-auth-threat-model.md"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# --- V-5 (AC-5): case-insensitive match ------------------------------------
+@test "V-5 case-insensitive: Creative-...-Architecture.md -> silent allow" {
+    run run_hook_write "$TMP_DOC_DIR/Creative-API-Architecture-uuid48.md"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}
+
+# --- V-3 (AC-3): fail-soft when allowlist absent ---------------------------
+@test "V-3 allowlist absent -> architecture doc denied (fail-soft to gate)" {
+    run run_hook_write "$TMP_DOC_DIR/creative-DEV-1462-architecture.md" "$TMP_DOC_DIR/does-not-exist.patterns"
+    [ "$status" -eq 0 ]
+    decision=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+# --- V-4 (AC-4): deny reason carries the escape-hatch ----------------------
+@test "V-4 deny reason names the exempt-allowlist escape-hatch" {
+    run run_hook_write "$TMP_DOC_DIR/creative-database-schema.md"
+    [ "$status" -eq 0 ]
+    reason=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+    case "$reason" in
+        *coworker-delegation-exempt.patterns*) : ;;
+        *) printf 'reason missing escape-hatch: %s\n' "$reason" >&2; return 1 ;;
+    esac
+}
+
+# --- No-regression: other protected artefacts still denied -----------------
+@test "no-regression: prd-*.md still denied" {
+    run run_hook_write "$TMP_DOC_DIR/prd-FOO-0001.md"
+    [ "$status" -eq 0 ]
+    decision=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+@test "no-regression: *-task-description.md still denied" {
+    run run_hook_write "$TMP_DOC_DIR/FOO-0001-task-description.md"
+    [ "$status" -eq 0 ]
+    decision=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+}
+
+# --- Custom per-project allowlist via env override -------------------------
+@test "AC-3 custom allowlist file via COWORKER_GUARD_EXEMPT_FILE" {
+    custom="$TMP_DOC_DIR/custom.patterns"
+    printf '%s\n' '# custom' 'creative-*-myteam-spec.md' > "$custom"
+    run run_hook_write "$TMP_DOC_DIR/creative-billing-myteam-spec.md" "$custom"
+    [ "$status" -eq 0 ]
+    [ -z "$output" ]
+}


### PR DESCRIPTION
## Problem
`coworker-hook-guard` denied ALL `creative-*.md` under coworker delegation, contradicting the global "Do NOT delegate -> Architectural decisions" rule. Agents hit the desync and faked compliance (throwaway coworker skeleton -> overwrite).

## Fix
- `is_delegation_exempt` consults an external allowlist `dev-tools/coworker-delegation-exempt.patterns` (per-project tunable + `COWORKER_GUARD_EXEMPT_FILE` override).
- Architecture/ADR/threat-model/design creative-docs -> silent allow; ordinary drafts stay gated.
- Deny reason gains an escape-hatch (write directly / add to allowlist / Bash heredoc) so agents stop faking compliance.

## Cross-platform
- case-insensitive `tr`-lowercase (no `shopt`/`${var,,}`, macOS bash 3.2 safe)
- `.gitattributes` `eol=lf` (Windows CRLF)
- `# shellcheck shell=bash`

## Tests
- new `tests/test-coworker-hook-guard-write-protected.bats` (10 cases, both axes + fail-soft)
- 66 guard cases green; `shellcheck -S warning` clean (1 justified SC2254)
- fail-soft: absent allowlist -> prior deny behaviour

Archive: `documentation/archive/framework/archive-TUNE-0372.md`