### PR TITLE
Verify committed blob (not working tree) in shared repos

### DIFF
--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -139,3 +139,29 @@ From 24 failure memories:
 Run the command. Read the output. THEN claim the result.
 
 This is non-negotiable.
+
+## Shared Working Tree — Verify the Committed Blob, Not the Tree
+
+In a **shared** git working tree (a framework or workspace repo touched by
+multiple parallel agent sessions), another session may `git checkout` a
+different branch in the same tree *after* you committed your work. A direct
+`grep` / `cat` / `Read` of the working tree then measures the WRONG branch —
+you can read a sibling task's pre-fix state and raise a false failure against
+your own already-correct commit.
+
+**Rule:** before verifying a task's output, probe the tree's current branch:
+
+```bash
+git -C <repo> rev-parse --abbrev-ref HEAD
+```
+
+If it differs from your task branch, read your committed state directly from
+your branch instead of the working tree:
+
+```bash
+git -C <repo> cat-file blob <task-branch>:<path>   # or: git show <task-branch>:<path>
+```
+
+This applies at every verification gate (self-review, QA, compliance,
+archive). The working tree is shared state; your branch is the source of
+truth for what you shipped.


### PR DESCRIPTION
Adds a rule to `skills/verification-before-completion` for shared git working trees: a parallel session may checkout another branch after you commit, so verification must read the task branch's committed blob via `git cat-file` rather than the shared working tree. Re-applied from the stale tune-0356 branch (its original flat-file target had migrated to the SKILL.md dir layout). 38-line addition, no conflicts.