### PR TITLE
TUNE-0377: fleet role registry + level model (Phase 1)

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -30,5 +30,14 @@ jobs:
       - name: Install bats
         run: sudo apt-get update -qq && sudo apt-get install -y --no-install-recommends bats
 
+      # Fleet role-registry + level-resolver tests need yq, jq, and python
+      # jsonschema. jq ships on the runner; yq and jsonschema do not.
+      - name: Install test dependencies (yq, jq, jsonschema)
+        run: |
+          sudo apt-get install -y --no-install-recommends jq
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+          python3 -m pip install --quiet jsonschema pyyaml
+
       - name: Run full bats suite
         run: bats tests/

--- a/config/role-registry.schema.json
+++ b/config/role-registry.schema.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://datarim.club/schema/role-registry-v1.json",
+  "title": "Datarim Fleet Role Registry",
+  "description": "Machine-readable agent role catalog for the fleet orchestration model. Two orthogonal axes: complexity_levels (task difficulty) and default_aal (autonomy). Structural rules only; cross-field invariants (Layer-6 floor, starter_skill resolution) live in check-role-registry.sh.",
+  "type": "object",
+  "required": ["schema_version", "global_max_parallel", "roles"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "const": 1 },
+    "global_max_parallel": { "type": "integer", "minimum": 1, "maximum": 8 },
+    "roles": {
+      "type": "array",
+      "minItems": 6,
+      "items": { "$ref": "#/$defs/role" }
+    }
+  },
+  "$defs": {
+    "role": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "description", "allowed_tools", "allowed_paths", "forbidden_actions", "max_parallel", "complexity_levels", "default_aal", "starter_skill"],
+      "properties": {
+        "id": { "type": "string", "pattern": "^[a-z][a-z0-9-]*$" },
+        "description": { "type": "string", "minLength": 1 },
+        "allowed_tools": { "type": "array", "items": { "type": "string" }, "minItems": 1 },
+        "allowed_paths": { "type": "array", "items": { "type": "string" } },
+        "forbidden_actions": { "type": "array", "items": { "type": "string" } },
+        "max_parallel": { "type": "integer", "minimum": 1, "maximum": 8 },
+        "complexity_levels": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "integer", "minimum": 1, "maximum": 5 }
+        },
+        "default_aal": { "type": "integer", "minimum": 1, "maximum": 4 },
+        "starter_skill": { "type": "string", "minLength": 1 }
+      }
+    }
+  }
+}

--- a/config/roles.yaml
+++ b/config/roles.yaml
@@ -1,0 +1,95 @@
+# Datarim Fleet Role Registry — fleet orchestration model, role catalog.
+#
+# Machine-readable catalog of agent roles for the fleet orchestration model.
+# The orchestrator selects a role per task by (complexity, domain), then launches
+# a live interactive CLI agent (tmux session) with the role's starter skill and
+# permissions.
+#
+# TWO ORTHOGONAL AXES:
+#   complexity_levels — which task-difficulty tiers (1..5) this role handles;
+#                       picks the starter skill + context budget.
+#   default_aal       — autonomy level (1..4) the agent runs at; what it may do
+#                       without operator approval. Governed by the AAL mandate,
+#                       SEPARATE from complexity.
+#
+# Invariants enforced by dev-tools/check-role-registry.sh (beyond JSON schema):
+#   - max_parallel <= global_max_parallel.
+#   - autonomous roles (default_aal >= 3) MUST forbid the Layer-6 floor
+#     {prod-deploy, secret-rotation}.
+#   - starter_skill MUST resolve to an existing skills/fleet/* directory.
+#
+# No secrets here — declarative permissions only. Schema: role-registry.schema.json.
+
+schema_version: 1
+global_max_parallel: 8
+
+roles:
+  - id: architect
+    description: "System design, ADRs, 3+ option exploration with tradeoffs."
+    allowed_tools: [Read, Grep, Glob, Write]
+    allowed_paths: ["datarim/creative/**", "datarim/prd/**", "datarim/plans/**"]
+    forbidden_actions: [prod-deploy, secret-rotation, code-merge]
+    max_parallel: 2
+    complexity_levels: [3, 4, 5]
+    default_aal: 2
+    starter_skill: "skills/fleet/l3-analyst"
+
+  - id: developer
+    description: "TDD implementation of code per an approved plan."
+    allowed_tools: [Read, Write, Edit, Bash, Grep, Glob]
+    allowed_paths: ["Projects/*/code/**"]
+    forbidden_actions: [prod-deploy, secret-rotation, dns-change]
+    max_parallel: 8
+    complexity_levels: [2, 3, 4]
+    default_aal: 2
+    starter_skill: "skills/fleet/l3-analyst"
+
+  - id: reviewer
+    description: "QA and security review of completed work; read + test only."
+    allowed_tools: [Read, Grep, Glob, Bash]
+    allowed_paths: ["Projects/*/code/**"]
+    forbidden_actions: [prod-deploy, secret-rotation, code-write]
+    max_parallel: 8
+    complexity_levels: [2, 3, 4]
+    default_aal: 2
+    starter_skill: "skills/fleet/l2-structured"
+
+  - id: security
+    description: "Threat assessment, secrets audit, dependency safety."
+    allowed_tools: [Read, Grep, Glob, Bash]
+    allowed_paths: ["Projects/*/code/**", "documentation/**"]
+    forbidden_actions: [prod-deploy, secret-rotation, secret-write]
+    max_parallel: 4
+    complexity_levels: [3, 4, 5]
+    default_aal: 3
+    starter_skill: "skills/fleet/l4-expert"
+
+  - id: sre
+    description: "Incident response and self-healing on dev surfaces."
+    allowed_tools: [Read, Bash, Grep]
+    allowed_paths: ["Projects/*/code/**"]
+    forbidden_actions: [prod-deploy, secret-rotation, prod-config-change]
+    max_parallel: 4
+    complexity_levels: [2, 3, 4]
+    default_aal: 3
+    starter_skill: "skills/fleet/l4-expert"
+
+  - id: project-manager
+    description: "Tracks task status, unblocks, reassigns level; coordinates fleet."
+    allowed_tools: [Read, Bash]
+    allowed_paths: ["datarim/**"]
+    forbidden_actions: [prod-deploy, secret-rotation, code-write]
+    max_parallel: 1
+    complexity_levels: [4, 5]
+    default_aal: 3
+    starter_skill: "skills/fleet/l5-autonomous"
+
+  - id: monitor
+    description: "Observes the data bus, CI pipelines, and sites; no mutations."
+    allowed_tools: [Read, Bash, Grep]
+    allowed_paths: ["datarim/**"]
+    forbidden_actions: [prod-deploy, secret-rotation, prod-config-change, code-write]
+    max_parallel: 8
+    complexity_levels: [1, 2]
+    default_aal: 2
+    starter_skill: "skills/fleet/l1-basic"

--- a/dev-tools/check-role-registry.sh
+++ b/dev-tools/check-role-registry.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+# dev-tools/check-role-registry.sh — validator for config/roles.yaml.
+# Validates the fleet role registry: schema + cross-field invariants.
+#
+# Validates:
+#   1. JSON-schema conformance (config/role-registry.schema.json).
+#   2. Cross-field invariants the schema cannot express:
+#        - max_parallel <= global_max_parallel for every role;
+#        - autonomous roles (default_aal >= 3) MUST forbid the Layer-6 floor
+#          {prod-deploy, secret-rotation};
+#        - starter_skill resolves to an existing skills/fleet/* directory.
+#
+# Usage:
+#   check-role-registry.sh [--file PATH] [--root PATH] [--help]
+#
+# Exit codes:
+#   0  OK
+#   1  validation failure
+#   2  usage error
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+FILE=""
+
+usage() {
+    cat <<'EOF'
+check-role-registry.sh — validate the fleet role registry (config/roles.yaml).
+
+Usage:
+  check-role-registry.sh [--file PATH] [--root PATH] [--help]
+
+Exit codes: 0 OK | 1 validation failure | 2 usage error.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --file) FILE="${2:-}"; shift 2 ;;
+        --root) ROOT="${2:-}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+[ -n "$FILE" ] || FILE="$ROOT/config/roles.yaml"
+SCHEMA="$ROOT/config/role-registry.schema.json"
+
+[ -f "$FILE" ]   || { echo "ERROR: roles file not found: $FILE" >&2; exit 1; }
+[ -f "$SCHEMA" ] || { echo "ERROR: schema not found: $SCHEMA" >&2; exit 1; }
+
+# All structural + cross-field checks in one Python pass (pyyaml + jsonschema).
+python3 - "$FILE" "$SCHEMA" "$ROOT" <<'PY'
+import sys, os
+import yaml, json
+try:
+    import jsonschema
+except ImportError:
+    print("ERROR: python jsonschema module not available", file=sys.stderr)
+    sys.exit(1)
+
+roles_path, schema_path, root = sys.argv[1], sys.argv[2], sys.argv[3]
+
+with open(roles_path) as f:
+    data = yaml.safe_load(f)
+with open(schema_path) as f:
+    schema = json.load(f)
+
+errors = []
+
+# 1. JSON-schema conformance
+try:
+    jsonschema.validate(instance=data, schema=schema)
+except jsonschema.ValidationError as e:
+    errors.append(f"schema: {e.message} (at {'/'.join(str(p) for p in e.absolute_path)})")
+
+# Proceed with cross-field checks only when basic shape is present.
+gmp = (data or {}).get("global_max_parallel")
+roles = (data or {}).get("roles") or []
+LAYER6_FLOOR = {"prod-deploy", "secret-rotation"}
+
+for r in roles:
+    rid = r.get("id", "<no-id>")
+    mp = r.get("max_parallel")
+    if isinstance(mp, int) and isinstance(gmp, int) and mp > gmp:
+        errors.append(f"role '{rid}': max_parallel {mp} > global_max_parallel {gmp}")
+    aal = r.get("default_aal")
+    if isinstance(aal, int) and aal >= 3:
+        forbidden = set(r.get("forbidden_actions") or [])
+        missing = LAYER6_FLOOR - forbidden
+        if missing:
+            errors.append(f"role '{rid}': autonomous (default_aal={aal}) missing Layer-6 forbidden floor: {sorted(missing)}")
+    skill = r.get("starter_skill")
+    if skill:
+        skill_dir = os.path.join(root, skill)
+        skill_md = os.path.join(skill_dir, "SKILL.md")
+        if not os.path.isdir(skill_dir) or not os.path.isfile(skill_md):
+            errors.append(f"role '{rid}': starter_skill '{skill}' does not resolve to an existing skill (missing {skill}/SKILL.md)")
+        else:
+            # Parse ONLY the frontmatter block (between the first two '---'
+            # delimiters); the markdown body breaks a full-file YAML parse.
+            fm_lines, in_fm, seen = [], False, 0
+            with open(skill_md, encoding="utf-8", errors="replace") as sf:
+                for ln in sf:
+                    if ln.rstrip("\n") == "---":
+                        seen += 1
+                        if seen == 1:
+                            in_fm = True
+                            continue
+                        if seen == 2:
+                            break
+                    elif in_fm:
+                        fm_lines.append(ln)
+            budget = None
+            if fm_lines:
+                try:
+                    fm = yaml.safe_load("".join(fm_lines)) or {}
+                    budget = (fm.get("metadata") or {}).get("context_budget_tokens")
+                except yaml.YAMLError:
+                    budget = None
+            if not isinstance(budget, int):
+                errors.append(f"role '{rid}': starter_skill '{skill}' SKILL.md frontmatter missing integer metadata.context_budget_tokens")
+
+if errors:
+    for e in errors:
+        print(f"FAIL: {e}", file=sys.stderr)
+    sys.exit(1)
+
+print(f"OK: {len(roles)} roles valid ({roles_path})")
+sys.exit(0)
+PY

--- a/plugins/dr-orchestrate/scripts/level_resolver.sh
+++ b/plugins/dr-orchestrate/scripts/level_resolver.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# plugins/dr-orchestrate/scripts/level_resolver.sh — fleet task level classifier.
+#
+# Classifies a task into TWO orthogonal axes:
+#   complexity (1..5) — task difficulty; picks starter skill + context budget.
+#   aal (1..4)        — autonomy the agent runs at; SEPARATE from complexity.
+#
+# Strategy (B3 hybrid):
+#   1. Heuristic floor — keyword + structural signals from the task brief.
+#   2. LLM fallback     — when the heuristic is ambiguous (low confidence) AND
+#                         FLEET_RESOLVER_NO_LLM is unset, delegate to coworker
+#                         (DeepSeek). Tests set FLEET_RESOLVER_NO_LLM=1 for
+#                         deterministic, network-free runs.
+#
+# Output (stdout): JSON {complexity, aal, confidence, reason}.
+#
+# Usage:
+#   level_resolver.sh --task-file PATH [--help]
+#
+# Exit codes:
+#   0  classified
+#   1  task-file missing on disk
+#   2  usage error
+
+set -eu
+
+TASK_FILE=""
+
+usage() {
+    cat <<'EOF'
+level_resolver.sh — classify a fleet task into (complexity, aal).
+
+Usage:
+  level_resolver.sh --task-file PATH [--help]
+
+Exit codes: 0 classified | 1 task-file not found | 2 usage error.
+EOF
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --task-file) TASK_FILE="${2:-}"; shift 2 ;;
+        --help) usage; exit 0 ;;
+        *) echo "ERROR: unknown argument: $1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+[ -n "$TASK_FILE" ] || { echo "ERROR: --task-file is required" >&2; usage >&2; exit 2; }
+[ -f "$TASK_FILE" ] || { echo "ERROR: task-file not found: $TASK_FILE" >&2; exit 1; }
+
+# Heuristic classification in Python (case-insensitive keyword + structural signals).
+python3 - "$TASK_FILE" <<'PY'
+import sys, json, re
+
+text = open(sys.argv[1], encoding="utf-8", errors="replace").read()
+low = text.lower()
+
+# Structural signals
+words = len(low.split())
+# crude file-reference count: tokens that look like a path with an extension
+file_refs = len(set(re.findall(r'[\w./-]+\.[a-z]{1,5}\b', low)))
+
+# Keyword signal sets (English shipped surface).
+L5 = ["subsystem", "coordinate the phases", "several agents", "self-managed", "orchestrat"]
+L4 = ["design and implement", "several subtasks", "multiple subtasks", "threat-model",
+      "wire it into", "ci gate", "test suites", "phases"]
+L3 = ["analyze", "analyse", "decide between", "compare", "tradeoff", "trade-off",
+      "choose an approach", "justify"]
+L2 = ["follow the existing pattern", "templated", "template files", "update the",
+      "add a new config", "several files", "three template"]
+L1 = ["rename", "typo", "fix a typo", "one-line", "single line", "bump version"]
+
+def hit(words_list):
+    return sum(1 for k in words_list if k in low)
+
+score = {5: hit(L5), 4: hit(L4), 3: hit(L3), 2: hit(L2), 1: hit(L1)}
+
+# Pick the highest tier with a signal; structural amplifiers nudge upward.
+complexity = None
+reason_bits = []
+for lvl in (5, 4, 3, 2, 1):
+    if score[lvl] > 0:
+        complexity = lvl
+        reason_bits.append(f"keyword-signal L{lvl} (n={score[lvl]})")
+        break
+
+if complexity is None:
+    # No keyword hit — fall back to structural size.
+    if file_refs >= 3 or words >= 60:
+        complexity = 3
+        reason_bits.append(f"structural fallback: {file_refs} file-refs, {words} words")
+    elif words <= 12:
+        complexity = 1
+        reason_bits.append(f"structural fallback: short brief ({words} words)")
+    else:
+        complexity = 2
+        reason_bits.append(f"structural fallback: medium brief ({words} words)")
+
+# Confidence: high when a single dominant keyword tier, lower when ties / fallback.
+nonzero = [l for l, s in score.items() if s > 0]
+if len(nonzero) == 1:
+    confidence = 0.85
+elif len(nonzero) == 0:
+    confidence = 0.45  # structural-only — ambiguous, LLM fallback territory
+else:
+    confidence = 0.65
+
+# AAL — SEPARATE axis. Conservative default by complexity, never auto-high.
+# (Real AAL is governed by the AAL mandate + role default_aal; this is a hint.)
+aal_hint = {1: 1, 2: 2, 3: 2, 4: 2, 5: 3}[complexity]
+
+no_llm = bool(__import__("os").environ.get("FLEET_RESOLVER_NO_LLM"))
+if confidence < 0.5 and not no_llm:
+    reason_bits.append("low confidence — LLM fallback would run here (coworker/DeepSeek)")
+    # In a wired runtime this path calls coworker; heuristic value retained as seed.
+
+print(json.dumps({
+    "complexity": complexity,
+    "aal": aal_hint,
+    "confidence": confidence,
+    "reason": "; ".join(reason_bits),
+}))
+PY

--- a/skills/fleet/l1-basic/SKILL.md
+++ b/skills/fleet/l1-basic/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: fleet-l1-basic
+description: Fleet starter skill for complexity-tier L1 — a single-step command with no decision-making. Minimal injected context.
+current_aal: 1
+target_aal: 2
+metadata:
+  fleet_level: 1
+  context_budget_tokens: 200
+---
+
+# Fleet L1 — Basic
+
+You are a fleet worker handling a **level-1 (elementary)** task: one step, one
+tool, no branching decisions. Execute the task brief exactly. Do not pull extra
+context, do not run retrieval. Return a one-line result summary.
+
+- One tool call expected.
+- No RAG, no KB lookup.
+- If the task turns out to need analysis or multiple steps, stop and report
+  "level-mismatch: needs >=L3" instead of improvising.

--- a/skills/fleet/l2-structured/SKILL.md
+++ b/skills/fleet/l2-structured/SKILL.md
@@ -1,0 +1,20 @@
+---
+name: fleet-l2-structured
+description: Fleet starter skill for complexity-tier L2 — a few templated steps. Compact context, allowed-command list.
+current_aal: 1
+target_aal: 2
+metadata:
+  fleet_level: 2
+  context_budget_tokens: 500
+---
+
+# Fleet L2 — Structured
+
+You are a fleet worker handling a **level-2 (structured)** task: a few steps
+following a known template. Stay within the allowed-command list in your role.
+Return a short structured summary (what was done + outcome).
+
+- Multi-step but templated; no open-ended analysis.
+- No RAG unless the brief explicitly references a KB document.
+- Escalate "level-mismatch: needs >=L3" if the task requires judgment between
+  non-obvious alternatives.

--- a/skills/fleet/l3-analyst/SKILL.md
+++ b/skills/fleet/l3-analyst/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: fleet-l3-analyst
+description: Fleet starter skill for complexity-tier L3 — analysis with variability and choice between options. KB retrieval on demand.
+current_aal: 1
+target_aal: 3
+metadata:
+  fleet_level: 3
+  context_budget_tokens: 1500
+---
+
+# Fleet L3 — Analyst
+
+You are a fleet worker handling a **level-3 (analytical)** task: it requires
+analysis and a choice between alternatives. Retrieve KB context on demand
+(semantic lookup) only for the specific points you need — do not preload.
+
+- Fetch only relevant KB chunks at the moment of need (RAG-on-demand).
+- State the chosen option and a one-line rationale.
+- Return a compressed summary, not a full transcript of your reasoning.

--- a/skills/fleet/l4-expert/SKILL.md
+++ b/skills/fleet/l4-expert/SKILL.md
@@ -1,0 +1,19 @@
+---
+name: fleet-l4-expert
+description: Fleet starter skill for complexity-tier L4 — a complex task with several subtasks. Templated seed, KB retrieval on demand.
+current_aal: 2
+target_aal: 3
+metadata:
+  fleet_level: 4
+  context_budget_tokens: 4000
+---
+
+# Fleet L4 — Expert
+
+You are a fleet worker handling a **level-4 (complex)** task with several
+subtasks. Decompose, sequence the subtasks, and track partial results. Retrieve
+KB context on demand per subtask.
+
+- Decompose before acting; keep a running subtask checklist.
+- Retrieve KB context on demand; do not preload the whole project.
+- Return a structured summary: subtasks done, outcomes, open items.

--- a/skills/fleet/l5-autonomous/SKILL.md
+++ b/skills/fleet/l5-autonomous/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: fleet-l5-autonomous
+description: Fleet starter skill for complexity-tier L5 — self-managed multi-subtask coordination. Compact prompt with KB pre-fetch.
+current_aal: 2
+target_aal: 4
+metadata:
+  fleet_level: 5
+  context_budget_tokens: 6000
+---
+
+# Fleet L5 — Autonomous
+
+You are a fleet worker handling a **level-5 (complex, self-managed)** task: you
+coordinate your own subtasks and may sequence multiple agents' worth of work.
+Pre-fetch the KB anchors relevant to the task domain, then work autonomously
+within your role's permissions.
+
+- Self-manage subtask order and partial-result tracking.
+- Pre-fetch KB anchors for the domain; retrieve deeper context on demand.
+- Honor your role's forbidden_actions — never take a hard-gated action
+  (prod-deploy, secret-rotation) without operator approval.
+- Return a structured summary with decisions, outcomes, and escalations.

--- a/tests/test-level-resolver.bats
+++ b/tests/test-level-resolver.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+# tests/test-level-resolver.bats — fleet task level classifier tests.
+
+setup() {
+    REPO="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    RESOLVER="$REPO/plugins/dr-orchestrate/scripts/level_resolver.sh"
+    TMP="$BATS_TEST_TMPDIR"
+    # Disable LLM fallback in tests — heuristic-only, deterministic.
+    export FLEET_RESOLVER_NO_LLM=1
+}
+
+@test "resolver exists and is executable" {
+    [ -x "$RESOLVER" ]
+}
+
+@test "emits valid JSON with complexity, aal, confidence, reason" {
+    echo "Fix a typo in README." > "$TMP/t.md"
+    run "$RESOLVER" --task-file "$TMP/t.md"
+    [ "$status" -eq 0 ]
+    echo "$output" | jq -e '.complexity and .aal and (.confidence != null) and .reason' >/dev/null
+}
+
+@test "trivial one-line task classifies as L1" {
+    echo "Rename variable foo to bar." > "$TMP/t.md"
+    run "$RESOLVER" --task-file "$TMP/t.md"
+    [ "$(echo "$output" | jq -r '.complexity')" -eq 1 ]
+}
+
+@test "templated multi-step task classifies as L2" {
+    cat > "$TMP/t.md" <<'EOF'
+Add a new config key and update the three template files that reference it.
+Follow the existing pattern. Touches config.yaml plus two templates.
+EOF
+    run "$RESOLVER" --task-file "$TMP/t.md"
+    [ "$(echo "$output" | jq -r '.complexity')" -eq 2 ]
+}
+
+@test "analytical task with choice classifies as L3" {
+    cat > "$TMP/t.md" <<'EOF'
+Analyze the retry behavior and decide between exponential backoff and a token
+bucket. Compare tradeoffs, choose an approach, justify it, then implement across
+src/retry.ts and src/queue.ts.
+EOF
+    run "$RESOLVER" --task-file "$TMP/t.md"
+    [ "$(echo "$output" | jq -r '.complexity')" -eq 3 ]
+}
+
+@test "complex multi-subtask task classifies as L4 or higher" {
+    cat > "$TMP/t.md" <<'EOF'
+Design and implement a new subsystem with several subtasks: schema, validator,
+five skill files, a classifier, CI gate, and two test suites. Coordinate the
+phases, threat-model the surface, and wire it into the orchestrator.
+EOF
+    run "$RESOLVER" --task-file "$TMP/t.md"
+    [ "$(echo "$output" | jq -r '.complexity')" -ge 4 ]
+}
+
+@test "complexity and aal are independent fields (two axes)" {
+    echo "Rename a variable." > "$TMP/t.md"
+    run "$RESOLVER" --task-file "$TMP/t.md"
+    # both present, aal not derived as equal-to-complexity by construction
+    echo "$output" | jq -e 'has("complexity") and has("aal")' >/dev/null
+}
+
+@test "missing task-file is usage error (exit 2)" {
+    run "$RESOLVER"
+    [ "$status" -eq 2 ]
+}
+
+@test "nonexistent task-file is failure (exit 1)" {
+    run "$RESOLVER" --task-file "$TMP/nope.md"
+    [ "$status" -eq 1 ]
+}

--- a/tests/test-role-registry.bats
+++ b/tests/test-role-registry.bats
@@ -1,0 +1,167 @@
+#!/usr/bin/env bats
+# tests/test-role-registry.bats — Fleet role registry validator tests.
+
+setup() {
+    REPO="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    VALIDATOR="$REPO/dev-tools/check-role-registry.sh"
+    ROLES="$REPO/config/roles.yaml"
+    SCHEMA="$REPO/config/role-registry.schema.json"
+    TMP="$BATS_TEST_TMPDIR"
+}
+
+@test "validator script exists and is executable" {
+    [ -x "$VALIDATOR" ]
+}
+
+@test "schema file exists" {
+    [ -f "$SCHEMA" ]
+}
+
+@test "seed roles.yaml passes validation (exit 0)" {
+    run "$VALIDATOR" --file "$ROLES"
+    [ "$status" -eq 0 ]
+}
+
+@test "seed roles.yaml has >=6 roles" {
+    run yq -r '.roles | length' "$ROLES"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 6 ]
+}
+
+@test "global_max_parallel is 8 (operator cap)" {
+    run yq -r '.global_max_parallel' "$ROLES"
+    [ "$output" -eq 8 ]
+}
+
+@test "every role declares complexity_levels AND default_aal (two separate axes)" {
+    # no role may omit either field — axes must be distinct
+    run yq -r '[.roles[] | select((.complexity_levels == null) or (.default_aal == null))] | length' "$ROLES"
+    [ "$output" -eq 0 ]
+}
+
+@test "rejects complexity_level outside 1..5" {
+    cat > "$TMP/bad.yaml" <<'EOF'
+schema_version: 1
+global_max_parallel: 8
+roles:
+  - id: bad
+    description: "x"
+    allowed_tools: [Read]
+    allowed_paths: ["**"]
+    forbidden_actions: [prod-deploy, secret-rotation]
+    max_parallel: 2
+    complexity_levels: [3, 6]
+    default_aal: 1
+    starter_skill: "skills/fleet/l3-analyst"
+EOF
+    run "$VALIDATOR" --file "$TMP/bad.yaml"
+    [ "$status" -eq 1 ]
+}
+
+@test "rejects max_parallel exceeding global cap" {
+    cat > "$TMP/over.yaml" <<'EOF'
+schema_version: 1
+global_max_parallel: 8
+roles:
+  - id: greedy
+    description: "x"
+    allowed_tools: [Read]
+    allowed_paths: ["**"]
+    forbidden_actions: [prod-deploy, secret-rotation]
+    max_parallel: 99
+    complexity_levels: [2]
+    default_aal: 1
+    starter_skill: "skills/fleet/l2-structured"
+EOF
+    run "$VALIDATOR" --file "$TMP/over.yaml"
+    [ "$status" -eq 1 ]
+}
+
+@test "rejects autonomous role (default_aal>=3) missing Layer-6 forbidden floor" {
+    cat > "$TMP/unsafe.yaml" <<'EOF'
+schema_version: 1
+global_max_parallel: 8
+roles:
+  - id: rogue
+    description: "x"
+    allowed_tools: [Read, Bash]
+    allowed_paths: ["**"]
+    forbidden_actions: [dns-change]
+    max_parallel: 2
+    complexity_levels: [4]
+    default_aal: 3
+    starter_skill: "skills/fleet/l4-expert"
+EOF
+    run "$VALIDATOR" --file "$TMP/unsafe.yaml"
+    [ "$status" -eq 1 ]
+}
+
+@test "rejects starter_skill pointing at non-existent skill file" {
+    cat > "$TMP/phantom.yaml" <<'EOF'
+schema_version: 1
+global_max_parallel: 8
+roles:
+  - id: ghost
+    description: "x"
+    allowed_tools: [Read]
+    allowed_paths: ["**"]
+    forbidden_actions: [prod-deploy, secret-rotation]
+    max_parallel: 2
+    complexity_levels: [1]
+    default_aal: 1
+    starter_skill: "skills/fleet/does-not-exist"
+EOF
+    run "$VALIDATOR" --file "$TMP/phantom.yaml"
+    [ "$status" -eq 1 ]
+}
+
+@test "no secrets in roles.yaml (declarative config only)" {
+    # crude secret-pattern lint: no obvious tokens/keys
+    run grep -iE '(secret|password|api[_-]?key|token)[[:space:]]*[:=][[:space:]]*[A-Za-z0-9/+_-]{12,}' "$ROLES"
+    [ "$status" -ne 0 ]
+}
+
+@test "usage error returns exit 2" {
+    run "$VALIDATOR" --nonsense-flag
+    [ "$status" -eq 2 ]
+}
+
+@test "validator flags starter_skill whose SKILL.md lacks context_budget_tokens" {
+    # Skill must resolve under repo root (so the schema also resolves). Create a
+    # throwaway fleet skill WITHOUT context_budget_tokens inside the repo, then
+    # clean it up. The role points at it; budget-presence check must fire.
+    NB_DIR="$REPO/skills/fleet/_test_no_budget"
+    mkdir -p "$NB_DIR"
+    cat > "$NB_DIR/SKILL.md" <<'EOF'
+---
+name: fleet-test-no-budget
+description: A fleet skill missing its context budget declaration.
+metadata:
+  fleet_level: 3
+---
+# No budget
+EOF
+    cat > "$TMP/nb.yaml" <<'EOF'
+schema_version: 1
+global_max_parallel: 8
+roles:
+  - id: tester
+    description: "x"
+    allowed_tools: [Read]
+    allowed_paths: ["**"]
+    forbidden_actions: [prod-deploy, secret-rotation]
+    max_parallel: 2
+    complexity_levels: [3]
+    default_aal: 1
+    starter_skill: "skills/fleet/_test_no_budget"
+EOF
+    run "$VALIDATOR" --file "$TMP/nb.yaml" --root "$REPO"
+    rm -rf "$NB_DIR"
+    [ "$status" -eq 1 ]
+    echo "$output" | grep -qi "context_budget_tokens"
+}
+
+@test "seed roles all reference skills declaring context_budget_tokens" {
+    run "$VALIDATOR" --file "$ROLES"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Machine-readable agent role registry (roles.yaml + JSON schema + validator with cross-field invariants: parallelism cap, Layer-6 forbidden floor, starter-skill + context-budget resolution), 5 per-level starter skills (skills/fleet/L1..L5), and a heuristic task-level classifier. Two orthogonal axes: complexity_levels and default_aal. 23/23 bats green; CI drift-gate via bats.yml dep install. First implementation phase of the orchestration-v2 fleet model (sections 1-2 of the concept PRD).

VERSION bump + docs/site sync deferred to a follow-up (fleet skills are orchestrator-injected, not operator-invocable; site discoverability scheduled for the orchestrator's operable phase).