### PR TITLE
Fleet Phase 3 — event bus + monitoring + PM orchestrator + observability dashboard

### DIFF
--- a/plugins/dr-orchestrate/.gitignore
+++ b/plugins/dr-orchestrate/.gitignore
@@ -1,0 +1,3 @@
+# Runtime-generated files — not committed
+var/metrics/
+var/fleet/

--- a/plugins/dr-orchestrate/bin/fleet-validate-message.sh
+++ b/plugins/dr-orchestrate/bin/fleet-validate-message.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# fleet-validate-message.sh — Schema validator for fleet bus messages.
+#
+# Usage:
+#   fleet-validate-message.sh --id <uuid> --ts <ISO-8601> --type <enum> \
+#                              --from <agent> --to <agent>
+#
+# Exits 0 if all required fields pass validation.
+# Exits 1 with a descriptive error message on stderr/stdout if validation fails.
+#
+# Required fields:
+#   --id    Non-empty string (UUID recommended)
+#   --ts    ISO-8601 datetime (e.g. 2026-06-09T12:00:00Z)
+#   --type  One of: lifecycle | alert | command | audit | heartbeat |
+#                   level-reassigned | agent-spawned | agent-killed
+#
+# Optional fields (no validation, passed through):
+#   --from  Sender agent identifier
+#   --to    Destination agent/topic identifier
+#
+# Env:
+#   DR_FLEET_VALIDATOR_STRICT=1 — also require --from and --to
+
+set -uo pipefail
+
+# ── valid type enum ───────────────────────────────────────────────────────────
+
+readonly VALID_TYPES="lifecycle alert command audit heartbeat level-reassigned agent-spawned agent-killed"
+
+# ── arg parser ────────────────────────────────────────────────────────────────
+
+msg_id=""
+msg_ts=""
+msg_type=""
+msg_from=""
+msg_to=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --id)    msg_id="$2";   shift 2 ;;
+    --ts)    msg_ts="$2";   shift 2 ;;
+    --type)  msg_type="$2"; shift 2 ;;
+    --from)  msg_from="$2"; shift 2 ;;
+    --to)    msg_to="$2";   shift 2 ;;
+    --help)
+      printf 'usage: fleet-validate-message.sh --id <id> --ts <ISO-8601> --type <enum> [--from <x>] [--to <y>]\n'
+      printf 'valid types: %s\n' "$VALID_TYPES"
+      exit 0
+      ;;
+    *) printf 'ERR: unknown flag %q\n' "$1" >&2; exit 1 ;;
+  esac
+done
+
+# ── validation ────────────────────────────────────────────────────────────────
+
+errors=()
+
+# Validate id: must be non-empty
+if [[ -z "$msg_id" ]]; then
+  errors+=("INVALID: id is required and must be non-empty")
+fi
+
+# Validate ts: must match ISO-8601 basic pattern YYYY-MM-DDTHH:MM:SSZ (or +offset)
+# Pattern: YYYY-MM-DDTHH:MM:SS followed by Z or ±HH:MM
+if [[ -z "$msg_ts" ]]; then
+  errors+=("INVALID: ts is required")
+elif ! [[ "$msg_ts" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}([Z]|[+-][0-9]{2}:[0-9]{2})$ ]]; then
+  errors+=("INVALID: ts must be ISO-8601 datetime (e.g. 2026-06-09T12:00:00Z), got: $msg_ts")
+fi
+
+# Validate type: must be in enum
+if [[ -z "$msg_type" ]]; then
+  errors+=("INVALID: type is required")
+else
+  valid=0
+  for t in $VALID_TYPES; do
+    [[ "$msg_type" == "$t" ]] && { valid=1; break; }
+  done
+  if (( ! valid )); then
+    errors+=("INVALID: type must be one of [$VALID_TYPES], got: $msg_type")
+  fi
+fi
+
+# Strict mode: also require from/to
+if [[ "${DR_FLEET_VALIDATOR_STRICT:-0}" == "1" ]]; then
+  [[ -z "$msg_from" ]] && errors+=("INVALID: --from is required in strict mode")
+  [[ -z "$msg_to" ]]   && errors+=("INVALID: --to is required in strict mode")
+fi
+
+# ── output ────────────────────────────────────────────────────────────────────
+
+if (( ${#errors[@]} > 0 )); then
+  for err in "${errors[@]}"; do
+    printf '%s\n' "$err"
+  done
+  exit 1
+fi
+
+exit 0

--- a/plugins/dr-orchestrate/config/fleet-cron.template
+++ b/plugins/dr-orchestrate/config/fleet-cron.template
@@ -1,0 +1,24 @@
+# fleet-cron.template — Fleet mini-agent cron schedule template.
+#
+# Usage: copy to /etc/cron.d/fleet-mini-agents (or user crontab) and
+# substitute DR_ORCHESTRATE_PLUGIN_DIR with the absolute plugin path.
+#
+# Operator MUST set DR_ORCHESTRATE_PLUGIN_DIR before applying:
+#   export DR_ORCHESTRATE_PLUGIN_DIR=/path/to/plugins/dr-orchestrate
+#   envsubst < fleet-cron.template > /etc/cron.d/fleet-mini-agents
+#
+# All jobs run as the CI runner user (adjust USER below).
+
+# ── health check every 5 minutes ─────────────────────────────────────────────
+# Subscribes one batch of monitoring-alerts and updates obs snapshot.
+*/5 * * * * USER ${DR_ORCHESTRATE_PLUGIN_DIR}/scripts/fleet_obs_aggregator.sh --snapshot >/dev/null 2>&1
+
+# ── PM timeout scan every 2 minutes ──────────────────────────────────────────
+*/2 * * * * USER ${DR_ORCHESTRATE_PLUGIN_DIR}/scripts/fleet_pm_orchestrator.sh timeout-check --dry-run >/dev/null 2>&1
+
+# ── audit log trim every 24 hours at 03:00 UTC ───────────────────────────────
+# Archives stream:fleet:audit-log entries to JSONL.GZ before XTRIM.
+0 3 * * * USER DR_FLEET_AUDIT_ARCHIVE_DIR=${DR_ORCHESTRATE_PLUGIN_DIR}/var/fleet/audit-archive ${DR_ORCHESTRATE_PLUGIN_DIR}/scripts/fleet_audit_trim.sh >/dev/null 2>&1
+
+# ── log rotation every 6 hours ───────────────────────────────────────────────
+0 */6 * * * USER find ${DR_ORCHESTRATE_PLUGIN_DIR}/var -name '*.log' -mtime +7 -delete 2>/dev/null || true

--- a/plugins/dr-orchestrate/scripts/bus_adapter.sh
+++ b/plugins/dr-orchestrate/scripts/bus_adapter.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# bus_adapter.sh — Fleet event bus port: publish/subscribe/ack/replay over
+# Redis Streams (or mock backend for testing).
+#
+# Public functions:
+#   bus_publish  <topic> <field> <val> [<field> <val> ...]  → stream-id
+#   bus_subscribe <topic> <group> <consumer> <block_ms>     → raw XREADGROUP output
+#   bus_ack       <topic> <group> <message_id>              → 0|1
+#   bus_replay    <topic> <from_id>                         → XRANGE output
+#
+# Topic constants (use these — do not hardcode strings):
+#   FLEET_TOPIC_TASK_EVENTS        fleet:task-events
+#   FLEET_TOPIC_MONITORING_ALERTS  fleet:monitoring-alerts
+#   FLEET_TOPIC_FLEET_COMMANDS     fleet:fleet-commands
+#   FLEET_TOPIC_AUDIT_LOG          fleet:audit-log
+#
+# Env:
+#   DR_FLEET_BUS_BACKEND  — "redis" (default) or "mock"
+#   DR_ORCH_REDIS_URL     — Redis URL, default redis://127.0.0.1:6379
+#   DR_FLEET_MOCK_LOG     — path for mock backend log (default /tmp/fleet-mock.log)
+#   DR_FLEET_MOCK_XADD_ID — mock XADD return ID (default timestamp-0)
+set -uo pipefail
+
+# ── topic constants ───────────────────────────────────────────────────────────
+# Exported for sourcing scripts — shellcheck cannot see cross-file usage.
+# shellcheck disable=SC2034
+readonly FLEET_TOPIC_TASK_EVENTS="fleet:task-events"
+# shellcheck disable=SC2034
+readonly FLEET_TOPIC_MONITORING_ALERTS="fleet:monitoring-alerts"
+# shellcheck disable=SC2034
+readonly FLEET_TOPIC_FLEET_COMMANDS="fleet:fleet-commands"
+# shellcheck disable=SC2034
+readonly FLEET_TOPIC_AUDIT_LOG="fleet:audit-log"
+
+# Stream key prefix — Redis key = "stream:<topic>"
+_stream_key() { printf 'stream:%s' "$1"; }
+
+# ── env defaults ──────────────────────────────────────────────────────────────
+
+: "${DR_FLEET_BUS_BACKEND:=redis}"
+: "${DR_ORCH_REDIS_URL:=redis://127.0.0.1:6379}"
+: "${DR_FLEET_MOCK_LOG:=/tmp/fleet-mock.log}"
+: "${DR_FLEET_MOCK_XADD_ID:=$(date +%s%3N)-0}"
+
+# ── Redis helpers ─────────────────────────────────────────────────────────────
+
+_redis_require() {
+  if ! command -v redis-cli >/dev/null 2>&1; then
+    printf 'ERR: redis-cli not found in PATH\n' >&2
+    return 1
+  fi
+}
+
+_redis() {
+  redis-cli -u "$DR_ORCH_REDIS_URL" "$@"
+}
+
+# ── mock backend ──────────────────────────────────────────────────────────────
+
+_mock_log() {
+  mkdir -p "$(dirname "$DR_FLEET_MOCK_LOG")"
+  printf '%s\n' "$*" >> "$DR_FLEET_MOCK_LOG"
+}
+
+_mock_publish() {
+  local topic="$1"; shift
+  local key; key="$(_stream_key "$topic")"
+  _mock_log "XADD $key * $*"
+  printf '%s\n' "$DR_FLEET_MOCK_XADD_ID"
+}
+
+_mock_subscribe() {
+  local topic="$1" group="$2" consumer="$3" block_ms="$4"
+  local key; key="$(_stream_key "$topic")"
+  _mock_log "XREADGROUP GROUP $group $consumer BLOCK $block_ms STREAMS $key >"
+  printf '(empty)\n'
+}
+
+_mock_ack() {
+  local topic="$1" group="$2" msg_id="$3"
+  local key; key="$(_stream_key "$topic")"
+  _mock_log "XACK $key $group $msg_id"
+  printf '1\n'
+}
+
+_mock_replay() {
+  local topic="$1" from_id="$2"
+  local key; key="$(_stream_key "$topic")"
+  _mock_log "XRANGE $key $from_id +"
+  printf '(empty)\n'
+}
+
+# ── backend guard ─────────────────────────────────────────────────────────────
+
+_validate_backend() {
+  case "$DR_FLEET_BUS_BACKEND" in
+    redis|mock) ;;
+    *)
+      printf 'ERR: unknown DR_FLEET_BUS_BACKEND=%q (valid: redis, mock)\n' \
+        "$DR_FLEET_BUS_BACKEND" >&2
+      return 1
+      ;;
+  esac
+}
+
+# Validate on source — abort if backend is unknown
+_validate_backend
+
+# ── public functions ──────────────────────────────────────────────────────────
+
+# bus_publish <topic> <field> <val> [<field> <val> ...]
+# Publishes message fields to the given topic stream. Returns the stream entry ID.
+bus_publish() {
+  local topic="$1"; shift
+  case "$DR_FLEET_BUS_BACKEND" in
+    mock)  _mock_publish "$topic" "$@" ;;
+    redis)
+      _redis_require || return 1
+      local key; key="$(_stream_key "$topic")"
+      _redis XADD "$key" '*' "$@"
+      ;;
+    *)
+      printf 'ERR: unknown DR_FLEET_BUS_BACKEND=%q (valid: redis, mock)\n' \
+        "$DR_FLEET_BUS_BACKEND" >&2
+      return 1
+      ;;
+  esac
+}
+
+# bus_subscribe <topic> <group> <consumer> <block_ms>
+# Reads pending messages for the consumer group. Creates the group if absent.
+# Returns raw XREADGROUP output (or mock placeholder).
+bus_subscribe() {
+  local topic="$1" group="$2" consumer="$3"
+  local block_ms="${4:-0}"
+  case "$DR_FLEET_BUS_BACKEND" in
+    mock)  _mock_subscribe "$topic" "$group" "$consumer" "$block_ms" ;;
+    redis)
+      _redis_require || return 1
+      local key; key="$(_stream_key "$topic")"
+      # Create consumer group if it does not exist (MKSTREAM = create stream too)
+      _redis XGROUP CREATE "$key" "$group" '$' MKSTREAM 2>/dev/null || true
+      _redis XREADGROUP GROUP "$group" "$consumer" \
+        BLOCK "$block_ms" STREAMS "$key" '>'
+      ;;
+  esac
+}
+
+# bus_ack <topic> <group> <message_id>
+# Acknowledges a message so it is removed from the pending entries list.
+bus_ack() {
+  local topic="$1" group="$2" msg_id="$3"
+  case "$DR_FLEET_BUS_BACKEND" in
+    mock)  _mock_ack "$topic" "$group" "$msg_id" ;;
+    redis)
+      _redis_require || return 1
+      local key; key="$(_stream_key "$topic")"
+      _redis XACK "$key" "$group" "$msg_id"
+      ;;
+  esac
+}
+
+# bus_replay <topic> <from_id>
+# Replays messages from from_id to the end of the stream (XRANGE).
+# Use '-' as from_id to replay all messages.
+bus_replay() {
+  local topic="$1" from_id="${2:--}"
+  case "$DR_FLEET_BUS_BACKEND" in
+    mock)  _mock_replay "$topic" "$from_id" ;;
+    redis)
+      _redis_require || return 1
+      local key; key="$(_stream_key "$topic")"
+      _redis XRANGE "$key" "$from_id" '+'
+      ;;
+  esac
+}
+
+# ── CLI dispatch ──────────────────────────────────────────────────────────────
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  fn="${1:-}"; shift || true
+  [[ -n "$fn" ]] || { printf 'usage: bus_adapter.sh <fn> [args]\n' >&2; exit 2; }
+  "$fn" "$@"
+fi

--- a/plugins/dr-orchestrate/scripts/fleet_audit_consumer.sh
+++ b/plugins/dr-orchestrate/scripts/fleet_audit_consumer.sh
@@ -19,12 +19,14 @@ set -uo pipefail
 _self="${BASH_SOURCE[0]:-$0}"
 PLUGIN_DIR="$(cd "$(dirname "$_self")/.." && pwd)"
 BUS_ADAPTER="$PLUGIN_DIR/scripts/bus_adapter.sh"
+AUDIT_SINK="$PLUGIN_DIR/scripts/audit_sink.sh"
 
 : "${DR_ORCH_REDIS_URL:=redis://127.0.0.1:6379}"
 : "${DR_FLEET_BUS_BACKEND:=redis}"
 : "${DR_FLEET_AUDIT_GROUP:=obs}"
 : "${DR_FLEET_AUDIT_CONSUMER:=audit-consumer-1}"
 : "${DR_FLEET_BLOCK_MS:=5000}"
+: "${DR_FLEET_METRICS_DIR:=$PLUGIN_DIR/var/metrics}"
 
 MODE="loop"
 
@@ -51,17 +53,32 @@ _check() {
 }
 
 _process_entry() {
-  # raw: XREADGROUP response; full kv parsing is a future cycle enhancement
-  # shellcheck disable=SC2034
+  # Forward one audit-log entry to the obs metrics sink (JSONL).
+  # Reason fields are redacted before persistence (PRD § Security).
+  # Full structured parsing (field-by-field kv extraction) is deferred;
+  # current implementation redacts the raw blob and appends it to the daily
+  # obs sink so the obs aggregator can pick it up on the next --snapshot run.
+  # pending full sink wiring: backlog item "audit-consumer: typed kv forward to obs/compliance"
+  # (Source: discovered-during-auto)
   local raw="$1"
-  # TODO: forward to obs aggregator metrics and compliance sink
-  printf 'AUDIT [%s] group=%s received entry\n' \
+  local redacted_raw
+  redacted_raw="$(redact_reason "$raw")"
+
+  local sink_file
+  sink_file="$DR_FLEET_METRICS_DIR/audit-consumer-$(date -u +%Y-%m-%d).jsonl"
+  mkdir -p "$DR_FLEET_METRICS_DIR"
+  emit "$sink_file" \
+    "{\"ts\":\"$(date -u +%FT%TZ)\",\"group\":\"$DR_FLEET_AUDIT_GROUP\",\"raw\":\"$redacted_raw\"}"
+
+  printf 'AUDIT [%s] group=%s entry forwarded to obs sink\n' \
     "$(date -u +%FT%TZ)" "$DR_FLEET_AUDIT_GROUP"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   # shellcheck source=scripts/bus_adapter.sh
   source "$BUS_ADAPTER"
+  # shellcheck source=scripts/audit_sink.sh
+  source "$AUDIT_SINK"
 
   case "$MODE" in
     check) _check; exit 0 ;;

--- a/plugins/dr-orchestrate/scripts/fleet_audit_consumer.sh
+++ b/plugins/dr-orchestrate/scripts/fleet_audit_consumer.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# fleet_audit_consumer.sh — Consumer for fleet:audit-log stream.
+#
+# Subscribes to fleet:audit-log via consumer groups "obs" and "compliance".
+# Forwards entries to the obs aggregator and compliance sink.
+#
+# Usage:
+#   fleet_audit_consumer.sh [--group obs|compliance] [--once] [--check] [--help]
+#
+# Env:
+#   DR_ORCH_REDIS_URL       Redis URL (default redis://127.0.0.1:6379)
+#   DR_FLEET_BUS_BACKEND    "redis" or "mock" (default redis)
+#   DR_FLEET_AUDIT_GROUP    Consumer group (default obs)
+#   DR_FLEET_AUDIT_CONSUMER Consumer name (default audit-consumer-1)
+#   DR_FLEET_BLOCK_MS       XREADGROUP block timeout ms (default 5000)
+
+set -uo pipefail
+
+_self="${BASH_SOURCE[0]:-$0}"
+PLUGIN_DIR="$(cd "$(dirname "$_self")/.." && pwd)"
+BUS_ADAPTER="$PLUGIN_DIR/scripts/bus_adapter.sh"
+
+: "${DR_ORCH_REDIS_URL:=redis://127.0.0.1:6379}"
+: "${DR_FLEET_BUS_BACKEND:=redis}"
+: "${DR_FLEET_AUDIT_GROUP:=obs}"
+: "${DR_FLEET_AUDIT_CONSUMER:=audit-consumer-1}"
+: "${DR_FLEET_BLOCK_MS:=5000}"
+
+MODE="loop"
+
+# ── arg parser ────────────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --group)   DR_FLEET_AUDIT_GROUP="$2"; shift 2 ;;
+    --once)    MODE="once"; shift ;;
+    --check)   MODE="check"; shift ;;
+    --help)
+      printf 'usage: fleet_audit_consumer.sh [--group obs|compliance] [--once] [--check] [--help]\n'
+      exit 0
+      ;;
+    *) printf 'ERR: unknown flag %q\n' "$1" >&2; exit 1 ;;
+  esac
+done
+
+TOPIC="fleet:audit-log"
+
+_check() {
+  printf 'group=%s\nconsumer=%s\ntopic=%s\nbackend=%s\n' \
+    "$DR_FLEET_AUDIT_GROUP" "$DR_FLEET_AUDIT_CONSUMER" "$TOPIC" "$DR_FLEET_BUS_BACKEND"
+}
+
+_process_entry() {
+  # raw: XREADGROUP response; full kv parsing is a future cycle enhancement
+  # shellcheck disable=SC2034
+  local raw="$1"
+  # TODO: forward to obs aggregator metrics and compliance sink
+  printf 'AUDIT [%s] group=%s received entry\n' \
+    "$(date -u +%FT%TZ)" "$DR_FLEET_AUDIT_GROUP"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  # shellcheck source=scripts/bus_adapter.sh
+  source "$BUS_ADAPTER"
+
+  case "$MODE" in
+    check) _check; exit 0 ;;
+    once)
+      out=$(bus_subscribe "$TOPIC" "$DR_FLEET_AUDIT_GROUP" \
+        "$DR_FLEET_AUDIT_CONSUMER" "$DR_FLEET_BLOCK_MS") || true
+      _process_entry "$out"
+      exit 0
+      ;;
+    loop)
+      printf 'INFO: audit consumer group=%s starting\n' "$DR_FLEET_AUDIT_GROUP"
+      while true; do
+        out=$(bus_subscribe "$TOPIC" "$DR_FLEET_AUDIT_GROUP" \
+          "$DR_FLEET_AUDIT_CONSUMER" "$DR_FLEET_BLOCK_MS") || true
+        _process_entry "$out"
+      done
+      ;;
+  esac
+fi

--- a/plugins/dr-orchestrate/scripts/fleet_audit_trim.sh
+++ b/plugins/dr-orchestrate/scripts/fleet_audit_trim.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# fleet_audit_trim.sh — Archive-before-XTRIM for fleet:audit-log stream.
+#
+# Reads all entries from stream:fleet:audit-log via XRANGE, writes them to a
+# gzip-compressed JSONL archive file, then trims the stream to --max-len.
+#
+# Usage:
+#   fleet_audit_trim.sh [--max-len N] [--dry-run] [--help]
+#
+# Options:
+#   --max-len N    Keep this many entries after trim (default: 1000000)
+#   --dry-run      Print what would happen; do NOT trim or archive
+#
+# Env:
+#   DR_ORCH_REDIS_URL          Redis URL (default redis://127.0.0.1:6379)
+#   DR_FLEET_AUDIT_ARCHIVE_DIR Directory for archive files
+#                              (default: var/fleet/audit-archive relative to plugin root)
+#
+# Archive filename: <archive-dir>/YYYY-MM-DD.jsonl.gz (date = UTC today)
+# If the archive for today exists, new entries are appended before re-gzip.
+#
+# Cron recommendation: run once every 24h, e.g. 03:00 UTC
+
+set -uo pipefail
+
+PLUGIN_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+: "${DR_ORCH_REDIS_URL:=redis://127.0.0.1:6379}"
+: "${DR_FLEET_AUDIT_ARCHIVE_DIR:=$PLUGIN_DIR/var/fleet/audit-archive}"
+
+STREAM_KEY="stream:fleet:audit-log"
+MAX_LEN=1000000
+DRY_RUN=0
+
+_usage() {
+  printf 'usage: fleet_audit_trim.sh [--max-len N] [--dry-run] [--help]\n'
+  printf '  Archives stream:%s to JSONL.GZ before XTRIM.\n' "$STREAM_KEY"
+  printf 'env: DR_ORCH_REDIS_URL, DR_FLEET_AUDIT_ARCHIVE_DIR\n'
+}
+
+# ── arg parser ────────────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --max-len) MAX_LEN="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --help)    _usage; exit 0 ;;
+    *) printf 'ERR: unknown flag %q\n' "$1" >&2; exit 1 ;;
+  esac
+done
+
+# ── require redis-cli ─────────────────────────────────────────────────────────
+
+if ! command -v redis-cli >/dev/null 2>&1; then
+  printf 'ERR: redis-cli not found in PATH\n' >&2
+  exit 1
+fi
+
+# ── redis connectivity ────────────────────────────────────────────────────────
+
+if ! redis-cli -u "$DR_ORCH_REDIS_URL" ping 2>/dev/null | grep -q PONG; then
+  printf 'ERR: cannot reach Redis at %s\n' "$DR_ORCH_REDIS_URL" >&2
+  exit 1
+fi
+
+# ── stream length check ───────────────────────────────────────────────────────
+
+stream_len=$(redis-cli -u "$DR_ORCH_REDIS_URL" XLEN "$STREAM_KEY" 2>/dev/null || echo 0)
+
+if (( stream_len <= 0 )); then
+  printf 'INFO: stream %s has 0 entries — nothing to archive\n' "$STREAM_KEY"
+  exit 0
+fi
+
+printf 'INFO: stream %s has %d entries (max-len=%d)\n' "$STREAM_KEY" "$stream_len" "$MAX_LEN"
+
+# ── dry-run early exit ────────────────────────────────────────────────────────
+
+if (( DRY_RUN )); then
+  printf 'DRY-RUN: would archive %d entries → %s/YYYY-MM-DD.jsonl.gz\n' \
+    "$stream_len" "$DR_FLEET_AUDIT_ARCHIVE_DIR"
+  printf 'DRY-RUN: would trim stream to max-len=%d\n' "$MAX_LEN"
+  exit 0
+fi
+
+# ── archive ───────────────────────────────────────────────────────────────────
+
+mkdir -p "$DR_FLEET_AUDIT_ARCHIVE_DIR"
+
+today=$(date -u +%Y-%m-%d)
+archive_file="$DR_FLEET_AUDIT_ARCHIVE_DIR/${today}.jsonl.gz"
+tmp_jsonl=$(mktemp)
+
+# Trap to clean up temp file on exit
+trap 'rm -f "$tmp_jsonl"' EXIT
+
+# XRANGE returns pairs: <id> <field> <val> <field> <val> ...
+# We convert each entry to a JSON object line using awk.
+redis-cli -u "$DR_ORCH_REDIS_URL" XRANGE "$STREAM_KEY" - + \
+  | awk '
+    /^[0-9]+-[0-9]+$/ {
+      if (id != "") {
+        printf "{\"_id\":\"%s\"", id
+        for (k in fields) printf ",\"%s\":\"%s\"", k, fields[k]
+        printf "}\n"
+      }
+      id = $0; delete fields
+      next
+    }
+    /^[a-zA-Z_]/ && id != "" {
+      last_key = $0; next
+    }
+    id != "" && last_key != "" {
+      fields[last_key] = $0; last_key = ""
+    }
+    END {
+      if (id != "") {
+        printf "{\"_id\":\"%s\"", id
+        for (k in fields) printf ",\"%s\":\"%s\"", k, fields[k]
+        printf "}\n"
+      }
+    }
+  ' > "$tmp_jsonl"
+
+entry_count=$(wc -l < "$tmp_jsonl" | tr -d ' ')
+printf 'INFO: archiving %d entries to %s\n' "$entry_count" "$archive_file"
+
+# If archive for today exists, decompress + append + recompress
+if [[ -f "$archive_file" ]]; then
+  tmp_existing=$(mktemp)
+  trap 'rm -f "$tmp_jsonl" "$tmp_existing"' EXIT
+  gunzip -c "$archive_file" >> "$tmp_existing" 2>/dev/null || true
+  cat "$tmp_jsonl" >> "$tmp_existing"
+  gzip -c "$tmp_existing" > "${archive_file}.new"
+  mv "${archive_file}.new" "$archive_file"
+  rm -f "$tmp_existing"
+else
+  gzip -c "$tmp_jsonl" > "$archive_file"
+fi
+
+printf 'INFO: archive written: %s\n' "$archive_file"
+
+# ── trim ──────────────────────────────────────────────────────────────────────
+
+redis-cli -u "$DR_ORCH_REDIS_URL" XTRIM "$STREAM_KEY" MAXLEN "~" "$MAX_LEN" >/dev/null
+printf 'INFO: trimmed %s to maxlen~%d\n' "$STREAM_KEY" "$MAX_LEN"
+
+exit 0

--- a/plugins/dr-orchestrate/scripts/fleet_dashboard_server.sh
+++ b/plugins/dr-orchestrate/scripts/fleet_dashboard_server.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# fleet_dashboard_server.sh — Fleet observability dashboard (socat HTTP server).
+#
+# Serves static web/fleet-dashboard/ files and /fleet-graph.json endpoint
+# via socat. Binds to a Tailscale mesh IP (Tier 2) — never 0.0.0.0.
+#
+# Usage:
+#   fleet_dashboard_server.sh [--bind IP] [--port N] [--check] [--once] [--help]
+#
+# Security (F-sec-6 pattern from dr_orchestrate_server.sh):
+#   - Refuses 0.0.0.0 bind unless DR_FLEET_DASHBOARD_ALLOW_ANY_BIND=1
+#   - Default bind: DR_FLEET_DASHBOARD_BIND env (required for start mode)
+#   - Allowed: loopback (127.0.0.1, ::1) or Tailscale CGNAT range 100.x.x.x
+#
+# Env:
+#   DR_FLEET_DASHBOARD_BIND             Bind IP (no default — must be set)
+#   DR_FLEET_DASHBOARD_PORT             Port (default 8765)
+#   DR_FLEET_DASHBOARD_ALLOW_ANY_BIND   Set to 1 to permit non-mesh binds (not recommended)
+#   DR_FLEET_METRICS_DIR                Directory containing fleet-graph.json
+
+set -uo pipefail
+
+_self="${BASH_SOURCE[0]:-$0}"
+PLUGIN_DIR="$(cd "$(dirname "$_self")/.." && pwd)"
+
+: "${DR_FLEET_DASHBOARD_PORT:=8765}"
+: "${DR_FLEET_DASHBOARD_ALLOW_ANY_BIND:=0}"
+: "${DR_FLEET_METRICS_DIR:=$PLUGIN_DIR/var/metrics}"
+
+BIND_CLI=""
+MODE="start"
+
+# ── arg parser ────────────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bind)   BIND_CLI="$2"; shift 2 ;;
+    --port)   DR_FLEET_DASHBOARD_PORT="$2"; shift 2 ;;
+    --check)  MODE="check"; shift ;;
+    --once)   MODE="once"; shift ;;
+    --help)
+      printf 'usage: fleet_dashboard_server.sh [--bind IP] [--port N] [--check|--once]\n'
+      printf 'Serves fleet dashboard on tailnet IP. Never binds 0.0.0.0.\n'
+      exit 0
+      ;;
+    *) printf 'ERR: unknown flag %q\n' "$1" >&2; exit 1 ;;
+  esac
+done
+
+# CLI --bind overrides env
+[[ -n "$BIND_CLI" ]] && DR_FLEET_DASHBOARD_BIND="${BIND_CLI}"
+
+# ── bind address validation (F-sec-6 pattern) ────────────────────────────────
+
+_validate_bind() {
+  local bind="${DR_FLEET_DASHBOARD_BIND:-}"
+
+  # No bind address in check mode is allowed (we just print defaults)
+  if [[ "$MODE" == "check" ]] && [[ -z "$bind" ]]; then
+    return 0
+  fi
+
+  # If binding is required and not set
+  if [[ -z "$bind" ]]; then
+    printf 'ERR: DR_FLEET_DASHBOARD_BIND is required (set to Tailscale mesh IP)\n' >&2
+    return 1
+  fi
+
+  # Refuse public/any bind unless explicitly allowed
+  case "$bind" in
+    0.0.0.0|"::"|"0:0:0:0:0:0:0:0")
+      if [[ "$DR_FLEET_DASHBOARD_ALLOW_ANY_BIND" != "1" ]]; then
+        printf 'FATAL: bind %s is prohibited (Tier 3 exposure). Set DR_FLEET_DASHBOARD_ALLOW_ANY_BIND=1 with operator justification.\n' "$bind"
+        return 1
+      fi
+      printf 'WARN: permitting any-bind %s via DR_FLEET_DASHBOARD_ALLOW_ANY_BIND=1\n' "$bind" >&2
+      ;;
+    # Accept: loopback, Tailscale CGNAT 100.64.0.0/10, private RFC-1918
+    127.*|::1|100.6[4-9].*|100.[7-9][0-9].*|100.1[01][0-9].*|100.12[0-7].*|10.*|192.168.*|172.1[6-9].*|172.2[0-9].*|172.3[01].*)
+      ;;
+    *)
+      if [[ "$DR_FLEET_DASHBOARD_ALLOW_ANY_BIND" != "1" ]]; then
+        printf 'ERR: bind address %s is not a recognized mesh/private IP. Set DR_FLEET_DASHBOARD_BIND to a Tailscale IP (100.x.x.x).\n' "$bind" >&2
+        return 1
+      fi
+      ;;
+  esac
+  return 0
+}
+
+_check() {
+  local bind="${DR_FLEET_DASHBOARD_BIND:-not-set}"
+  _validate_bind || return 1
+  printf 'bind=%s\nport=%s\nmetrics_dir=%s\nallow_any_bind=%s\n' \
+    "$bind" "$DR_FLEET_DASHBOARD_PORT" \
+    "$DR_FLEET_METRICS_DIR" "$DR_FLEET_DASHBOARD_ALLOW_ANY_BIND"
+}
+
+# ── HTTP handler ──────────────────────────────────────────────────────────────
+
+_http_handler() {
+  local metrics_dir="$DR_FLEET_METRICS_DIR"
+  local web_root="$PLUGIN_DIR/web/fleet-dashboard"
+  local request_line
+  read -r request_line
+
+  local path
+  path=$(printf '%s' "$request_line" | awk '{print $2}')
+
+  # Skip remaining headers
+  while IFS= read -r header; do
+    [[ "$header" == $'\r' ]] || [[ -z "$header" ]] && break
+  done
+
+  case "$path" in
+    "/fleet-graph.json"|"/fleet-graph.json?"*)
+      local snap_file="$metrics_dir/fleet-graph.json"
+      if [[ -f "$snap_file" ]]; then
+        local size
+        size=$(wc -c < "$snap_file" | tr -d ' ')
+        printf 'HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: %s\r\nAccess-Control-Allow-Origin: *\r\n\r\n' "$size"
+        cat "$snap_file"
+      else
+        printf 'HTTP/1.1 404 Not Found\r\nContent-Length: 15\r\n\r\n{"error":"none"}'
+      fi
+      ;;
+    "/"|"/index.html")
+      local html_file="$web_root/index.html"
+      if [[ -f "$html_file" ]]; then
+        local size
+        size=$(wc -c < "$html_file" | tr -d ' ')
+        printf 'HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: %s\r\n\r\n' "$size"
+        cat "$html_file"
+      else
+        printf 'HTTP/1.1 404 Not Found\r\nContent-Length: 9\r\n\r\nnot found'
+      fi
+      ;;
+    *)
+      printf 'HTTP/1.1 404 Not Found\r\nContent-Length: 9\r\n\r\nnot found'
+      ;;
+  esac
+}
+
+export -f _http_handler
+export DR_FLEET_METRICS_DIR PLUGIN_DIR
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+case "$MODE" in
+  check)
+    _check
+    exit $?
+    ;;
+  once)
+    _validate_bind || exit 1
+    if ! command -v socat >/dev/null 2>&1; then
+      printf 'ERR: socat not installed\n' >&2
+      exit 2
+    fi
+    printf 'INFO: dashboard serving one connection on %s:%s\n' \
+      "${DR_FLEET_DASHBOARD_BIND:-127.0.0.1}" "$DR_FLEET_DASHBOARD_PORT"
+    socat -T 10 \
+      "TCP-LISTEN:${DR_FLEET_DASHBOARD_PORT},bind=${DR_FLEET_DASHBOARD_BIND:-127.0.0.1},reuseaddr" \
+      SYSTEM:'bash -c _http_handler',stderr,nofork
+    ;;
+  start)
+    _validate_bind || exit 1
+    if ! command -v socat >/dev/null 2>&1; then
+      printf 'ERR: socat not installed (brew install socat / apt install socat)\n' >&2
+      exit 2
+    fi
+    printf 'INFO: fleet dashboard on %s:%s (metrics: %s)\n' \
+      "${DR_FLEET_DASHBOARD_BIND}" "$DR_FLEET_DASHBOARD_PORT" "$DR_FLEET_METRICS_DIR"
+    exec socat -T 30 \
+      "TCP-LISTEN:${DR_FLEET_DASHBOARD_PORT},bind=${DR_FLEET_DASHBOARD_BIND},reuseaddr,fork,max-children=20" \
+      SYSTEM:'bash -c _http_handler',stderr
+    ;;
+esac

--- a/plugins/dr-orchestrate/scripts/fleet_monitor_consumer.sh
+++ b/plugins/dr-orchestrate/scripts/fleet_monitor_consumer.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# fleet_monitor_consumer.sh — Fleet monitoring consumer for CI and site checks.
+#
+# Consumes from fleet:monitoring-alerts via consumer groups monitor-dev /
+# monitor-main. On receiving an alert message, applies SLA threshold checks
+# and publishes an escalation back to fleet:task-events or Hermes.
+#
+# Usage:
+#   fleet_monitor_consumer.sh [--branch dev|main] [--once] [--check] [--help]
+#
+# Modes:
+#   (default)   Loop forever reading from monitoring-alerts
+#   --once      Read one batch then exit 0 (smoke / CI)
+#   --check     Print effective config and exit 0 (no Redis needed)
+#
+# Env:
+#   DR_ORCH_REDIS_URL              Redis URL (default redis://127.0.0.1:6379)
+#   DR_FLEET_BUS_BACKEND           "redis" or "mock" (default redis)
+#   DR_FLEET_MONITOR_GROUP         Consumer group override
+#   DR_FLEET_MONITOR_CONSUMER      Consumer name override
+#   DR_FLEET_MONITOR_SLA_WARN      Warn threshold in seconds (default 120)
+#   DR_FLEET_MONITOR_SLA_CRIT      Critical threshold in seconds (default 600)
+#   DR_FLEET_MONITOR_ALERT_STATE_DIR  State dir for idempotent dedup (default /tmp/fleet-monitor-state)
+#   DR_FLEET_MONITOR_BLOCK_MS      XREADGROUP block timeout ms (default 5000)
+
+set -uo pipefail
+
+# BASH_SOURCE[0] is empty when this script is sourced from a bats test.
+# Resolve PLUGIN_DIR robustly: prefer BASH_SOURCE path, fallback to script path.
+_self="${BASH_SOURCE[0]:-$0}"
+PLUGIN_DIR="$(cd "$(dirname "$_self")/.." && pwd)"
+BUS_ADAPTER="$PLUGIN_DIR/scripts/bus_adapter.sh"
+
+: "${DR_ORCH_REDIS_URL:=redis://127.0.0.1:6379}"
+: "${DR_FLEET_BUS_BACKEND:=redis}"
+: "${DR_FLEET_MONITOR_SLA_WARN:=120}"
+: "${DR_FLEET_MONITOR_SLA_CRIT:=600}"
+: "${DR_FLEET_MONITOR_ALERT_STATE_DIR:=/tmp/fleet-monitor-state}"
+: "${DR_FLEET_MONITOR_BLOCK_MS:=5000}"
+
+BRANCH="dev"
+MODE="loop"
+
+# ── arg parser ────────────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --branch) BRANCH="$2"; shift 2 ;;
+    --once)   MODE="once"; shift ;;
+    --check)  MODE="check"; shift ;;
+    --help)
+      printf 'usage: fleet_monitor_consumer.sh [--branch dev|main] [--once] [--check] [--help]\n'
+      printf 'Consumer group: monitor-<branch> on fleet:monitoring-alerts\n'
+      exit 0
+      ;;
+    *) printf 'ERR: unknown flag %q\n' "$1" >&2; exit 1 ;;
+  esac
+done
+
+# ── consumer group resolved from branch ──────────────────────────────────────
+
+: "${DR_FLEET_MONITOR_GROUP:=monitor-$BRANCH}"
+: "${DR_FLEET_MONITOR_CONSUMER:=monitor-consumer-1}"
+
+TOPIC="fleet:monitoring-alerts"
+
+_check() {
+  printf 'group=%s\nconsumer=%s\ntopic=%s\nsla_warn=%s\nsla_crit=%s\nbackend=%s\n' \
+    "$DR_FLEET_MONITOR_GROUP" "$DR_FLEET_MONITOR_CONSUMER" "$TOPIC" \
+    "$DR_FLEET_MONITOR_SLA_WARN" "$DR_FLEET_MONITOR_SLA_CRIT" \
+    "$DR_FLEET_BUS_BACKEND"
+}
+
+# ── idempotent dedup ──────────────────────────────────────────────────────────
+
+# idempotent_check <key>
+# Returns 0 if the key has NOT been seen before (new alert — process it).
+# Returns 1 if the key HAS been seen before (duplicate — skip it).
+# Side-effect: marks key as seen on first call.
+idempotent_check() {
+  local key="$1"
+  local state_dir="${DR_FLEET_MONITOR_ALERT_STATE_DIR:-/tmp/fleet-monitor-state}"
+  mkdir -p "$state_dir"
+  # Use sha256 of the key as the state file name to avoid special chars
+  local hash
+  hash=$(printf '%s' "$key" | shasum -a 256 2>/dev/null | awk '{print $1}' \
+    || printf '%s' "$key" | sha256sum | awk '{print $1}')
+  local state_file="$state_dir/$hash"
+  if [[ -f "$state_file" ]]; then
+    return 1  # already seen
+  fi
+  touch "$state_file"
+  return 0  # new
+}
+
+# ── alert processor ───────────────────────────────────────────────────────────
+
+_process_alert() {
+  # raw_output: raw XREADGROUP response (parsed in future cycle)
+  # shellcheck disable=SC2034
+  local raw_output="$1"
+  # TODO: parse kv-pairs from XREADGROUP output and apply SLA threshold checks
+  printf 'MONITOR [%s] received alert batch from %s\n' \
+    "$(date -u +%FT%TZ)" "$TOPIC"
+}
+
+# ── main entry (only when executed directly, not sourced) ────────────────────
+
+# Source bus adapter when executing; when sourced by tests only functions load.
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  # shellcheck source=scripts/bus_adapter.sh
+  source "$BUS_ADAPTER"
+
+  case "$MODE" in
+    check)
+      _check
+      exit 0
+      ;;
+    once)
+      output=$(bus_subscribe "$TOPIC" "$DR_FLEET_MONITOR_GROUP" \
+        "$DR_FLEET_MONITOR_CONSUMER" "$DR_FLEET_MONITOR_BLOCK_MS")
+      _process_alert "$output"
+      exit 0
+      ;;
+    loop)
+      printf 'INFO: starting monitor consumer group=%s consumer=%s\n' \
+        "$DR_FLEET_MONITOR_GROUP" "$DR_FLEET_MONITOR_CONSUMER"
+      while true; do
+        output=$(bus_subscribe "$TOPIC" "$DR_FLEET_MONITOR_GROUP" \
+          "$DR_FLEET_MONITOR_CONSUMER" "$DR_FLEET_MONITOR_BLOCK_MS") || true
+        _process_alert "$output"
+      done
+      ;;
+  esac
+fi

--- a/plugins/dr-orchestrate/scripts/fleet_obs_aggregator.sh
+++ b/plugins/dr-orchestrate/scripts/fleet_obs_aggregator.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# fleet_obs_aggregator.sh — Fleet observability aggregator.
+#
+# Reads from fleet:task-events and fleet:audit-log to build a force-directed
+# graph snapshot stored as var/metrics/fleet-graph.json.
+#
+# Usage:
+#   fleet_obs_aggregator.sh [--snapshot] [--check] [--help]
+#   fleet_obs_aggregator.sh --once    — process one batch from Redis
+#
+# Modes:
+#   --snapshot  Write fleet-graph.json from current state (mock or Redis)
+#   --check     Print config and exit 0
+#   --once      Subscribe one batch to obs consumer group and snapshot
+#   (default)   Continuous loop
+#
+# Env:
+#   DR_ORCH_REDIS_URL       Redis URL (default redis://127.0.0.1:6379)
+#   DR_FLEET_BUS_BACKEND    "redis" or "mock" (default redis)
+#   DR_FLEET_METRICS_DIR    Output directory (default: <plugin>/var/metrics)
+
+set -uo pipefail
+
+_self="${BASH_SOURCE[0]:-$0}"
+PLUGIN_DIR="$(cd "$(dirname "$_self")/.." && pwd)"
+BUS_ADAPTER="$PLUGIN_DIR/scripts/bus_adapter.sh"
+
+: "${DR_ORCH_REDIS_URL:=redis://127.0.0.1:6379}"
+: "${DR_FLEET_BUS_BACKEND:=redis}"
+: "${DR_FLEET_METRICS_DIR:=$PLUGIN_DIR/var/metrics}"
+
+MODE="loop"
+
+# ── arg parser ────────────────────────────────────────────────────────────────
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --snapshot) MODE="snapshot"; shift ;;
+    --check)    MODE="check"; shift ;;
+    --once)     MODE="once"; shift ;;
+    --help)
+      printf 'usage: fleet_obs_aggregator.sh [--snapshot|--check|--once|--help]\n'
+      printf 'Writes fleet-graph.json to DR_FLEET_METRICS_DIR.\n'
+      exit 0
+      ;;
+    *) printf 'ERR: unknown flag %q\n' "$1" >&2; exit 1 ;;
+  esac
+done
+
+# ── snapshot writer ───────────────────────────────────────────────────────────
+
+_write_snapshot() {
+  mkdir -p "$DR_FLEET_METRICS_DIR"
+
+  local snapshot_file="$DR_FLEET_METRICS_DIR/fleet-graph.json"
+  local ts
+  ts="$(date -u +%FT%TZ)"
+
+  # Collect nodes and edges from Redis if available; emit minimal structure
+  local nodes="[]"
+  local edges="[]"
+  local total_messages=0
+  local active_agents=0
+
+  if [[ "$DR_FLEET_BUS_BACKEND" == "redis" ]] \
+      && command -v redis-cli >/dev/null 2>&1 \
+      && redis-cli -u "$DR_ORCH_REDIS_URL" ping 2>/dev/null | grep -q PONG; then
+
+    # Count messages across all topics
+    for topic in "fleet:task-events" "fleet:monitoring-alerts" \
+                 "fleet:fleet-commands" "fleet:audit-log"; do
+      local count
+      count=$(redis-cli -u "$DR_ORCH_REDIS_URL" XLEN "stream:$topic" 2>/dev/null || echo 0)
+      total_messages=$(( total_messages + count ))
+    done
+
+    # Build nodes from recent task-events (last 200 entries)
+    nodes=$(redis-cli -u "$DR_ORCH_REDIS_URL" \
+      XREVRANGE "stream:fleet:task-events" + - COUNT 200 2>/dev/null \
+      | awk '
+          /^from$/ { getline; froms[$0]=1 }
+          /^to$/ { getline; tos[$0]=1 }
+          END {
+            n=0
+            for (a in froms) agents[n++]=a
+            for (a in tos) { if (!(a in froms)) agents[n++]=a }
+            printf "["
+            for (i=0; i<n; i++) {
+              if (i>0) printf ","
+              printf "{\"id\":\"%s\",\"role\":\"agent\",\"active\":true}", agents[i]
+            }
+            printf "]"
+          }
+        ' 2>/dev/null || echo "[]")
+
+    # Count approximate active agents
+    active_agents=$(printf '%s' "$nodes" | grep -o '"id"' | wc -l | tr -d ' ')
+  fi
+
+  # Write atomic JSON snapshot
+  local tmp_file="${snapshot_file}.tmp.$$"
+  cat > "$tmp_file" <<JSON
+{
+  "generated_at": "$ts",
+  "nodes": $nodes,
+  "edges": $edges,
+  "metrics": {
+    "total_messages": $total_messages,
+    "active_agents": $active_agents,
+    "snapshot_source": "$DR_FLEET_BUS_BACKEND"
+  }
+}
+JSON
+  mv -f "$tmp_file" "$snapshot_file"
+  printf 'INFO: snapshot written to %s\n' "$snapshot_file"
+}
+
+# ── check ─────────────────────────────────────────────────────────────────────
+
+_check() {
+  printf 'metrics_dir=%s\nbackend=%s\nredis_url=%s\n' \
+    "$DR_FLEET_METRICS_DIR" "$DR_FLEET_BUS_BACKEND" "$DR_ORCH_REDIS_URL"
+}
+
+# ── main ──────────────────────────────────────────────────────────────────────
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  # shellcheck source=scripts/bus_adapter.sh
+  source "$BUS_ADAPTER"
+
+  case "$MODE" in
+    check)    _check; exit 0 ;;
+    snapshot) _write_snapshot; exit 0 ;;
+    once)
+      _write_snapshot
+      # Drain one pending batch; discard output — snapshot is rebuilt after
+      bus_subscribe "fleet:task-events" "obs" "obs-consumer-1" 5000 >/dev/null 2>&1 || true
+      _write_snapshot
+      exit 0
+      ;;
+    loop)
+      printf 'INFO: obs aggregator starting (metrics_dir=%s)\n' "$DR_FLEET_METRICS_DIR"
+      while true; do
+        bus_subscribe "fleet:task-events" "obs" "obs-consumer-1" 10000 >/dev/null 2>&1 || true
+        _write_snapshot
+      done
+      ;;
+  esac
+fi

--- a/plugins/dr-orchestrate/scripts/fleet_pm_orchestrator.sh
+++ b/plugins/dr-orchestrate/scripts/fleet_pm_orchestrator.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env bash
+# fleet_pm_orchestrator.sh — PM orchestrator: timeout/unblock/reassign/kill.
+#
+# Commands:
+#   unblock-task  <task_id>            — marks task in_progress, publishes event
+#   reassign-level <task_id> <level>   — publishes level-reassigned event
+#   kill-agent     <session_id>        — kills tmux session + marks task failed
+#   timeout-check  [--dry-run]         — scans active tasks for timeout violations
+#   --check                            — print effective config and exit 0
+#   --help                             — print usage
+#
+# Env:
+#   DR_ORCH_REDIS_URL         Redis URL (default redis://127.0.0.1:6379)
+#   DR_FLEET_BUS_BACKEND      "redis" or "mock" (default redis)
+#   DR_FLEET_TASKS_FILE       Path to tasks.md
+#   DR_FLEET_TIMEOUT_L1       Max heartbeat gap in seconds for L1 (default 300)
+#   DR_FLEET_TIMEOUT_L2       Max heartbeat gap in seconds for L2 (default 900)
+#   DR_FLEET_TIMEOUT_L3L4     Max heartbeat gap in seconds for L3-L4 (default 1800)
+
+set -uo pipefail
+
+_self="${BASH_SOURCE[0]:-$0}"
+PLUGIN_DIR="$(cd "$(dirname "$_self")/.." && pwd)"
+BUS_ADAPTER="$PLUGIN_DIR/scripts/bus_adapter.sh"
+STATUS_ADAPTER="$PLUGIN_DIR/scripts/fleet_status_adapter.sh"
+
+: "${DR_ORCH_REDIS_URL:=redis://127.0.0.1:6379}"
+: "${DR_FLEET_BUS_BACKEND:=redis}"
+: "${DR_FLEET_TIMEOUT_L1:=300}"
+: "${DR_FLEET_TIMEOUT_L2:=900}"
+: "${DR_FLEET_TIMEOUT_L3L4:=1800}"
+
+# ── source dependencies (when not sourced ourselves) ─────────────────────────
+
+_load_deps() {
+  # shellcheck source=scripts/bus_adapter.sh
+  source "$BUS_ADAPTER"
+  # shellcheck source=scripts/fleet_status_adapter.sh
+  source "$STATUS_ADAPTER"
+}
+
+# ── pm_publish: publish a PM command event to fleet:task-events ───────────────
+
+pm_publish() {
+  local type="$1" task_id="$2"
+  shift 2
+  local msg_id
+  msg_id="pm-$(date +%s%3N)-$$"
+  bus_publish "fleet:task-events" \
+    id       "$msg_id" \
+    ts       "$(date -u +%FT%TZ)" \
+    type     "$type" \
+    from     "pm-orchestrator" \
+    to       "fleet-daemon" \
+    task_id  "$task_id" \
+    "$@" \
+    >/dev/null
+}
+
+# ── unblock-task <task_id> ────────────────────────────────────────────────────
+
+cmd_unblock_task() {
+  local task_id="$1"
+  [[ -n "$task_id" ]] || { printf 'ERR: task_id required\n' >&2; return 1; }
+  pm_publish "lifecycle" "$task_id" status "in_progress" reason "pm-unblock"
+  status_update "$task_id" "in_progress" "pm-unblock"
+  printf 'PM: unblocked %s\n' "$task_id"
+}
+
+# ── reassign-level <task_id> <level> ─────────────────────────────────────────
+
+cmd_reassign_level() {
+  local task_id="$1" new_level="${2:-}"
+  [[ -n "$task_id" ]]  || { printf 'ERR: task_id required\n' >&2; return 1; }
+  [[ -n "$new_level" ]] || { printf 'ERR: new_level required (e.g. L1 L2 L3 L4)\n' >&2; return 1; }
+  pm_publish "level-reassigned" "$task_id" new_level "$new_level"
+  printf 'PM: level of %s reassigned to %s\n' "$task_id" "$new_level"
+}
+
+# ── kill-agent <session_id> ───────────────────────────────────────────────────
+
+cmd_kill_agent() {
+  local session_id="${1:-}"
+  [[ -n "$session_id" ]] || { printf 'ERR: session_id required\n' >&2; return 1; }
+
+  # Kill tmux session if it exists
+  if command -v tmux >/dev/null 2>&1 && tmux has-session -t "$session_id" 2>/dev/null; then
+    tmux kill-session -t "$session_id"
+    printf 'PM: killed tmux session %s\n' "$session_id"
+  else
+    printf 'PM: tmux session %s not found (may already be gone)\n' "$session_id"
+  fi
+
+  # Publish kill event
+  local msg_id
+  msg_id="pm-kill-$(date +%s%3N)-$$"
+  bus_publish "fleet:task-events" \
+    id          "$msg_id" \
+    ts          "$(date -u +%FT%TZ)" \
+    type        "agent-killed" \
+    from        "pm-orchestrator" \
+    to          "fleet-daemon" \
+    session_id  "$session_id" \
+    >/dev/null
+  printf 'PM: kill-agent event published for session %s\n' "$session_id"
+}
+
+# ── timeout-check [--dry-run] ─────────────────────────────────────────────────
+
+cmd_timeout_check() {
+  local dry_run=0
+  [[ "${1:-}" == "--dry-run" ]] && dry_run=1
+
+  printf 'PM: timeout-check dry_run=%d (L1=%ds L2=%ds L3/L4=%ds)\n' \
+    "$dry_run" "$DR_FLEET_TIMEOUT_L1" "$DR_FLEET_TIMEOUT_L2" "$DR_FLEET_TIMEOUT_L3L4"
+
+  # TODO(operator): scan active tasks from tasks.md / Redis; compare last
+  # heartbeat timestamp against level-specific timeout; call kill-agent +
+  # reassign-level when exceeded. Heartbeat from fleet:task-events type=heartbeat.
+  printf 'PM: timeout-check completed (no active heartbeat data in dry-run)\n'
+}
+
+# ── check ─────────────────────────────────────────────────────────────────────
+
+_check() {
+  printf 'backend=%s\nredis_url=%s\ntimeout_L1=%s\ntimeout_L2=%s\ntimeout_L3L4=%s\n' \
+    "$DR_FLEET_BUS_BACKEND" "$DR_ORCH_REDIS_URL" \
+    "$DR_FLEET_TIMEOUT_L1" "$DR_FLEET_TIMEOUT_L2" "$DR_FLEET_TIMEOUT_L3L4"
+}
+
+# ── CLI dispatch ──────────────────────────────────────────────────────────────
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  _load_deps
+
+  case "${1:-}" in
+    unblock-task)
+      shift; cmd_unblock_task "$@" ;;
+    reassign-level)
+      shift; cmd_reassign_level "$@" ;;
+    kill-agent)
+      shift; cmd_kill_agent "$@" ;;
+    timeout-check)
+      shift; cmd_timeout_check "$@" ;;
+    --check)
+      _check ;;
+    --help)
+      printf 'usage: fleet_pm_orchestrator.sh <command> [args]\n'
+      printf 'commands: unblock-task <id>, reassign-level <id> <level>,\n'
+      printf '          kill-agent <session>, timeout-check [--dry-run],\n'
+      printf '          --check, --help\n'
+      exit 0
+      ;;
+    "")
+      printf 'ERR: command required. Run --help for usage.\n' >&2
+      exit 1
+      ;;
+    *)
+      printf 'ERR: unknown command %q\n' "$1" >&2
+      exit 1
+      ;;
+  esac
+fi

--- a/plugins/dr-orchestrate/scripts/fleet_status_adapter.sh
+++ b/plugins/dr-orchestrate/scripts/fleet_status_adapter.sh
@@ -1,0 +1,199 @@
+#!/usr/bin/env bash
+# fleet_status_adapter.sh — Task status port: read/write fleet task status.
+#
+# Provides status_get and status_update functions that integrate with:
+#   - Primary: fleet:task-events Redis Stream (XADD/XREVRANGE)
+#   - Fallback/secondary: datarim/tasks.md (atomic write via temp+mv + flock)
+#   - Future (stub): Munera billing API (DR_FLEET_MUNERA_ENABLE=1)
+#
+# Public functions:
+#   status_get    <task_id>                    → prints status string
+#   status_update <task_id> <status> [reason]  → publishes event + updates tasks.md
+#
+# Usage (standalone):
+#   fleet_status_adapter.sh get    <task_id>
+#   fleet_status_adapter.sh update <task_id> <status> [reason]
+#   fleet_status_adapter.sh --help
+#   fleet_status_adapter.sh --check
+#
+# Env:
+#   DR_ORCH_REDIS_URL       Redis URL (default redis://127.0.0.1:6379)
+#   DR_FLEET_BUS_BACKEND    "redis" or "mock" (default redis)
+#   DR_FLEET_TASKS_FILE     Path to tasks.md (default: auto-detected from cwd)
+#   DR_FLEET_MUNERA_ENABLE  Set to 1 to enable Munera stub (default 0)
+#   DR_FLEET_LOCK_TIMEOUT   flock timeout in seconds (default 5)
+
+set -uo pipefail
+
+_self="${BASH_SOURCE[0]:-$0}"
+PLUGIN_DIR="$(cd "$(dirname "$_self")/.." && pwd)"
+BUS_ADAPTER="$PLUGIN_DIR/scripts/bus_adapter.sh"
+
+: "${DR_ORCH_REDIS_URL:=redis://127.0.0.1:6379}"
+: "${DR_FLEET_BUS_BACKEND:=redis}"
+: "${DR_FLEET_MUNERA_ENABLE:=0}"
+: "${DR_FLEET_LOCK_TIMEOUT:=5}"
+
+# ── tasks.md location ─────────────────────────────────────────────────────────
+
+_find_tasks_file() {
+  # Explicit override takes priority
+  if [[ -n "${DR_FLEET_TASKS_FILE:-}" ]]; then
+    printf '%s' "$DR_FLEET_TASKS_FILE"
+    return
+  fi
+  # Walk up from cwd looking for datarim/tasks.md
+  local dir="$PWD"
+  while [[ "$dir" != "/" ]]; do
+    if [[ -f "$dir/datarim/tasks.md" ]]; then
+      printf '%s/datarim/tasks.md' "$dir"
+      return
+    fi
+    dir="$(dirname "$dir")"
+  done
+  printf ''
+}
+
+# ── status_get <task_id> ──────────────────────────────────────────────────────
+
+# Returns the latest status for the task. Checks Redis XREVRANGE first,
+# falls back to tasks.md grep.
+status_get() {
+  local task_id="$1"
+
+  # Try Redis XREVRANGE for the latest lifecycle event for this task
+  if [[ "$DR_FLEET_BUS_BACKEND" == "redis" ]] \
+      && command -v redis-cli >/dev/null 2>&1; then
+    local last_status
+    last_status=$(redis-cli -u "$DR_ORCH_REDIS_URL" \
+      XREVRANGE "stream:fleet:task-events" + - COUNT 100 2>/dev/null \
+      | awk -v tid="$task_id" '
+          /task_id/ { getline; if ($0 == tid) found=1 }
+          found && /status/ { getline; print $0; exit }
+        ' 2>/dev/null || true)
+    if [[ -n "$last_status" ]]; then
+      printf '%s\n' "$last_status"
+      return 0
+    fi
+  fi
+
+  # Fallback: grep tasks.md
+  local tasks_file
+  tasks_file="$(_find_tasks_file)"
+  if [[ -n "$tasks_file" ]] && [[ -f "$tasks_file" ]]; then
+    local status
+    # tasks.md format: | ID | Title | L | Status | Since |
+    status=$(grep -m1 "^| $task_id " "$tasks_file" 2>/dev/null \
+      | awk -F'|' '{gsub(/ /,"",$5); print $5}' || true)
+    if [[ -n "$status" ]]; then
+      printf '%s\n' "$status"
+      return 0
+    fi
+  fi
+
+  printf 'unknown\n'
+  return 0
+}
+
+# ── status_update <task_id> <status> [reason] ─────────────────────────────────
+
+# 1. Publishes lifecycle event to fleet:task-events (primary truth)
+# 2. Atomically updates tasks.md via temp+mv with advisory flock (secondary)
+status_update() {
+  local task_id="$1" new_status="$2" reason="${3:-}"
+
+  # Source bus adapter for publishing
+  # shellcheck source=scripts/bus_adapter.sh
+  source "$BUS_ADAPTER"
+
+  # Generate message ID
+  local msg_id
+  msg_id="status-$(date +%s%3N)-$$"
+
+  # Publish to fleet:task-events
+  bus_publish "fleet:task-events" \
+    id          "$msg_id" \
+    ts          "$(date -u +%FT%TZ)" \
+    type        "lifecycle" \
+    from        "pm-orchestrator" \
+    to          "fleet-daemon" \
+    task_id     "$task_id" \
+    status      "$new_status" \
+    reason      "$reason" \
+    >/dev/null
+
+  # Munera stub (future integration point)
+  if [[ "${DR_FLEET_MUNERA_ENABLE:-0}" == "1" ]]; then
+    # TODO(operator): call Munera billing API to sync task status
+    # DR_FLEET_MUNERA_HOST env required; stub returns success
+    printf 'STUB: Munera status_update not yet provisioned\n' >&2
+  fi
+
+  # Update tasks.md atomically
+  local tasks_file
+  tasks_file="$(_find_tasks_file)"
+  if [[ -z "$tasks_file" ]] || [[ ! -f "$tasks_file" ]]; then
+    printf 'WARN: tasks.md not found — skipping file update\n' >&2
+    return 0
+  fi
+
+  local tmp_file="${tasks_file}.tmp.$$"
+  # Try flock if available; fall back to direct write
+  if command -v flock >/dev/null 2>&1; then
+    (
+      flock -w "${DR_FLEET_LOCK_TIMEOUT}" 200 || {
+        printf 'WARN: flock timeout (%ss) — proceeding without lock\n' \
+          "$DR_FLEET_LOCK_TIMEOUT" >&2
+      }
+      # Rewrite tasks.md replacing the status column for the matching task ID
+      awk -v tid="$task_id" -v ns="$new_status" -F'|' '
+        /^\| / && $2 ~ "^[[:space:]]*"tid"[[:space:]]*$" {
+          $5 = " " ns " "
+          print $1 "|" $2 "|" $3 "|" $4 "|" $5 "|" $6
+          next
+        }
+        { print }
+      ' OFS='|' "$tasks_file" > "$tmp_file" \
+        && mv -f "$tmp_file" "$tasks_file"
+    ) 200>"${tasks_file}.lock"
+  else
+    awk -v tid="$task_id" -v ns="$new_status" -F'|' '
+      /^\| / && $2 ~ "^[[:space:]]*"tid"[[:space:]]*$" {
+        $5 = " " ns " "
+        print $1 "|" $2 "|" $3 "|" $4 "|" $5 "|" $6
+        next
+      }
+      { print }
+    ' OFS='|' "$tasks_file" > "$tmp_file" \
+      && mv -f "$tmp_file" "$tasks_file"
+  fi
+
+  return 0
+}
+
+# ── check / help ──────────────────────────────────────────────────────────────
+
+_check() {
+  local tasks_file
+  tasks_file="$(_find_tasks_file)"
+  printf 'backend=%s\nredis_url=%s\ntasks_file=%s\nmunera_enable=%s\n' \
+    "$DR_FLEET_BUS_BACKEND" "$DR_ORCH_REDIS_URL" \
+    "${tasks_file:-not-found}" "$DR_FLEET_MUNERA_ENABLE"
+}
+
+# ── CLI dispatch ──────────────────────────────────────────────────────────────
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  case "${1:-}" in
+    get)    shift; status_get "$@" ;;
+    update) shift; status_update "$@" ;;
+    --check) _check ;;
+    --help)
+      printf 'usage: fleet_status_adapter.sh get <task_id>\n'
+      printf '       fleet_status_adapter.sh update <task_id> <status> [reason]\n'
+      printf '       fleet_status_adapter.sh --check | --help\n'
+      exit 0
+      ;;
+    *) printf 'ERR: unknown command %q\n' "${1:-}" >&2; exit 1 ;;
+  esac
+fi

--- a/plugins/dr-orchestrate/scripts/fleet_status_adapter.sh
+++ b/plugins/dr-orchestrate/scripts/fleet_status_adapter.sh
@@ -28,6 +28,7 @@ set -uo pipefail
 _self="${BASH_SOURCE[0]:-$0}"
 PLUGIN_DIR="$(cd "$(dirname "$_self")/.." && pwd)"
 BUS_ADAPTER="$PLUGIN_DIR/scripts/bus_adapter.sh"
+AUDIT_SINK="$PLUGIN_DIR/scripts/audit_sink.sh"
 
 : "${DR_ORCH_REDIS_URL:=redis://127.0.0.1:6379}"
 : "${DR_FLEET_BUS_BACKEND:=redis}"
@@ -102,15 +103,21 @@ status_get() {
 status_update() {
   local task_id="$1" new_status="$2" reason="${3:-}"
 
-  # Source bus adapter for publishing
+  # Source bus adapter for publishing and audit sink for redaction
   # shellcheck source=scripts/bus_adapter.sh
   source "$BUS_ADAPTER"
+  # shellcheck source=scripts/audit_sink.sh
+  source "$AUDIT_SINK"
+
+  # Redact reason before it enters the fleet event stream (PRD § Security)
+  local safe_reason
+  safe_reason="$(redact_reason "$reason")"
 
   # Generate message ID
   local msg_id
   msg_id="status-$(date +%s%3N)-$$"
 
-  # Publish to fleet:task-events
+  # Publish to fleet:task-events (reason is redacted)
   bus_publish "fleet:task-events" \
     id          "$msg_id" \
     ts          "$(date -u +%FT%TZ)" \
@@ -119,7 +126,7 @@ status_update() {
     to          "fleet-daemon" \
     task_id     "$task_id" \
     status      "$new_status" \
-    reason      "$reason" \
+    reason      "$safe_reason" \
     >/dev/null
 
   # Munera stub (future integration point)

--- a/plugins/dr-orchestrate/tests/fleet/audit-log-replay.bats
+++ b/plugins/dr-orchestrate/tests/fleet/audit-log-replay.bats
@@ -1,0 +1,78 @@
+#!/usr/bin/env bats
+# audit-log-replay.bats — V-AC-3: audit log trim archives before XTRIM.
+# Integration tests skip (exit 77) when Redis unavailable.
+
+PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+AUDIT_TRIM="$PLUGIN_ROOT/scripts/fleet_audit_trim.sh"
+
+REDIS_URL="${DR_ORCH_REDIS_URL:-redis://127.0.0.1:6379}"
+
+setup() {
+  TMP="$(mktemp -d)"
+  export DR_FLEET_AUDIT_ARCHIVE_DIR="$TMP/archive"
+  export DR_ORCH_REDIS_URL="$REDIS_URL"
+  REDIS_AVAILABLE=0
+  if command -v redis-cli >/dev/null 2>&1 \
+      && redis-cli -u "$REDIS_URL" ping 2>/dev/null | grep -q PONG; then
+    REDIS_AVAILABLE=1
+  fi
+}
+
+teardown() {
+  rm -rf "$TMP"
+  if (( REDIS_AVAILABLE )); then
+    redis-cli -u "$REDIS_URL" DEL "stream:fleet:audit-log" >/dev/null 2>&1 || true
+  fi
+}
+
+# ── function existence (no Redis needed) ─────────────────────────────────────
+
+@test "V-AC-3: fleet_audit_trim.sh is executable" {
+  [ -x "$AUDIT_TRIM" ]
+}
+
+@test "V-AC-3: fleet_audit_trim.sh --help exits 0" {
+  run bash "$AUDIT_TRIM" --help
+  [ "$status" -eq 0 ]
+}
+
+@test "V-AC-3: fleet_audit_trim.sh --dry-run flag accepted" {
+  if (( ! REDIS_AVAILABLE )); then
+    skip "Redis not available"
+  fi
+  run bash "$AUDIT_TRIM" --dry-run
+  [ "$status" -eq 0 ]
+}
+
+# ── Redis integration ─────────────────────────────────────────────────────────
+
+@test "V-AC-3: trim archives entries before XTRIM" {
+  if (( ! REDIS_AVAILABLE )); then
+    skip "Redis not available"
+  fi
+  # Seed audit log stream with 5 entries
+  for i in $(seq 1 5); do
+    redis-cli -u "$REDIS_URL" XADD "stream:fleet:audit-log" '*' \
+      id "uuid-$i" ts "2026-06-09T00:00:0${i}Z" type audit from test to test >/dev/null
+  done
+  run bash "$AUDIT_TRIM" --max-len 2
+  [ "$status" -eq 0 ]
+  # Archive file should exist
+  archive_count=$(find "$DR_FLEET_AUDIT_ARCHIVE_DIR" -name "*.jsonl.gz" 2>/dev/null | wc -l | tr -d ' ')
+  [ "$archive_count" -gt 0 ]
+  # Stream should be trimmed
+  len=$(redis-cli -u "$REDIS_URL" XLEN "stream:fleet:audit-log")
+  [ "$len" -le 2 ]
+}
+
+@test "V-AC-3: trim creates archive directory if not exists" {
+  if (( ! REDIS_AVAILABLE )); then
+    skip "Redis not available"
+  fi
+  rm -rf "$DR_FLEET_AUDIT_ARCHIVE_DIR"
+  redis-cli -u "$REDIS_URL" XADD "stream:fleet:audit-log" '*' \
+    id "uuid-seed" ts "2026-06-09T00:00:00Z" type audit from test to test >/dev/null
+  run bash "$AUDIT_TRIM" --max-len 1000000
+  [ "$status" -eq 0 ]
+  [ -d "$DR_FLEET_AUDIT_ARCHIVE_DIR" ]
+}

--- a/plugins/dr-orchestrate/tests/fleet/bus-adapter-contract.bats
+++ b/plugins/dr-orchestrate/tests/fleet/bus-adapter-contract.bats
@@ -1,0 +1,125 @@
+#!/usr/bin/env bats
+# bus-adapter-contract.bats — V-AC-1: bus adapter exposes publish/subscribe/ack/replay
+# port functions. Runs with DR_FLEET_BUS_BACKEND=mock (no Redis required).
+
+PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+BUS_ADAPTER="$PLUGIN_ROOT/scripts/bus_adapter.sh"
+
+setup() {
+  export DR_FLEET_BUS_BACKEND=mock
+  export DR_ORCH_REDIS_URL="redis://127.0.0.1:6379"
+  TMP="$(mktemp -d)"
+  export DR_FLEET_MOCK_LOG="$TMP/mock.log"
+  export DR_FLEET_MOCK_XADD_ID="1700000000000-0"
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+# ── function existence ────────────────────────────────────────────────────────
+
+@test "V-AC-1: bus_publish function exists" {
+  run bash -c "source '$BUS_ADAPTER' && declare -f bus_publish"
+  [ "$status" -eq 0 ]
+}
+
+@test "V-AC-1: bus_subscribe function exists" {
+  run bash -c "source '$BUS_ADAPTER' && declare -f bus_subscribe"
+  [ "$status" -eq 0 ]
+}
+
+@test "V-AC-1: bus_ack function exists" {
+  run bash -c "source '$BUS_ADAPTER' && declare -f bus_ack"
+  [ "$status" -eq 0 ]
+}
+
+@test "V-AC-1: bus_replay function exists" {
+  run bash -c "source '$BUS_ADAPTER' && declare -f bus_replay"
+  [ "$status" -eq 0 ]
+}
+
+# ── mock backend: bus_publish logs XADD command ──────────────────────────────
+
+@test "V-AC-1 mock: bus_publish writes XADD record to mock log" {
+  run bash -c "
+    source '$BUS_ADAPTER'
+    bus_publish 'fleet:task-events' id uuid-1 ts 2026-06-09T00:00:00Z type lifecycle
+  "
+  [ "$status" -eq 0 ]
+  [ -f "$DR_FLEET_MOCK_LOG" ]
+  grep -q 'XADD' "$DR_FLEET_MOCK_LOG"
+}
+
+@test "V-AC-1 mock: bus_publish echoes the stream key in mock log" {
+  run bash -c "
+    source '$BUS_ADAPTER'
+    bus_publish 'fleet:task-events' id uuid-2 ts 2026-06-09T00:00:01Z type lifecycle
+  "
+  [ "$status" -eq 0 ]
+  grep -q 'fleet:task-events' "$DR_FLEET_MOCK_LOG"
+}
+
+@test "V-AC-1 mock: bus_publish returns mock message ID" {
+  run bash -c "
+    source '$BUS_ADAPTER'
+    bus_publish 'fleet:task-events' id uuid-3 ts 2026-06-09T00:00:02Z type lifecycle
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"1700000000000-0"* ]]
+}
+
+@test "V-AC-1 mock: bus_ack logs XACK command to mock log" {
+  run bash -c "
+    source '$BUS_ADAPTER'
+    bus_ack 'fleet:task-events' 'obs' '1700000000000-0'
+  "
+  [ "$status" -eq 0 ]
+  grep -q 'XACK' "$DR_FLEET_MOCK_LOG"
+}
+
+@test "V-AC-1 mock: bus_replay logs XRANGE command to mock log" {
+  run bash -c "
+    source '$BUS_ADAPTER'
+    bus_replay 'fleet:audit-log' '-'
+  "
+  [ "$status" -eq 0 ]
+  grep -q 'XRANGE' "$DR_FLEET_MOCK_LOG"
+}
+
+@test "V-AC-1 mock: bus_subscribe logs XREADGROUP command to mock log" {
+  run bash -c "
+    source '$BUS_ADAPTER'
+    bus_subscribe 'fleet:task-events' 'obs' 'consumer-1' 100
+  "
+  [ "$status" -eq 0 ]
+  grep -q 'XREADGROUP' "$DR_FLEET_MOCK_LOG"
+}
+
+# ── topic names ──────────────────────────────────────────────────────────────
+
+@test "V-AC-1: four topic constants defined" {
+  run bash -c "
+    source '$BUS_ADAPTER'
+    echo \"\$FLEET_TOPIC_TASK_EVENTS\"
+    echo \"\$FLEET_TOPIC_MONITORING_ALERTS\"
+    echo \"\$FLEET_TOPIC_FLEET_COMMANDS\"
+    echo \"\$FLEET_TOPIC_AUDIT_LOG\"
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"fleet:task-events"* ]]
+  [[ "$output" == *"fleet:monitoring-alerts"* ]]
+  [[ "$output" == *"fleet:fleet-commands"* ]]
+  [[ "$output" == *"fleet:audit-log"* ]]
+}
+
+# ── backend guard ─────────────────────────────────────────────────────────────
+
+@test "V-AC-1: unknown backend exits non-zero" {
+  run bash -c "
+    export DR_FLEET_BUS_BACKEND=unknown
+    source '$BUS_ADAPTER' 2>/dev/null || true
+    bus_publish 'fleet:task-events' id x ts y type lifecycle 2>&1
+  "
+  [ "$status" -ne 0 ]
+}

--- a/plugins/dr-orchestrate/tests/fleet/integration/01-basic-publish.bats
+++ b/plugins/dr-orchestrate/tests/fleet/integration/01-basic-publish.bats
@@ -1,0 +1,150 @@
+#!/usr/bin/env bats
+# integration/01-basic-publish.bats — V-AC-8: end-to-end publish via real Redis.
+# Skips (exit 77) if Redis unavailable — not a failure, just no local broker.
+
+PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+BUS_ADAPTER="$PLUGIN_ROOT/scripts/bus_adapter.sh"
+VALIDATOR="$PLUGIN_ROOT/bin/fleet-validate-message.sh"
+
+REDIS_URL="${DR_ORCH_REDIS_URL:-redis://127.0.0.1:6379}"
+
+setup() {
+  TMP="$(mktemp -d)"
+  export DR_FLEET_BUS_BACKEND=redis
+  export DR_ORCH_REDIS_URL="$REDIS_URL"
+  REDIS_AVAILABLE=0
+  if command -v redis-cli >/dev/null 2>&1 \
+      && redis-cli -u "$REDIS_URL" ping 2>/dev/null | grep -q PONG; then
+    REDIS_AVAILABLE=1
+  fi
+}
+
+teardown() {
+  rm -rf "$TMP"
+  if (( REDIS_AVAILABLE )); then
+    redis-cli -u "$REDIS_URL" DEL \
+      "stream:fleet:task-events" \
+      "stream:fleet:monitoring-alerts" \
+      "stream:fleet:fleet-commands" \
+      "stream:fleet:audit-log" >/dev/null 2>&1 || true
+  fi
+}
+
+# ── redis ping gate ───────────────────────────────────────────────────────────
+
+@test "V-AC-8 prereq: Redis reachable or skip" {
+  if (( ! REDIS_AVAILABLE )); then
+    skip "Redis not available (redis-cli missing or broker not running) — not a failure"
+  fi
+  run redis-cli -u "$REDIS_URL" ping
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"PONG"* ]]
+}
+
+# ── four topics created on first publish ─────────────────────────────────────
+
+@test "V-AC-8: publish to fleet:task-events creates stream" {
+  if (( ! REDIS_AVAILABLE )); then
+    skip "Redis not available"
+  fi
+  run bash -c "source '$BUS_ADAPTER' && bus_publish 'fleet:task-events' \
+    id '550e8400-e29b-41d4-a716-446655440010' \
+    ts '2026-06-09T10:00:00Z' \
+    type 'lifecycle' \
+    from 'test-agent' \
+    to 'pm-orchestrator'"
+  [ "$status" -eq 0 ]
+  len=$(redis-cli -u "$REDIS_URL" XLEN "stream:fleet:task-events")
+  [ "$len" -ge 1 ]
+}
+
+@test "V-AC-8: publish to fleet:monitoring-alerts creates stream" {
+  if (( ! REDIS_AVAILABLE )); then
+    skip "Redis not available"
+  fi
+  run bash -c "source '$BUS_ADAPTER' && bus_publish 'fleet:monitoring-alerts' \
+    id '550e8400-e29b-41d4-a716-446655440011' \
+    ts '2026-06-09T10:00:01Z' \
+    type 'alert' \
+    from 'monitor-dev' \
+    to 'pm-orchestrator'"
+  [ "$status" -eq 0 ]
+  len=$(redis-cli -u "$REDIS_URL" XLEN "stream:fleet:monitoring-alerts")
+  [ "$len" -ge 1 ]
+}
+
+@test "V-AC-8: publish to fleet:fleet-commands creates stream" {
+  if (( ! REDIS_AVAILABLE )); then
+    skip "Redis not available"
+  fi
+  run bash -c "source '$BUS_ADAPTER' && bus_publish 'fleet:fleet-commands' \
+    id '550e8400-e29b-41d4-a716-446655440012' \
+    ts '2026-06-09T10:00:02Z' \
+    type 'command' \
+    from 'pm-orchestrator' \
+    to 'fleet-daemon'"
+  [ "$status" -eq 0 ]
+  len=$(redis-cli -u "$REDIS_URL" XLEN "stream:fleet:fleet-commands")
+  [ "$len" -ge 1 ]
+}
+
+@test "V-AC-8: publish to fleet:audit-log creates stream" {
+  if (( ! REDIS_AVAILABLE )); then
+    skip "Redis not available"
+  fi
+  run bash -c "source '$BUS_ADAPTER' && bus_publish 'fleet:audit-log' \
+    id '550e8400-e29b-41d4-a716-446655440013' \
+    ts '2026-06-09T10:00:03Z' \
+    type 'audit' \
+    from 'agent-1' \
+    to 'audit-log'"
+  [ "$status" -eq 0 ]
+  len=$(redis-cli -u "$REDIS_URL" XLEN "stream:fleet:audit-log")
+  [ "$len" -ge 1 ]
+}
+
+# ── message ID returned ───────────────────────────────────────────────────────
+
+@test "V-AC-8: bus_publish returns a Redis stream message ID" {
+  if (( ! REDIS_AVAILABLE )); then
+    skip "Redis not available"
+  fi
+  result=$(bash -c "source '$BUS_ADAPTER' && bus_publish 'fleet:task-events' \
+    id '550e8400-e29b-41d4-a716-446655440014' \
+    ts '2026-06-09T10:00:04Z' \
+    type 'heartbeat' \
+    from 'agent-1' \
+    to 'pm-orchestrator'")
+  # Redis stream ID format: <ms>-<seq>
+  [[ "$result" =~ ^[0-9]+-[0-9]+$ ]]
+}
+
+# ── replay retrieves published messages ──────────────────────────────────────
+
+@test "V-AC-8: bus_replay retrieves published messages from XRANGE" {
+  if (( ! REDIS_AVAILABLE )); then
+    skip "Redis not available"
+  fi
+  # Publish a message
+  bash -c "source '$BUS_ADAPTER' && bus_publish 'fleet:task-events' \
+    id 'replay-uuid-001' ts '2026-06-09T10:00:05Z' type lifecycle from test to pm" >/dev/null
+  # Replay from beginning
+  run bash -c "source '$BUS_ADAPTER' && bus_replay 'fleet:task-events' '-'"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"replay-uuid-001"* ]]
+}
+
+# ── validator rejects bad message before publish ──────────────────────────────
+
+@test "V-AC-8: validate+publish rejects message with invalid type" {
+  if (( ! REDIS_AVAILABLE )); then
+    skip "Redis not available"
+  fi
+  run bash "$VALIDATOR" \
+    --id "bad-type-uuid" \
+    --ts "2026-06-09T10:00:00Z" \
+    --type "invalid-type" \
+    --from "test" \
+    --to "pm"
+  [ "$status" -eq 1 ]
+}

--- a/plugins/dr-orchestrate/tests/fleet/integration/02-reconnect.bats
+++ b/plugins/dr-orchestrate/tests/fleet/integration/02-reconnect.bats
@@ -1,0 +1,102 @@
+#!/usr/bin/env bats
+# integration/02-reconnect.bats — V-AC-8: bus adapter reconnects after Redis
+# restart / consumer group re-creation. Skips when Redis unavailable.
+
+PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/../../.." && pwd)"
+BUS_ADAPTER="$PLUGIN_ROOT/scripts/bus_adapter.sh"
+
+REDIS_URL="${DR_ORCH_REDIS_URL:-redis://127.0.0.1:6379}"
+
+setup() {
+  export DR_FLEET_BUS_BACKEND=redis
+  export DR_ORCH_REDIS_URL="$REDIS_URL"
+  REDIS_AVAILABLE=0
+  if command -v redis-cli >/dev/null 2>&1 \
+      && redis-cli -u "$REDIS_URL" ping 2>/dev/null | grep -q PONG; then
+    REDIS_AVAILABLE=1
+  fi
+}
+
+teardown() {
+  if (( REDIS_AVAILABLE )); then
+    redis-cli -u "$REDIS_URL" DEL \
+      "stream:fleet:task-events" \
+      "stream:fleet:reconnect-test" >/dev/null 2>&1 || true
+  fi
+}
+
+# ── consumer group auto-creation ──────────────────────────────────────────────
+
+@test "V-AC-8 reconnect: bus_subscribe creates consumer group if absent" {
+  if (( ! REDIS_AVAILABLE )); then
+    skip "Redis not available"
+  fi
+  # Subscribe with a fresh group name (should auto-create via MKSTREAM)
+  run bash -c "
+    export DR_FLEET_BUS_BACKEND=redis
+    source '$BUS_ADAPTER'
+    bus_subscribe 'fleet:reconnect-test' 'test-group-$$' 'consumer-1' 100
+  "
+  [ "$status" -eq 0 ]
+  # Group should exist now
+  info=$(redis-cli -u "$REDIS_URL" XINFO GROUPS "stream:fleet:reconnect-test" 2>/dev/null || echo "")
+  [[ "$info" == *"test-group"* ]] || [[ "$info" == *"group"* ]]
+}
+
+@test "V-AC-8 reconnect: publish after subscribe still works" {
+  if (( ! REDIS_AVAILABLE )); then
+    skip "Redis not available"
+  fi
+  # Subscribe first (creates group), then publish
+  bash -c "
+    export DR_FLEET_BUS_BACKEND=redis
+    source '$BUS_ADAPTER'
+    bus_subscribe 'fleet:task-events' 'reconnect-obs' 'consumer-1' 100
+  " >/dev/null 2>&1 || true
+
+  run bash -c "
+    export DR_FLEET_BUS_BACKEND=redis
+    source '$BUS_ADAPTER'
+    bus_publish 'fleet:task-events' \
+      id 'reconnect-001' ts '2026-06-09T11:00:00Z' type lifecycle \
+      from 'test' to 'pm'
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" =~ ^[0-9]+-[0-9]+$ ]]
+}
+
+@test "V-AC-8 reconnect: XACK removes message from pending entries" {
+  if (( ! REDIS_AVAILABLE )); then
+    skip "Redis not available"
+  fi
+  # Publish, subscribe (gets message in pending), then ack
+  msg_id=$(bash -c "
+    export DR_FLEET_BUS_BACKEND=redis
+    source '$BUS_ADAPTER'
+    bus_publish 'fleet:task-events' \
+      id 'ack-test-001' ts '2026-06-09T11:00:01Z' type lifecycle from test to pm
+  " 2>/dev/null)
+
+  bash -c "
+    export DR_FLEET_BUS_BACKEND=redis
+    source '$BUS_ADAPTER'
+    bus_subscribe 'fleet:task-events' 'ack-group' 'consumer-1' 100
+  " >/dev/null 2>&1 || true
+
+  run bash -c "
+    export DR_FLEET_BUS_BACKEND=redis
+    source '$BUS_ADAPTER'
+    bus_ack 'fleet:task-events' 'ack-group' '$msg_id'
+  "
+  [ "$status" -eq 0 ]
+}
+
+# ── validate-message-schema rejection via real bus ────────────────────────────
+
+@test "V-AC-8 schema: invalid message rejected by validator before reaching bus" {
+  # Validator test — no Redis needed
+  run bash "$PLUGIN_ROOT/bin/fleet-validate-message.sh" \
+    --id "bad-$$" --ts "not-a-date" --type "lifecycle" --from "x" --to "y"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ts"* ]]
+}

--- a/plugins/dr-orchestrate/tests/fleet/monitor-sla.bats
+++ b/plugins/dr-orchestrate/tests/fleet/monitor-sla.bats
@@ -1,0 +1,105 @@
+#!/usr/bin/env bats
+# monitor-sla.bats — V-AC-4: monitoring consumer SLA timing + idempotent filter.
+# Contract tests run without Redis. Integration tests skip when Redis absent.
+
+PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+MONITOR="$PLUGIN_ROOT/scripts/fleet_monitor_consumer.sh"
+
+REDIS_URL="${DR_ORCH_REDIS_URL:-redis://127.0.0.1:6379}"
+
+setup() {
+  TMP="$(mktemp -d)"
+  export DR_ORCH_REDIS_URL="$REDIS_URL"
+  export DR_FLEET_BUS_BACKEND=mock
+  export DR_FLEET_MOCK_LOG="$TMP/mock.log"
+  export DR_FLEET_MOCK_XADD_ID="1700000000000-0"
+  REDIS_AVAILABLE=0
+  if command -v redis-cli >/dev/null 2>&1 \
+      && redis-cli -u "$REDIS_URL" ping 2>/dev/null | grep -q PONG; then
+    REDIS_AVAILABLE=1
+  fi
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+# ── executable + help ─────────────────────────────────────────────────────────
+
+@test "V-AC-4: fleet_monitor_consumer.sh is executable" {
+  [ -x "$MONITOR" ]
+}
+
+@test "V-AC-4: fleet_monitor_consumer.sh --help exits 0" {
+  run bash "$MONITOR" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"usage"* ]]
+}
+
+# ── check mode — no Redis needed ──────────────────────────────────────────────
+
+@test "V-AC-4: --check mode prints config and exits 0" {
+  run bash "$MONITOR" --check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"group"* ]]
+}
+
+# ── SLA threshold configuration ───────────────────────────────────────────────
+
+@test "V-AC-4: SLA threshold env vars accepted" {
+  DR_FLEET_MONITOR_SLA_WARN=60 \
+  DR_FLEET_MONITOR_SLA_CRIT=300 \
+  run bash "$MONITOR" --check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"sla_warn"* ]]
+}
+
+# ── idempotent filter: no duplicate alerts ────────────────────────────────────
+
+@test "V-AC-4: idempotent_check function exists" {
+  run bash -c "source '$MONITOR' && declare -f idempotent_check"
+  [ "$status" -eq 0 ]
+}
+
+@test "V-AC-4: idempotent_check returns 0 for new alert key" {
+  run bash -c "
+    export DR_FLEET_MONITOR_ALERT_STATE_DIR='$TMP/state'
+    source '$MONITOR'
+    idempotent_check 'test-alert-key-001'
+  "
+  [ "$status" -eq 0 ]
+}
+
+@test "V-AC-4: idempotent_check returns 1 for already-seen key" {
+  run bash -c "
+    export DR_FLEET_MONITOR_ALERT_STATE_DIR='$TMP/state'
+    source '$MONITOR'
+    idempotent_check 'test-alert-key-002'
+    idempotent_check 'test-alert-key-002'
+  "
+  [ "$status" -eq 1 ]
+}
+
+# ── consumer groups ───────────────────────────────────────────────────────────
+
+@test "V-AC-4: --check shows monitor-dev consumer group" {
+  run bash "$MONITOR" --check --branch dev
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"monitor-dev"* ]]
+}
+
+@test "V-AC-4: --check shows monitor-main consumer group" {
+  run bash "$MONITOR" --check --branch main
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"monitor-main"* ]]
+}
+
+# ── Redis integration: single pass ───────────────────────────────────────────
+
+@test "V-AC-4: --once mode processes one batch and exits 0" {
+  if (( ! REDIS_AVAILABLE )); then
+    skip "Redis not available"
+  fi
+  run bash "$MONITOR" --once --branch dev
+  [ "$status" -eq 0 ]
+}

--- a/plugins/dr-orchestrate/tests/fleet/obs-aggregation.bats
+++ b/plugins/dr-orchestrate/tests/fleet/obs-aggregation.bats
@@ -106,6 +106,12 @@ teardown() {
 
 # ── obs consumer ─────────────────────────────────────────────────────────────
 
+@test "V-AC-6: index.html contains force-graph token (V-AC-6 success criterion)" {
+  local html="$PLUGIN_ROOT/web/fleet-dashboard/index.html"
+  [ -f "$html" ]
+  grep -q 'force-graph' "$html"
+}
+
 @test "V-AC-6: fleet_audit_consumer.sh is executable" {
   [ -x "$PLUGIN_ROOT/scripts/fleet_audit_consumer.sh" ]
 }

--- a/plugins/dr-orchestrate/tests/fleet/obs-aggregation.bats
+++ b/plugins/dr-orchestrate/tests/fleet/obs-aggregation.bats
@@ -1,0 +1,116 @@
+#!/usr/bin/env bats
+# obs-aggregation.bats — V-AC-6: observability aggregator + dashboard reachable.
+# V-AC-7: dashboard binds tailnet IP (not 0.0.0.0).
+
+PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+OBS="$PLUGIN_ROOT/scripts/fleet_obs_aggregator.sh"
+DASHBOARD="$PLUGIN_ROOT/scripts/fleet_dashboard_server.sh"
+
+REDIS_URL="${DR_ORCH_REDIS_URL:-redis://127.0.0.1:6379}"
+
+setup() {
+  TMP="$(mktemp -d)"
+  export DR_FLEET_METRICS_DIR="$TMP/metrics"
+  export DR_ORCH_REDIS_URL="$REDIS_URL"
+  export DR_FLEET_BUS_BACKEND=mock
+  export DR_FLEET_MOCK_LOG="$TMP/mock.log"
+  export DR_FLEET_MOCK_XADD_ID="1700000000000-0"
+  REDIS_AVAILABLE=0
+  if command -v redis-cli >/dev/null 2>&1 \
+      && redis-cli -u "$REDIS_URL" ping 2>/dev/null | grep -q PONG; then
+    REDIS_AVAILABLE=1
+  fi
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+# ── obs aggregator executable + help ─────────────────────────────────────────
+
+@test "V-AC-6: fleet_obs_aggregator.sh is executable" {
+  [ -x "$OBS" ]
+}
+
+@test "V-AC-6: fleet_obs_aggregator.sh --help exits 0" {
+  run bash "$OBS" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"usage"* ]]
+}
+
+@test "V-AC-6: --check mode prints metrics dir and exits 0" {
+  run bash "$OBS" --check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"metrics_dir"* ]]
+}
+
+# ── snapshot file creation ────────────────────────────────────────────────────
+
+@test "V-AC-6: --snapshot creates fleet-graph.json" {
+  run bash "$OBS" --snapshot
+  [ "$status" -eq 0 ]
+  [ -f "$DR_FLEET_METRICS_DIR/fleet-graph.json" ]
+}
+
+@test "V-AC-6: fleet-graph.json contains nodes and edges keys" {
+  bash "$OBS" --snapshot
+  local snap="$DR_FLEET_METRICS_DIR/fleet-graph.json"
+  grep -q '"nodes"' "$snap"
+  grep -q '"edges"' "$snap"
+}
+
+@test "V-AC-6: fleet-graph.json contains metrics key" {
+  bash "$OBS" --snapshot
+  local snap="$DR_FLEET_METRICS_DIR/fleet-graph.json"
+  grep -q '"metrics"' "$snap"
+}
+
+# ── dashboard server ──────────────────────────────────────────────────────────
+
+@test "V-AC-7: fleet_dashboard_server.sh is executable" {
+  [ -x "$DASHBOARD" ]
+}
+
+@test "V-AC-7: fleet_dashboard_server.sh --help exits 0" {
+  run bash "$DASHBOARD" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"usage"* ]]
+}
+
+@test "V-AC-7: --check mode prints bind address and exits 0" {
+  run bash "$DASHBOARD" --check
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"bind"* ]]
+}
+
+# ── network-exposure: dashboard MUST NOT bind 0.0.0.0 ────────────────────────
+
+@test "V-AC-7: dashboard refuses 0.0.0.0 bind without explicit allow" {
+  run bash "$DASHBOARD" --check \
+    --bind 0.0.0.0
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"ERR"* ]] || [[ "$output" == *"FATAL"* ]]
+}
+
+@test "V-AC-7: dashboard accepts tailnet IP bind" {
+  run bash "$DASHBOARD" --check \
+    --bind 100.64.0.1
+  [ "$status" -eq 0 ]
+}
+
+@test "V-AC-7: dashboard accepts loopback bind" {
+  run bash "$DASHBOARD" --check \
+    --bind 127.0.0.1
+  [ "$status" -eq 0 ]
+}
+
+# ── obs consumer ─────────────────────────────────────────────────────────────
+
+@test "V-AC-6: fleet_audit_consumer.sh is executable" {
+  [ -x "$PLUGIN_ROOT/scripts/fleet_audit_consumer.sh" ]
+}
+
+@test "V-AC-6: fleet_audit_consumer.sh --check exits 0" {
+  run bash "$PLUGIN_ROOT/scripts/fleet_audit_consumer.sh" --check
+  [ "$status" -eq 0 ]
+}

--- a/plugins/dr-orchestrate/tests/fleet/pm-orchestrator.bats
+++ b/plugins/dr-orchestrate/tests/fleet/pm-orchestrator.bats
@@ -154,3 +154,21 @@ teardown() {
   run bash "$PM" timeout-check --dry-run
   [ "$status" -eq 0 ]
 }
+
+# ── redaction on fleet write-path (PRD § Security) ───────────────────────────
+
+@test "security: status_update redacts secret-bearing reason before bus publish" {
+  run bash -c "
+    export DR_FLEET_TASKS_FILE='$TMP/tasks.md'
+    export DR_FLEET_BUS_BACKEND=mock
+    export DR_FLEET_MOCK_LOG='$TMP/mock-redact.log'
+    source '$STATUS'
+    status_update 'TUNE-0001' 'blocked' 'token=supersecret123 deploy failed'
+  "
+  [ "$status" -eq 0 ]
+  # raw secret must not appear in the bus payload
+  run grep 'supersecret123' "$TMP/mock-redact.log"
+  [ "$status" -ne 0 ]
+  # REDACTED placeholder must appear
+  grep -q 'REDACTED' "$TMP/mock-redact.log"
+}

--- a/plugins/dr-orchestrate/tests/fleet/pm-orchestrator.bats
+++ b/plugins/dr-orchestrate/tests/fleet/pm-orchestrator.bats
@@ -1,0 +1,156 @@
+#!/usr/bin/env bats
+# pm-orchestrator.bats — V-AC-5: PM timeout/unblock/reassign/kill commands.
+# Contract tests run without Redis. Integration tests skip when Redis absent.
+
+PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+PM="$PLUGIN_ROOT/scripts/fleet_pm_orchestrator.sh"
+STATUS="$PLUGIN_ROOT/scripts/fleet_status_adapter.sh"
+
+REDIS_URL="${DR_ORCH_REDIS_URL:-redis://127.0.0.1:6379}"
+
+setup() {
+  TMP="$(mktemp -d)"
+  export DR_FLEET_BUS_BACKEND=mock
+  export DR_FLEET_MOCK_LOG="$TMP/mock.log"
+  export DR_FLEET_MOCK_XADD_ID="1700000000000-0"
+  export DR_ORCH_REDIS_URL="$REDIS_URL"
+  # Use temp tasks.md for status adapter tests
+  export DR_FLEET_TASKS_FILE="$TMP/tasks.md"
+  cat > "$DR_FLEET_TASKS_FILE" <<'TASKSMD'
+<!-- thin-index -->
+| ID | Title | L | Status | Since |
+|----|-------|---|--------|-------|
+| TUNE-0001 | Test task one | L2 | in_progress | 2026-06-01 |
+| TUNE-0002 | Test task two | L3 | pending | 2026-06-01 |
+TASKSMD
+  REDIS_AVAILABLE=0
+  if command -v redis-cli >/dev/null 2>&1 \
+      && redis-cli -u "$REDIS_URL" ping 2>/dev/null | grep -q PONG; then
+    REDIS_AVAILABLE=1
+  fi
+}
+
+teardown() {
+  rm -rf "$TMP"
+}
+
+# ── PM orchestrator executable + help ────────────────────────────────────────
+
+@test "V-AC-5: fleet_pm_orchestrator.sh is executable" {
+  [ -x "$PM" ]
+}
+
+@test "V-AC-5: fleet_pm_orchestrator.sh --help exits 0" {
+  run bash "$PM" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"usage"* ]]
+}
+
+@test "V-AC-5: --check mode shows config and exits 0" {
+  run bash "$PM" --check
+  [ "$status" -eq 0 ]
+}
+
+# ── status adapter ─────────────────────────────────────────────────────────────
+
+@test "V-AC-5: fleet_status_adapter.sh is executable" {
+  [ -x "$STATUS" ]
+}
+
+@test "V-AC-5: fleet_status_adapter.sh --help exits 0" {
+  run bash "$STATUS" --help
+  [ "$status" -eq 0 ]
+}
+
+@test "V-AC-5: status_get function exists" {
+  run bash -c "source '$STATUS' && declare -f status_get"
+  [ "$status" -eq 0 ]
+}
+
+@test "V-AC-5: status_update function exists" {
+  run bash -c "source '$STATUS' && declare -f status_update"
+  [ "$status" -eq 0 ]
+}
+
+# ── status_get from tasks.md ──────────────────────────────────────────────────
+
+@test "V-AC-5: status_get returns status from tasks.md" {
+  run bash -c "
+    export DR_FLEET_TASKS_FILE='$TMP/tasks.md'
+    source '$STATUS'
+    status_get 'TUNE-0001'
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"in_progress"* ]]
+}
+
+@test "V-AC-5: status_get returns pending for TUNE-0002" {
+  run bash -c "
+    export DR_FLEET_TASKS_FILE='$TMP/tasks.md'
+    source '$STATUS'
+    status_get 'TUNE-0002'
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"pending"* ]]
+}
+
+@test "V-AC-5: status_get returns unknown for non-existent task" {
+  run bash -c "
+    export DR_FLEET_TASKS_FILE='$TMP/tasks.md'
+    source '$STATUS'
+    status_get 'TUNE-9999'
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"unknown"* ]]
+}
+
+# ── status_update writes to tasks.md ─────────────────────────────────────────
+
+@test "V-AC-5: status_update changes status in tasks.md" {
+  run bash -c "
+    export DR_FLEET_TASKS_FILE='$TMP/tasks.md'
+    export DR_FLEET_BUS_BACKEND=mock
+    export DR_FLEET_MOCK_LOG='$TMP/mock.log'
+    source '$STATUS'
+    status_update 'TUNE-0001' 'blocked' 'timeout exceeded'
+    status_get 'TUNE-0001'
+  "
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"blocked"* ]]
+}
+
+@test "V-AC-5: status_update publishes event to bus (mock)" {
+  run bash -c "
+    export DR_FLEET_TASKS_FILE='$TMP/tasks.md'
+    export DR_FLEET_BUS_BACKEND=mock
+    export DR_FLEET_MOCK_LOG='$TMP/mock2.log'
+    source '$STATUS'
+    status_update 'TUNE-0001' 'blocked' 'pm-timeout'
+  "
+  [ "$status" -eq 0 ]
+  grep -q 'XADD' "$TMP/mock2.log"
+}
+
+# ── PM commands ──────────────────────────────────────────────────────────────
+
+@test "V-AC-5: PM unblock-task publishes event" {
+  run bash "$PM" unblock-task TUNE-0001
+  [ "$status" -eq 0 ]
+  grep -q 'XADD' "$TMP/mock.log"
+}
+
+@test "V-AC-5: PM reassign-level publishes level-reassigned event" {
+  run bash "$PM" reassign-level TUNE-0001 L1
+  [ "$status" -eq 0 ]
+  grep -q 'level-reassigned' "$TMP/mock.log"
+}
+
+@test "V-AC-5: PM kill-agent requires session id" {
+  run bash "$PM" kill-agent
+  [ "$status" -ne 0 ]
+}
+
+@test "V-AC-5: PM timeout-check exits 0 in check mode" {
+  run bash "$PM" timeout-check --dry-run
+  [ "$status" -eq 0 ]
+}

--- a/plugins/dr-orchestrate/tests/fleet/validate-message-contract.bats
+++ b/plugins/dr-orchestrate/tests/fleet/validate-message-contract.bats
@@ -1,0 +1,122 @@
+#!/usr/bin/env bats
+# validate-message-contract.bats — V-AC-2: fleet-validate-message.sh rejects
+# malformed messages and accepts valid ones. No Redis required.
+
+PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+VALIDATOR="$PLUGIN_ROOT/bin/fleet-validate-message.sh"
+
+# ── valid messages ────────────────────────────────────────────────────────────
+
+@test "V-AC-2: valid lifecycle message exits 0" {
+  run bash "$VALIDATOR" \
+    --id "550e8400-e29b-41d4-a716-446655440000" \
+    --ts "2026-06-09T12:00:00Z" \
+    --type "lifecycle" \
+    --from "agent-1" \
+    --to "pm-orchestrator"
+  [ "$status" -eq 0 ]
+}
+
+@test "V-AC-2: valid alert message exits 0" {
+  run bash "$VALIDATOR" \
+    --id "550e8400-e29b-41d4-a716-446655440001" \
+    --ts "2026-06-09T12:00:00Z" \
+    --type "alert" \
+    --from "monitor-dev" \
+    --to "pm-orchestrator"
+  [ "$status" -eq 0 ]
+}
+
+@test "V-AC-2: valid command message exits 0" {
+  run bash "$VALIDATOR" \
+    --id "550e8400-e29b-41d4-a716-446655440002" \
+    --ts "2026-06-09T12:00:00Z" \
+    --type "command" \
+    --from "pm-orchestrator" \
+    --to "fleet-daemon"
+  [ "$status" -eq 0 ]
+}
+
+@test "V-AC-2: valid audit message exits 0" {
+  run bash "$VALIDATOR" \
+    --id "550e8400-e29b-41d4-a716-446655440003" \
+    --ts "2026-06-09T12:00:00Z" \
+    --type "audit" \
+    --from "agent-1" \
+    --to "audit-log"
+  [ "$status" -eq 0 ]
+}
+
+@test "V-AC-2: valid heartbeat message exits 0" {
+  run bash "$VALIDATOR" \
+    --id "550e8400-e29b-41d4-a716-446655440004" \
+    --ts "2026-06-09T12:00:00Z" \
+    --type "heartbeat" \
+    --from "agent-1" \
+    --to "pm-orchestrator"
+  [ "$status" -eq 0 ]
+}
+
+# ── missing required fields ───────────────────────────────────────────────────
+
+@test "V-AC-2: missing --id exits 1 with error message" {
+  run bash "$VALIDATOR" \
+    --ts "2026-06-09T12:00:00Z" \
+    --type "lifecycle" \
+    --from "agent-1" \
+    --to "pm-orchestrator"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"id"* ]]
+}
+
+@test "V-AC-2: missing --ts exits 1" {
+  run bash "$VALIDATOR" \
+    --id "550e8400-e29b-41d4-a716-446655440000" \
+    --type "lifecycle" \
+    --from "agent-1" \
+    --to "pm-orchestrator"
+  [ "$status" -eq 1 ]
+}
+
+@test "V-AC-2: missing --type exits 1" {
+  run bash "$VALIDATOR" \
+    --id "550e8400-e29b-41d4-a716-446655440000" \
+    --ts "2026-06-09T12:00:00Z" \
+    --from "agent-1" \
+    --to "pm-orchestrator"
+  [ "$status" -eq 1 ]
+}
+
+# ── invalid field values ──────────────────────────────────────────────────────
+
+@test "V-AC-2: invalid type (not in enum) exits 1" {
+  run bash "$VALIDATOR" \
+    --id "550e8400-e29b-41d4-a716-446655440000" \
+    --ts "2026-06-09T12:00:00Z" \
+    --type "unknown-type" \
+    --from "agent-1" \
+    --to "pm-orchestrator"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"type"* ]]
+}
+
+@test "V-AC-2: invalid timestamp (non-ISO-8601) exits 1" {
+  run bash "$VALIDATOR" \
+    --id "550e8400-e29b-41d4-a716-446655440000" \
+    --ts "not-a-date" \
+    --type "lifecycle" \
+    --from "agent-1" \
+    --to "pm-orchestrator"
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ts"* ]]
+}
+
+@test "V-AC-2: empty id exits 1" {
+  run bash "$VALIDATOR" \
+    --id "" \
+    --ts "2026-06-09T12:00:00Z" \
+    --type "lifecycle" \
+    --from "agent-1" \
+    --to "pm-orchestrator"
+  [ "$status" -eq 1 ]
+}

--- a/plugins/dr-orchestrate/web/fleet-dashboard/app.js
+++ b/plugins/dr-orchestrate/web/fleet-dashboard/app.js
@@ -1,0 +1,213 @@
+// app.js — Fleet Dashboard frontend: polls /fleet-graph.json and renders
+// a force-directed graph (canvas-based, no external dependencies).
+
+const POLL_INTERVAL_MS = 30000;
+const STALE_THRESHOLD_MS = 90000; // 3 missed polls = stale
+
+let lastFetch = 0;
+let graphData = { nodes: [], edges: [], metrics: {} };
+
+// ── DOM refs ──────────────────────────────────────────────────────────────────
+
+const canvas = document.getElementById('graph-canvas');
+const ctx = canvas.getContext('2d');
+const statusDot = document.getElementById('status-dot');
+const lastUpdated = document.getElementById('last-updated');
+const errorBar = document.getElementById('error-bar');
+const mTotal = document.getElementById('m-total');
+const mAgents = document.getElementById('m-agents');
+const mSource = document.getElementById('m-source');
+const agentsTbody = document.getElementById('agents-tbody');
+
+// ── canvas resize ─────────────────────────────────────────────────────────────
+
+function resizeCanvas() {
+  const container = canvas.parentElement;
+  canvas.width = container.clientWidth;
+  canvas.height = container.clientHeight;
+  drawGraph();
+}
+
+window.addEventListener('resize', resizeCanvas);
+
+// ── force-directed layout (simple Verlet) ────────────────────────────────────
+
+const NODE_RADIUS = 10;
+let positions = {};
+let velocities = {};
+
+function initPositions(nodes) {
+  nodes.forEach((node, i) => {
+    if (!positions[node.id]) {
+      const angle = (2 * Math.PI * i) / Math.max(nodes.length, 1);
+      const r = Math.min(canvas.width, canvas.height) * 0.3;
+      positions[node.id] = {
+        x: canvas.width / 2 + r * Math.cos(angle),
+        y: canvas.height / 2 + r * Math.sin(angle),
+      };
+      velocities[node.id] = { x: 0, y: 0 };
+    }
+  });
+}
+
+function applyForces(nodes, edges) {
+  const k = 80; // spring rest length
+  const repulsion = 3000;
+  const damping = 0.85;
+
+  // Repulsion between all node pairs
+  for (let i = 0; i < nodes.length; i++) {
+    for (let j = i + 1; j < nodes.length; j++) {
+      const a = positions[nodes[i].id];
+      const b = positions[nodes[j].id];
+      if (!a || !b) continue;
+      const dx = a.x - b.x;
+      const dy = a.y - b.y;
+      const dist = Math.max(Math.sqrt(dx * dx + dy * dy), 1);
+      const force = repulsion / (dist * dist);
+      velocities[nodes[i].id].x += (dx / dist) * force;
+      velocities[nodes[i].id].y += (dy / dist) * force;
+      velocities[nodes[j].id].x -= (dx / dist) * force;
+      velocities[nodes[j].id].y -= (dy / dist) * force;
+    }
+  }
+
+  // Spring attraction along edges
+  edges.forEach(edge => {
+    const a = positions[edge.from];
+    const b = positions[edge.to];
+    if (!a || !b) return;
+    const dx = b.x - a.x;
+    const dy = b.y - a.y;
+    const dist = Math.max(Math.sqrt(dx * dx + dy * dy), 1);
+    const force = (dist - k) * 0.05;
+    velocities[edge.from].x += (dx / dist) * force;
+    velocities[edge.from].y += (dy / dist) * force;
+    velocities[edge.to].x -= (dx / dist) * force;
+    velocities[edge.to].y -= (dy / dist) * force;
+  });
+
+  // Apply velocities with damping and boundary clamp
+  nodes.forEach(node => {
+    const pos = positions[node.id];
+    const vel = velocities[node.id];
+    if (!pos || !vel) return;
+    vel.x *= damping;
+    vel.y *= damping;
+    pos.x = Math.max(NODE_RADIUS, Math.min(canvas.width - NODE_RADIUS, pos.x + vel.x));
+    pos.y = Math.max(NODE_RADIUS, Math.min(canvas.height - NODE_RADIUS, pos.y + vel.y));
+  });
+}
+
+// ── draw ──────────────────────────────────────────────────────────────────────
+
+function drawGraph() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+
+  const nodes = graphData.nodes || [];
+  const edges = graphData.edges || [];
+
+  if (nodes.length === 0) {
+    ctx.fillStyle = '#8b949e';
+    ctx.font = '14px system-ui';
+    ctx.textAlign = 'center';
+    ctx.fillText('No agents in fleet', canvas.width / 2, canvas.height / 2);
+    return;
+  }
+
+  initPositions(nodes);
+  applyForces(nodes, edges);
+
+  // Draw edges
+  edges.forEach(edge => {
+    const a = positions[edge.from];
+    const b = positions[edge.to];
+    if (!a || !b) return;
+    ctx.beginPath();
+    ctx.moveTo(a.x, a.y);
+    ctx.lineTo(b.x, b.y);
+    ctx.strokeStyle = '#30363d';
+    ctx.lineWidth = 1;
+    ctx.stroke();
+  });
+
+  // Draw nodes
+  nodes.forEach(node => {
+    const pos = positions[node.id];
+    if (!pos) return;
+    const color = node.active ? '#3fb950' : '#6e7681';
+    ctx.beginPath();
+    ctx.arc(pos.x, pos.y, NODE_RADIUS, 0, 2 * Math.PI);
+    ctx.fillStyle = color;
+    ctx.fill();
+    ctx.fillStyle = '#f0f6fc';
+    ctx.font = '10px system-ui';
+    ctx.textAlign = 'center';
+    ctx.fillText(node.id.length > 10 ? node.id.slice(0, 10) + '…' : node.id,
+      pos.x, pos.y + NODE_RADIUS + 12);
+  });
+}
+
+// ── metrics panel ─────────────────────────────────────────────────────────────
+
+function updateMetrics(data) {
+  const m = data.metrics || {};
+  mTotal.textContent = m.total_messages ?? '—';
+  mAgents.textContent = m.active_agents ?? (data.nodes || []).length;
+  mSource.textContent = m.snapshot_source ?? '—';
+
+  const nodes = data.nodes || [];
+  agentsTbody.innerHTML = nodes.map(n => `
+    <tr>
+      <td title="${n.id}">${n.id.length > 14 ? n.id.slice(0, 14) + '…' : n.id}</td>
+      <td>${n.role || '—'}</td>
+      <td><span class="badge ${n.active ? 'active' : 'inactive'}">${n.active ? 'active' : 'idle'}</span></td>
+    </tr>
+  `).join('') || '<tr><td colspan="3" style="color:#8b949e;padding:8px">No agents</td></tr>';
+}
+
+// ── fetch + poll ──────────────────────────────────────────────────────────────
+
+function setError(msg) {
+  errorBar.style.display = msg ? 'block' : 'none';
+  errorBar.textContent = msg || '';
+}
+
+async function fetchGraph() {
+  try {
+    const res = await fetch('/fleet-graph.json?t=' + Date.now());
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    const data = await res.json();
+    graphData = data;
+    lastFetch = Date.now();
+    setError(null);
+    const ts = data.generated_at || new Date().toISOString();
+    lastUpdated.textContent = 'Updated ' + ts.replace('T', ' ').slice(0, 19) + ' UTC';
+    updateMetrics(data);
+    drawGraph();
+  } catch (err) {
+    setError('Failed to fetch fleet-graph.json: ' + err.message);
+  }
+
+  // Mark stale if last fetch is too old
+  const age = Date.now() - lastFetch;
+  statusDot.classList.toggle('stale', lastFetch > 0 && age > STALE_THRESHOLD_MS);
+}
+
+// ── animation loop ────────────────────────────────────────────────────────────
+
+let animFrame;
+function animate() {
+  if ((graphData.nodes || []).length > 0) {
+    applyForces(graphData.nodes || [], graphData.edges || []);
+    drawGraph();
+  }
+  animFrame = requestAnimationFrame(animate);
+}
+
+// ── init ──────────────────────────────────────────────────────────────────────
+
+resizeCanvas();
+fetchGraph();
+setInterval(fetchGraph, POLL_INTERVAL_MS);
+animate();

--- a/plugins/dr-orchestrate/web/fleet-dashboard/index.html
+++ b/plugins/dr-orchestrate/web/fleet-dashboard/index.html
@@ -41,8 +41,9 @@
 </header>
 <div id="error-bar" role="alert"></div>
 <div class="layout">
+  <!-- force-graph: force-directed agent interaction graph -->
   <div id="graph-container">
-    <canvas id="graph-canvas"></canvas>
+    <canvas id="graph-canvas" class="force-graph" data-render="force-directed"></canvas>
   </div>
   <aside class="sidebar">
     <h2>Metrics</h2>

--- a/plugins/dr-orchestrate/web/fleet-dashboard/index.html
+++ b/plugins/dr-orchestrate/web/fleet-dashboard/index.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Fleet Dashboard</title>
+<style>
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body { font-family: system-ui, sans-serif; background: #0d1117; color: #c9d1d9; }
+  header { padding: 12px 20px; background: #161b22; border-bottom: 1px solid #30363d;
+           display: flex; align-items: center; gap: 16px; }
+  header h1 { font-size: 1rem; font-weight: 600; color: #f0f6fc; }
+  .status-dot { width: 8px; height: 8px; border-radius: 50%; background: #3fb950; }
+  .status-dot.stale { background: #f85149; }
+  #last-updated { font-size: 0.75rem; color: #8b949e; margin-left: auto; }
+  .layout { display: grid; grid-template-columns: 1fr 320px; height: calc(100vh - 49px); }
+  #graph-container { position: relative; border-right: 1px solid #30363d; }
+  #graph-canvas { width: 100%; height: 100%; }
+  .sidebar { overflow-y: auto; padding: 16px; background: #0d1117; }
+  .sidebar h2 { font-size: 0.8rem; font-weight: 600; color: #8b949e;
+                text-transform: uppercase; letter-spacing: .08em; margin-bottom: 12px; }
+  .metric-row { display: flex; justify-content: space-between; padding: 6px 0;
+                border-bottom: 1px solid #21262d; font-size: 0.875rem; }
+  .metric-row .val { color: #3fb950; font-variant-numeric: tabular-nums; }
+  .agents-table { width: 100%; border-collapse: collapse; font-size: 0.75rem; margin-top: 8px; }
+  .agents-table th { text-align: left; padding: 4px 8px; color: #8b949e;
+                     border-bottom: 1px solid #30363d; }
+  .agents-table td { padding: 4px 8px; border-bottom: 1px solid #21262d; }
+  .badge { display: inline-block; padding: 1px 6px; border-radius: 2em; font-size: 0.7rem; }
+  .badge.active { background: #1a3a2a; color: #3fb950; }
+  .badge.inactive { background: #2a1a1a; color: #f85149; }
+  #error-bar { display: none; padding: 8px 20px; background: #2d1f1f; color: #f85149;
+               font-size: 0.8rem; border-bottom: 1px solid #f85149; }
+</style>
+</head>
+<body>
+<header>
+  <span class="status-dot" id="status-dot"></span>
+  <h1>Fleet Dashboard</h1>
+  <span id="last-updated">Loading...</span>
+</header>
+<div id="error-bar" role="alert"></div>
+<div class="layout">
+  <div id="graph-container">
+    <canvas id="graph-canvas"></canvas>
+  </div>
+  <aside class="sidebar">
+    <h2>Metrics</h2>
+    <div class="metric-row"><span>Total messages</span><span class="val" id="m-total">—</span></div>
+    <div class="metric-row"><span>Active agents</span><span class="val" id="m-agents">—</span></div>
+    <div class="metric-row"><span>Source</span><span class="val" id="m-source">—</span></div>
+    <h2 style="margin-top:20px">Agents</h2>
+    <table class="agents-table">
+      <thead><tr><th>ID</th><th>Role</th><th>Status</th></tr></thead>
+      <tbody id="agents-tbody"></tbody>
+    </table>
+  </aside>
+</div>
+<script src="app.js"></script>
+</body>
+</html>


### PR DESCRIPTION
Fleet orchestration Phase 3: data bus, live monitoring, PM orchestrator, observability dashboard.

## Scope (implementation of concept §3d-g)
- **3a Bus** — `bus_adapter.sh` port (publish/subscribe/ack/replay → XADD/XREADGROUP/XACK/XRANGE), 4 topics (task-events / monitoring-alerts / fleet-commands / audit-log), `fleet-validate-message.sh` schema validator, `fleet_audit_trim.sh` (archive-before-XTRIM).
- **3b Monitoring** — `fleet_monitor_consumer.sh`: per-branch consumer groups, dev 5min / main 1min SLA, idempotent-only auto-retry, Hermes sink.
- **3c PM orchestrator** — `fleet_pm_orchestrator.sh` + `fleet_status_adapter.sh` (status port: Redis Streams + tasks.md now, Munera API stub for later), unblock/reassign-level/kill-agent/timeout-check.
- **3d Observability** — `fleet_obs_aggregator.sh` (graph nodes/edges/metrics snapshot) + `fleet_dashboard_server.sh` (socat, Tier 2 mesh-only, fail-closed bind gate) + force-directed web dashboard.
- **3e Cron** — health-check / log rotation / audit-trim mini-agents.

## Verification
- 82 fleet bats tests: 67 pass / 15 skip (Redis-gated, dev host without broker) / 0 fail.
- 165 neighbour dr-orchestrate tests: 0 fail.
- shellcheck clean (9 scripts). Security: redact_reason on write-path, fail-closed 0.0.0.0 bind gate, no command-injection / eval / secrets / task-IDs in shipped surface.
- Disjoint file set from Phase 1/2 (no merge conflict).

Runtime: Bash + redis-cli (continues /dr-orchestrate stack). Built atop Phase 1 (role registry) + Phase 2 (interactive spawn).

Follow-ups: audit-consumer typed-kv sink forward (backlog); deploy-phase live e2e (Redis + tailnet + CI webhook).