### PR TITLE
ci(release): document required v* tag policy for release environments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,6 +76,15 @@ jobs:
     runs-on: ubuntu-latest
     # Conditional environment (TUNE-0351): a major bump routes to release-manual
     # (required reviewer); patch/minor flows through release-auto (no reviewer).
+    #
+    # REQUIRED ENVIRONMENT POLICY (repo Settings → Environments, not in this file):
+    # both `release-auto` and `release-manual` MUST allow deployments from the
+    # `v*` tag pattern. This workflow triggers on tag pushes (`on: push: tags`),
+    # and a tag is NOT a protected branch — so an environment whose deployment
+    # branch policy is "Protected branches only" rejects every tagged release at
+    # job start (~2s, no steps run). Set deployment_branch_policy to
+    # custom_branch_policies and add a `v*` tag rule. Tracked for IaC by a
+    # follow-up backlog task (see CHANGELOG / evolution-log).
     environment:
       name: ${{ (needs.classify.outputs.bump_level == 'major' && 'release-manual') || 'release-auto' }}
     permissions:


### PR DESCRIPTION
Documents (in `release.yml`) that `release-auto` + `release-manual` environments must allow the `v*` tag pattern — otherwise every tagged release fails at job start (~2s, no steps), as v2.32.0 and v2.33.0 did until the policy was fixed live via API during the TUNE-0388 release.

Full IaC of the environment policy is tracked as a follow-up backlog task (TUNE-0414). This PR is the in-file warning so the requirement is discoverable from the workflow itself.

Comment-only change to one workflow file.