### PR TITLE
fix(infra-automation): mesh-health placeholder block nosec-extract

### DIFF
--- a/skills/infra-automation/SKILL.md
+++ b/skills/infra-automation/SKILL.md
@@ -39,6 +39,7 @@ Tailscale reachability for each node. Unreachable nodes fall back to public IP o
 are deferred — never silently skipped without a log entry:
 
 ```bash
+# nosec-extract
 for host in <MESH_IP_LIST>; do
   if ping -c1 -W2 "$host" >/dev/null 2>&1; then
     echo "mesh-ok: $host"


### PR DESCRIPTION
Follow-up to #104. One-line: the mesh-health pre-check bash fence uses <MESH_IP_LIST> placeholder syntax that shellcheck cannot parse (SC1073/SC1058). Adds # nosec-extract (same idiom as the sibling <HOST_LIST> recipe) so the illustrative block is skipped by extract-code-blocks. Clears the informational shellcheck-extracted check for this block.