### PR TITLE
Datarim ergonomics: snapshot-writer missing-flag diag + stale-runtime reminder + task-id-gate --base-commit + shipped-surface de-identify

### DIFF
--- a/commands/dr-archive.md
+++ b/commands/dr-archive.md
@@ -376,6 +376,23 @@ Complete and archive current task.
      hard-blocks an otherwise-clean archive. Archive is idempotent; a fixed gap
      re-enters cleanly on the next `/dr-archive` run.
 
+0.48. **STALE-RUNTIME REMINDER** (advisory, non-blocking):
+   - Check whether the task's diff touched any shipped script (`scripts/lib/*.sh`) or
+     skill (`skills/*/SKILL.md`) in the framework repository.
+   - If yes, emit the following advisory before proceeding to reflection:
+
+     > **Advisory — update your Datarim installs.**
+     > This task changed one or more shipped scripts or skills. If you run Datarim on
+     > multiple machines, the fix is currently present only where you committed it.
+     > Update your Datarim install(s) on every machine per your topology so the change
+     > is not stranded on a single box. This reminder is non-blocking — proceed with
+     > the archive after noting it.
+
+   - Detection heuristic: `git -C <framework-repo> diff --name-only HEAD~1..HEAD | grep -E '(^|/)scripts/lib/[^/]+\.sh$|(^|/)skills/[^/]+/SKILL\.md$'`
+     (adapt the commit range to the task's actual merge-base if HEAD~1 does not cover
+     the full task diff). No match → skip silently.
+   - This step does NOT block or gate any subsequent step. It is a human reminder only.
+
 0.5. **REFLECT** (MANDATORY — runs at least once per task, via a conditional freshness gate):
    - **Freshness gate (decides whether to re-run reflection):** invoke
      `${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/reflection-freshness.sh --task {TASK-ID} --root "$DATARIM_ROOT"`.

--- a/commands/dr-qa.md
+++ b/commands/dr-qa.md
@@ -347,7 +347,7 @@ Resolution chain: space registry `spaces/<space>/space.yml` → `test_environmen
 
 **Why this gate exists:** a change can pass every component/unit/Playwright test in
 an isolated worktree and still have never run on a real deployed environment.
-Operator mandate (DEV-1530): when a test environment exists, the change MUST be
+Operator mandate: when a test environment exists, the change MUST be
 verified on it — **backend AND frontend** — **autonomously**, before the task is
 prepared for prod or archived. Do not ask the operator each task whether to test;
 this skill pre-resolves that decision to "yes".

--- a/scripts/lib/snapshot-writer.sh
+++ b/scripts/lib/snapshot-writer.sh
@@ -104,10 +104,20 @@ write_stage_snapshot() {
         esac
     done
 
-    # Argument validation.
-    if [ -z "$root" ] || [ -z "$task_id" ] || [ -z "$stage" ] \
-       || [ -z "$command" ] || [ -z "$captured_by" ] \
-       || [ -z "$recommended_next" ] || [ -z "$body_file" ]; then
+    # Argument validation. Name the specific missing flag(s) before the usage
+    # block so callers do not have to re-read the whole usage to find the gap.
+    # --options-file is intentionally NOT required (defaults to an empty options
+    # list); only these seven flags are mandatory.
+    local missing=""
+    [ -z "$root" ]             && missing="$missing --root"
+    [ -z "$task_id" ]          && missing="$missing --task"
+    [ -z "$stage" ]            && missing="$missing --stage"
+    [ -z "$command" ]          && missing="$missing --command"
+    [ -z "$captured_by" ]      && missing="$missing --captured-by"
+    [ -z "$recommended_next" ] && missing="$missing --recommended-next"
+    [ -z "$body_file" ]        && missing="$missing --body-file"
+    if [ -n "$missing" ]; then
+        printf 'write_stage_snapshot: missing required flag(s):%s\n' "$missing" >&2
         snapshot_writer_usage
         return 2
     fi

--- a/scripts/task-id-gate.sh
+++ b/scripts/task-id-gate.sh
@@ -14,6 +14,7 @@
 # Usage:
 #   scripts/task-id-gate.sh <file-or-dir> [--whitelist <path>] ...
 #                           [--diff-only [<base>]]
+#                           [--base-commit <sha>]
 #
 # Inputs:
 #   <file-or-dir>   Path to scan. File → single-file mode. Directory →
@@ -28,6 +29,10 @@
 #                   not exist as a filesystem path. Single-file target outside
 #                   a git repo or untracked → exit 2; directory scan silently
 #                   skips untracked files.
+#   --base-commit   Like --diff-only but with an explicit required SHA/ref
+#                   argument. Scans only lines added since <sha>; pre-existing
+#                   task-ID references that were present at <sha> are ignored.
+#                   Equivalent to: --diff-only <sha>.
 #
 # Output (stderr):
 #   Per match: "<path>:<line>:<id>"
@@ -88,6 +93,13 @@ while [ $# -gt 0 ]; do
                 DIFF_BASE="$1"
                 shift
             fi
+            ;;
+        --base-commit)
+            shift
+            [ $# -gt 0 ] || { echo "task-id-gate: --base-commit requires a SHA/ref argument" >&2; exit 2; }
+            DIFF_ONLY=1
+            DIFF_BASE="$1"
+            shift
             ;;
         --help|-h)
             sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'

--- a/scripts/task-id-gate.sh
+++ b/scripts/task-id-gate.sh
@@ -102,7 +102,7 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         --help|-h)
-            sed -n '2,40p' "$0" | sed 's/^# \{0,1\}//'
+            sed -n '2,53p' "$0" | sed 's/^# \{0,1\}//'
             exit 0
             ;;
         --*)

--- a/scripts/task-id-gate.sh
+++ b/scripts/task-id-gate.sh
@@ -102,7 +102,7 @@ while [ $# -gt 0 ]; do
             shift
             ;;
         --help|-h)
-            sed -n '2,53p' "$0" | sed 's/^# \{0,1\}//'
+            awk 'NR>1 && /^[^#]/{exit} NR>1{sub(/^# ?/,""); print}' "$0"
             exit 0
             ;;
         --*)

--- a/skills/stage-snapshot-writer/SKILL.md
+++ b/skills/stage-snapshot-writer/SKILL.md
@@ -42,6 +42,12 @@ bash "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/snapshot-writer-wrapper.sh" \
     [--captured-at <ISO8601 UTC>]       # default $(date -u +%FT%TZ)
 ```
 
+> **All seven flags above are required** (`--root`, `--task`, `--stage`,
+> `--command`, `--captured-by`, `--recommended-next`, `--body-file`).
+> `--options-file` is optional. On a missing required flag the writer names
+> the specific flag(s) on stderr (`missing required flag(s): --body-file`) and
+> exits 2 — do not reconstruct the call from memory; copy the example below.
+
 Call the wrapper, never the bare `write_stage_snapshot` function — see § Contract
 (Entry point) for why the function dies silently under a zsh-parent shell.
 

--- a/skills/test-env-verification/SKILL.md
+++ b/skills/test-env-verification/SKILL.md
@@ -111,7 +111,7 @@ run safe backend + frontend smoke — proceeds autonomously and is logged.
 
 ## Reference incident
 
-DEV-1530 (aether): a 3-repo editable-budget feature reached COMPLIANT with green
+A multi-repo feature once reached COMPLIANT with green
 component/Playwright tests, but had **never** been merged to `dev` nor deployed to
 the test environment — every prior "test" ran in isolated worktrees / throwaway
 containers. The operator caught it at archive time and mandated this gate:

--- a/tests/stage-snapshot-writer-overwrite.bats
+++ b/tests/stage-snapshot-writer-overwrite.bats
@@ -101,6 +101,41 @@ OPT
     [ ! -f "$TMPROOT/datarim/snapshots/TUNE-0254.snapshot.md" ]
 }
 
+@test "missing --body-file names the specific flag on stderr, still exit 2" {
+    run write_stage_snapshot \
+        --root "$TMPROOT" --task TUNE-0254 --stage plan --command /dr-plan \
+        --captured-by agent --recommended-next /dr-do \
+        --options-file "$OPTIONS"
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"missing required flag(s):"* ]]
+    [[ "$output" == *"--body-file"* ]]
+    # still prints the full usage block after the named-flag line
+    [[ "$output" == *"Usage: write_stage_snapshot"* ]]
+}
+
+@test "multiple missing flags are all named on stderr, exit 2" {
+    run write_stage_snapshot --root "$TMPROOT" --task TUNE-0254
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"--stage"* ]]
+    [[ "$output" == *"--command"* ]]
+    [[ "$output" == *"--captured-by"* ]]
+    [[ "$output" == *"--recommended-next"* ]]
+    [[ "$output" == *"--body-file"* ]]
+}
+
+@test "full flag set path is byte-identical (no missing-flag line)" {
+    run write_stage_snapshot \
+        --root "$TMPROOT" --task TUNE-0254 --stage plan --command /dr-plan \
+        --captured-by agent --recommended-next /dr-do \
+        --options-file "$OPTIONS" --body-file "$BODY1"
+    [ "$status" -eq 0 ]
+    # the success path must NEVER emit the missing-flag diagnostic
+    [[ "$output" != *"missing required flag(s)"* ]]
+    local snap="$TMPROOT/datarim/snapshots/TUNE-0254.snapshot.md"
+    [ -f "$snap" ]
+    grep -q 'first stage body — round 1' "$snap"
+}
+
 @test "snapshot file is chmod 600 (least-privilege Appendix A control)" {
     write_stage_snapshot \
         --root "$TMPROOT" --task TUNE-0254 --stage plan --command /dr-plan \

--- a/tests/task-id-gate.bats
+++ b/tests/task-id-gate.bats
@@ -116,6 +116,40 @@ EOF
     [ "$status" -eq 2 ]
 }
 
+# -----------------------------------------------------------------------------
+# --base-commit mode (TUNE-0425: named-flag variant of --diff-only).
+# These three tests cover: (a) pre-existing foreign ID ignored, (b) newly-added
+# foreign ID caught, (c) no-flag full-file scan unchanged (regression guard).
+# -----------------------------------------------------------------------------
+
+@test "T15: --base-commit ignores pre-existing foreign TASK-ID (added-lines-only pass)" {
+    setup_diff_repo
+    BASE_SHA="$(git -C "$DIFF_REPO" rev-parse HEAD)"
+    # Add a clean line — no new task-ID introduced.
+    printf '\n## Update\n\n- Minor clarification.\n' >> "$DIFF_REPO/runtime.md"
+    run "$GATE" --base-commit "$BASE_SHA" "$DIFF_REPO/runtime.md"
+    teardown_diff_repo
+    [ "$status" -eq 0 ]
+}
+
+@test "T16: --base-commit catches newly-added foreign TASK-ID" {
+    setup_diff_repo
+    BASE_SHA="$(git -C "$DIFF_REPO" rev-parse HEAD)"
+    # Introduce a new task-ID reference in an uncommitted edit.
+    printf '\n## Follow-up\n\n- See ABCD-0001 for context.\n' >> "$DIFF_REPO/runtime.md"
+    run "$GATE" --base-commit "$BASE_SHA" "$DIFF_REPO/runtime.md"
+    teardown_diff_repo
+    [ "$status" -eq 1 ]
+}
+
+@test "T17: no-flag full-file scan still fails on pre-existing foreign TASK-ID (byte-identical regression)" {
+    setup_diff_repo
+    # runtime.md at baseline already contains TUNE-0042 and DEV-1183.
+    run "$GATE" "$DIFF_REPO/runtime.md"
+    teardown_diff_repo
+    [ "$status" -eq 1 ]
+}
+
 @test "T11: skills/ scope is gate-clean (regression invariant)" {
     run "$GATE" "$REPO_ROOT/skills"
     [ "$status" -eq 0 ]


### PR DESCRIPTION
Batch of three small framework improvements + one hygiene fix. All shipped surface English-only, infra-agnostic (no private hosts/topology). Branch push was operator-gated.

## Commits
- `953e39c` snapshot-writer: name the specific missing required flag on stderr before usage (exit 2 preserved, full-flag path byte-identical). +3 bats.
- `1e88798` /dr-archive Step 0.48: advisory, non-blocking stale-runtime reminder when a shipped script/skill changed (generic «update your install(s) per your topology»; no hardcoded hosts/commands).
- `504bc27`+`4df1455`+`a105bd5` task-id-gate.sh: `--base-commit <sha>` added-lines-only scan mode so pre-existing foreign TASK-IDs no longer fail the gate (no-flag path byte-identical); awk-based `--help` extractor immune to header growth. +3 bats.
- `81e11e1` de-identify a leaked task-ID + private space name in commands/dr-qa.md and skills/test-env-verification/SKILL.md — restores the skills/ + commands/ gate-clean regression invariant (task-id-gate.bats T11/T12).

Note: base commit `e67efcc` (snapshot-writer TASK-ID regex) is a separate already-pushed feature branch; it appears here because this branch stacks on it and will collapse on squash-merge.

## Verification
- task-id-gate.bats 17/17; stage-snapshot bats green; dr-archive bats 34/34; shellcheck clean; English-only gate PASS; anti-deferral PASS.