### PR TITLE
fix(ci): green shellcheck-extracted + skill-desc-155

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -523,6 +523,7 @@ Consumers MUST mirror the canonical FB-rules text and the enforcement-mapping ta
 When a script's textual output is contractually paired with its exit code or internal state (e.g. "BLOCKED" message ↔ exit 1, "OK" message ↔ exit 0, "applied" flag ↔ side-effect performed), insert a precondition guard immediately before emitting the wording:
 
 ```bash
+# noshellcheck-extract
 if [ "$flag" -ne <expected> ]; then
     echo "ERROR: internal invariant violated: <description>" >&2
     exit 2

--- a/cli/tests/e2e-live-tmux.md
+++ b/cli/tests/e2e-live-tmux.md
@@ -26,6 +26,7 @@ bats --version
 ## Smoke procedure
 
 ```bash
+# noshellcheck-extract
 # 1. Start a Redis server in foreground (or as a service):
 redis-server --daemonize yes
 redis-cli ping     # expect PONG

--- a/skills/infra-automation/SKILL.md
+++ b/skills/infra-automation/SKILL.md
@@ -155,6 +155,7 @@ Before removing a suspected-stale copy of a web origin that sits behind a CDN pr
 Prove the live origin by querying each candidate server directly with the production Host header and comparing response bodies:
 
 ```bash
+# noshellcheck-extract
 for ip in <candidate-ip-1> <candidate-ip-2>; do
   echo "== $ip"
   curl -s --resolve <domain>:443:$ip https://<domain>/ -o /tmp/body-$ip --write-out '%{http_code} %{size_download}\n'

--- a/skills/test-env-verification/SKILL.md
+++ b/skills/test-env-verification/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: test-env-verification
-description: Mandatory gate — when the project space has a test environment, verify the change (backend AND frontend) on it autonomously before any prod prep or archive. Blocks /dr-qa, /dr-compliance, /dr-archive until done.
+description: Mandatory gate: verify the change on test env (backend + frontend) autonomously before prod prep or archive. Blocks /dr-qa, /dr-compliance, /dr-archive.
 current_aal: 1
 target_aal: 2
 ---

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -182,6 +182,7 @@ If it differs from your task branch, read your committed state directly from
 your branch instead of the working tree:
 
 ```bash
+# noshellcheck-extract
 git -C <repo> cat-file blob <task-branch>:<path>   # or: git show <task-branch>:<path>
 ```
 


### PR DESCRIPTION
## Summary

- Add `# noshellcheck-extract` to 4 illustrative pseudo-code fenced blocks (CLAUDE.md, cli/tests/e2e-live-tmux.md, skills/infra-automation/SKILL.md, skills/verification-before-completion/SKILL.md) so the extractor skips them — no logic change, markers only.
- Trim `test-env-verification` description from 213 → 152 chars to satisfy the `optimize-merge.bats` 155-char limit.

## Test plan

- [x] `bats tests/optimize-merge.bats` — all 3 tests pass (including T3 skill-desc-155)
- [x] Extractor + shellcheck loop: zero SC1073/SC1058 remaining
- [x] `dev-tools/check-body-english.sh --scope commands,skills,agents,plugins` — PASS