### PR TITLE
feat(autonomy): per-space autonomy flags — fail-closed action policy [TUNE-0436]

### DIFF
--- a/commands/dr-auto.md
+++ b/commands/dr-auto.md
@@ -81,7 +81,7 @@ target_aal: 2
 
 ## Actions that ask the operator
 
-Before asking, call `dev-tools/resolve-space-autonomy.sh gate` with the
+Before asking, call `${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/resolve-space-autonomy.sh gate` with the
 canonical action kind and any required discriminator payload. Exit `0` means
 execute autonomously; exit `10` means ask the operator; exit `2` means the
 policy is invalid and therefore also asks the operator.

--- a/commands/dr-auto.md
+++ b/commands/dr-auto.md
@@ -39,7 +39,10 @@ target_aal: 2
      activated_at: "<ISO 8601 timestamp>"
      activated_by: /dr-auto
      mode: resume | bootstrap
+     space: "<resolved-space-name>"
      ```
+   - The `space` value is required when the active space cannot be derived
+     from the workspace path. An absent or invalid value remains fail-closed.
    - The marker is removed at the terminal step (successful `/dr-compliance` + reflection, or a hard stop that surrenders control to the operator). If the env var is set without a matching marker, downstream stages treat the session as non-autonomous (fail-safe).
 
 4. **Load the operating rules.** Read the autonomous-mode skill at `${DATARIM_RUNTIME:-$HOME/.claude}/skills/autonomous-mode/SKILL.md`. It defines the decision rules every stage uses: how to handle minor gaps inline, when to walk through the question-suppression checks before prompting the operator, and which actions are always operator-gated regardless of mode.
@@ -47,7 +50,7 @@ target_aal: 2
 5. **Dispatch the pipeline as subagents.** For each stage that needs running, spawn the matching agent via the Agent tool, pass it the resolved task state, wait for its result, then summarise that result and decide the next stage. Stage → agent map: prd/design → `architect`, plan → `planner`, do → `developer`, qa → `reviewer`, compliance → `compliance`. The orchestrator itself does not perform stage work — it dispatches, summarises, and routes.
    - **Re-assert the marker before each dispatch (mandatory pre-dispatch gate).** Before spawning any stage subagent you MUST run the re-assert helper as the first action of every per-stage dispatch — skipping this step means skipping the dispatch gate:
      ```
-     ${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/auto-mode-marker.sh reassert --root <workspace> --task-id <TASK-ID>
+     ${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/auto-mode-marker.sh reassert --root <workspace> --task-id <TASK-ID> --space <resolved-space-name>
      ```
      If the marker file (located via the helper's `MARKER_RELPATH` constant — do not hard-code the filename) is absent, unparseable, holds a different task ID, or is stale, the helper rewrites it for the current task. If a valid current marker already exists the call is a no-op. The helper exits 0 when the marker is valid afterward; proceed to spawn the subagent only after exit 0.
    - **Carry the auto-signal in the subagent prompt.** Include an explicit line in every stage subagent's prompt: "You run stage `<stage>` in autonomous mode for `<TASK-ID>`." The spawned subagent activates the autonomous-mode skill from this signal plus the re-asserted marker, without the (un-inherited) environment variable — see `skills/autonomous-mode/SKILL.md` § When this skill is active, Spawned subagents (relaxed activation).
@@ -76,19 +79,18 @@ target_aal: 2
    - Emit the stage snapshot defined in the cta-format skill (`stage: auto`, `command: /dr-auto`).
    - The operator may explicitly `unset DATARIM_AUTO_MODE` in the shell. Otherwise, the next `/dr-*` invocation will detect that the env var is set but the marker is gone, log a single warning, and continue as a normal (non-autonomous) run.
 
-## Actions that always ask the operator
+## Actions that ask the operator
 
-Even under `/dr-auto`, the following actions never run automatically. They come from `documentation/mandates/autonomous-agents.md`; the autonomous-mode skill has the canonical, runtime-readable copy.
+Before asking, call `dev-tools/resolve-space-autonomy.sh gate` with the
+canonical action kind and any required discriminator payload. Exit `0` means
+execute autonomously; exit `10` means ask the operator; exit `2` means the
+policy is invalid and therefore also asks the operator.
 
-- Production deploys (any production environment).
-- Secret rotation: Vault keys, OAuth tokens, API keys, signing keys.
-- Irreversible database operations: `DROP`, `TRUNCATE`, schema migrations without a backup.
-- Public communications: posts to Telegram channels, blogs, social media, or any operator-fronting channel.
-- Finance or legal actions.
-- Force-push to `main` or `master`.
-- Deletion of git history (force-push that drops commits, `git reflog expire --expire=now`, `gc --prune=now`).
-- Actions that affect more than one human user (mass emails, broadcast notifications).
-- Cross-project boundary writes: edits to a repository whose task-prefix is not the current task's project.
+The always-gated floor never executes automatically in any space: finance or
+legal actions, irreversible database operations without a verified backup,
+git-history deletion, force-pushes that drop commits, and Supreme Directive
+violations. Other operational actions ask only when the resolved
+`autonomy.policy` value is `operator` or the space/policy cannot be resolved.
 
 ## When to use it
 

--- a/dev-tools/auto-mode-marker.sh
+++ b/dev-tools/auto-mode-marker.sh
@@ -2,10 +2,11 @@
 # auto-mode-marker.sh — manage the autonomous-mode marker file
 #
 # Verbs:
-#   reassert --root <DIR> --task-id <ID>
+#   reassert --root <DIR> --task-id <ID> [--space <NAME>]
 #     Idempotent. If <DIR>/datarim/.auto-mode-active is absent, unparseable,
 #     holds a different task_id, or is older than 24 hours, rewrite it with
-#     the given task_id. If a valid current marker already exists, no-op.
+#     the given task_id and optional space binding. If a valid current marker
+#     already exists, no-op.
 #     Exits 0 when the marker is valid for <ID> afterward; exits 2 on bad args.
 #
 #   subagent-active --root <DIR> --task-id <ID> --auto-signal <true|false>
@@ -35,12 +36,14 @@ shift || true
 ROOT=""
 TASK_ID=""
 AUTO_SIGNAL=""
+SPACE_NAME=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --root)       ROOT="$2";        shift 2 ;;
         --task-id)    TASK_ID="$2";     shift 2 ;;
         --auto-signal) AUTO_SIGNAL="$2"; shift 2 ;;
+        --space)       SPACE_NAME="$2";  shift 2 ;;
         -h|--help)
             grep '^#' "$0" | head -30 | sed 's/^# \?//'
             exit 0
@@ -79,6 +82,10 @@ if ! [[ "$TASK_ID" =~ ^[A-Z]{2,10}-[0-9]{4}$ ]]; then
     usage_error "--task-id must match ^[A-Z]{2,10}-[0-9]{4}\$, got: ${TASK_ID}"
 fi
 
+if [ -n "$SPACE_NAME" ] && ! [[ "$SPACE_NAME" =~ ^[a-z0-9][a-z0-9_-]*$ ]]; then
+    usage_error "--space must be a safe lowercase slug, got: ${SPACE_NAME}"
+fi
+
 # ── Helpers ───────────────────────────────────────────────────────────────────
 
 MARKER_PATH="${ROOT}/${MARKER_RELPATH}"
@@ -99,6 +106,7 @@ task_id: ${task_id}
 activated_at: ${ts}
 activated_by: /dr-auto
 mode: resume
+space: ${SPACE_NAME}
 YAML
 }
 
@@ -113,6 +121,12 @@ _marker_is_valid() {
     local file_id
     file_id=$(grep -m1 '^task_id:' "${MARKER_PATH}" | sed 's/^task_id:[[:space:]]*//' 2>/dev/null) || return 1
     [ "${file_id}" = "${expected_id}" ] || return 1
+
+    if [ -n "$SPACE_NAME" ]; then
+        local file_space
+        file_space=$(grep -m1 '^space:' "${MARKER_PATH}" | sed 's/^space:[[:space:]]*//' 2>/dev/null) || return 1
+        [ "$file_space" = "$SPACE_NAME" ] || return 1
+    fi
 
     # Check age: accept marker only if it was written within 24 hours (86400 s).
     # Probe GNU date first; fall back to BSD stat.

--- a/dev-tools/check-autonomy-schema.sh
+++ b/dev-tools/check-autonomy-schema.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Validate one or more space.yml autonomy blocks.
+set -euo pipefail
+
+(( $# > 0 )) || { echo "usage: check-autonomy-schema.sh <space.yml> [...]" >&2; exit 2; }
+
+failed=0
+for file in "$@"; do
+  if ! yq eval -e '
+    .autonomy.schema_version == 1 and
+    (.autonomy.policy | type == "!!map") and
+    ([.autonomy.policy[] | (. == "auto" or . == "operator")] | all)
+  ' "$file" >/dev/null 2>&1; then
+    echo "FAIL: invalid autonomy block: $file" >&2
+    failed=1
+  fi
+done
+exit "$failed"

--- a/dev-tools/lib/space-autonomy.sh
+++ b/dev-tools/lib/space-autonomy.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+# Core fail-closed resolver for per-space operational autonomy.
+
+_autonomy_json() {
+  jq -n -c "$@"
+}
+
+_autonomy_spaces_root() {
+  if [[ -n "${DATARIM_SPACES_ROOT:-}" ]]; then
+    printf '%s\n' "$DATARIM_SPACES_ROOT"
+    return 0
+  fi
+  if [[ -n "${DATARIM_WORKSPACE_ROOT:-}" && -d "$DATARIM_WORKSPACE_ROOT/spaces" ]]; then
+    printf '%s\n' "$DATARIM_WORKSPACE_ROOT/spaces"
+    return 0
+  fi
+  local dir="${PWD:-.}"
+  while [[ "$dir" != "/" ]]; do
+    if [[ -f "$dir/spaces/registry.yml" ]]; then
+      printf '%s\n' "$dir/spaces"
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  return 1
+}
+
+_autonomy_marker_name() {
+  local dir="${PWD:-.}" marker auto_marker
+  while [[ "$dir" != "/" ]]; do
+    auto_marker="$dir/datarim/.auto-mode-active"
+    if [[ -f "$auto_marker" ]]; then
+      yq eval -r '.space // ""' "$auto_marker" 2>/dev/null
+      return 0
+    fi
+    marker="$dir/datarim/.space"
+    if [[ -f "$marker" ]]; then
+      yq eval -r '.space // .name // ""' "$marker" 2>/dev/null
+      return 0
+    fi
+    dir="$(dirname "$dir")"
+  done
+  return 1
+}
+
+_autonomy_space_file() {
+  local spaces_root="$1" requested="${DATARIM_ACTIVE_SPACE:-${DATARIM_SPACE_NAME:-}}"
+  if [[ -n "${DATARIM_SPACE_YML:-}" && -f "$DATARIM_SPACE_YML" ]]; then
+    printf '%s\n' "$DATARIM_SPACE_YML"
+    return 0
+  fi
+  if [[ -z "$requested" ]]; then
+    requested="$(_autonomy_marker_name 2>/dev/null || true)"
+  fi
+  [[ "$requested" =~ ^[a-z0-9][a-z0-9_-]*$ ]] || return 1
+  if [[ -n "$requested" && -f "$spaces_root/$requested/space.yml" ]]; then
+    printf '%s\n' "$spaces_root/$requested/space.yml"
+    return 0
+  fi
+  return 1
+}
+
+_autonomy_effective_kind() {
+  local action="$1" payload="$2" branch
+  case "$action" in
+    force_push)
+      if [[ "$(jq -r 'if has("drops_commits") then .drops_commits else true end' \
+        <<<"$payload" 2>/dev/null)" == true ]]; then
+        printf '%s\n' force_push_drops_commits
+      else
+        branch="$(jq -r '.target_branch // ""' <<<"$payload" 2>/dev/null)"
+        case "$branch" in
+          main|master) printf '%s\n' merge_main ;;
+          "") printf '%s\n' force_push_unknown ;;
+          *) printf '%s\n' feature_branch_push ;;
+        esac
+      fi
+      ;;
+    irreversible_db_op)
+      if [[ "$(jq -r '.backup_verified // false' <<<"$payload" 2>/dev/null)" == true ]]; then
+        printf '%s\n' irreversible_db_op
+      else
+        printf '%s\n' irreversible_db_no_backup
+      fi
+      ;;
+    *) printf '%s\n' "$action" ;;
+  esac
+}
+
+_autonomy_operator() {
+  local action="$1" effective="$2" reason="$3" floor_hit="${4:-false}"
+  _autonomy_json \
+    --arg action "$action" --arg effective "$effective" --arg reason "$reason" \
+    --argjson floor "$floor_hit" \
+    '{schema_version:1,action_kind:$action,effective_action_kind:$effective,
+      decision:"operator",floor_hit:$floor,precedence_layer:(if $floor then "P0" else "P3" end),
+      reason_code:$reason}'
+  return 10
+}
+
+_autonomy_rules() {
+  local rules="${DR_AUTONOMY_RULES:-}"
+  [[ -n "$rules" && -s "$rules" ]] || return 1
+  yq eval -e '.always_gated_floor | type == "!!seq" and length > 0' "$rules" >/dev/null 2>&1 \
+    || return 1
+  yq eval -e '.action_autonomy_map | type == "!!map" and length > 0' "$rules" >/dev/null 2>&1 \
+    || return 1
+  printf '%s\n' "$rules"
+}
+
+_autonomy_release_allowed() {
+  local payload="$1"
+  jq -e '
+    (.bump_level == "patch" or .bump_level == "minor") and
+    (.escalate == false) and
+    (.zero_x_breaking != true)
+  ' <<<"$payload" >/dev/null 2>&1
+}
+
+_autonomy_policy_decision() {
+  local action="$1" effective="$2" rules="$3"
+  local spaces_root space_yml policy_key policy_value space_name valid_policy
+  spaces_root="$(_autonomy_spaces_root 2>/dev/null || true)"
+  space_yml="$(_autonomy_space_file "$spaces_root" 2>/dev/null || true)"
+  if [[ -z "$spaces_root" || -z "$space_yml" ]]; then
+    _autonomy_operator "$action" "$effective" unresolved_space
+    return 10
+  fi
+  policy_key="$(yq eval -r ".action_autonomy_map.\"$effective\" // \"\"" "$rules")"
+  if [[ -z "$policy_key" ]]; then
+    _autonomy_operator "$action" "$effective" unmapped_action
+    return 10
+  fi
+  valid_policy="$(yq eval -r '
+    .autonomy.schema_version == 1 and
+    (.autonomy.policy | type == "!!map") and
+    ([.autonomy.policy[] | (. == "auto" or . == "operator")] | all)
+  ' "$space_yml" 2>/dev/null || printf false)"
+  if [[ "$valid_policy" != true ]]; then
+    _autonomy_operator "$action" "$effective" invalid_or_missing_autonomy
+    return 10
+  fi
+  policy_value="$(yq eval -r ".autonomy.policy.\"$policy_key\" // \"operator\"" "$space_yml")"
+  space_name="$(yq eval -r '.space.name // ""' "$space_yml")"
+  _autonomy_json \
+    --arg action "$action" --arg effective "$effective" --arg key "$policy_key" \
+    --arg value "$policy_value" --arg space "$space_name" \
+    '{schema_version:1,action_kind:$action,effective_action_kind:$effective,
+      decision:$value,floor_hit:false,policy_key:$key,policy_value:$value,
+      space:$space,space_source:"resolved_space_yml",precedence_layer:"P2",
+      reason_code:"space_policy"}'
+  [[ "$policy_value" == auto ]] && return 0
+  return 10
+}
+
+autonomy_decision() {
+  local action="$1" payload="${2:-"{}"}" rules effective floor_hit
+  jq -e 'type == "object"' <<<"$payload" >/dev/null 2>&1 || payload='{}'
+  effective="$(_autonomy_effective_kind "$action" "$payload")"
+  rules="$(_autonomy_rules 2>/dev/null || true)"
+  if [[ -z "$rules" ]]; then
+    _autonomy_json --arg action "$action" \
+      '{schema_version:1,action_kind:$action,decision:"operator",floor_hit:false,
+        precedence_layer:"P0",reason_code:"invalid_rules"}'
+    return 2
+  fi
+  floor_hit="$(yq eval -o=json '.always_gated_floor' "$rules" \
+    | jq --arg kind "$effective" 'index($kind) != null')"
+  if [[ "$floor_hit" == true ]]; then
+    _autonomy_operator "$action" "$effective" always_gated_floor true
+    return 10
+  fi
+  if [[ "$action" == public_package_release ]] \
+    && ! _autonomy_release_allowed "$payload"; then
+    _autonomy_json --arg action "$action" \
+      '{schema_version:1,action_kind:$action,
+        effective_action_kind:"public_package_release",decision:"operator",
+        floor_hit:false,precedence_layer:"P1",
+        reason_code:"release_carveout_denied"}'
+    return 10
+  fi
+  _autonomy_policy_decision "$action" "$effective" "$rules"
+}

--- a/dev-tools/resolve-space-autonomy.sh
+++ b/dev-tools/resolve-space-autonomy.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Resolve a normally gated action against the active space policy.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/space-autonomy.sh
+source "$SCRIPT_DIR/lib/space-autonomy.sh"
+
+usage() {
+  echo "usage: resolve-space-autonomy.sh gate --action <kind> [--payload <json>]" >&2
+  exit 2
+}
+
+gate() {
+  local action="" payload='{}' output rc event space_hint
+  while (( $# > 0 )); do
+    case "$1" in
+      --action) action="${2:-}"; shift 2 ;;
+      --payload) payload="${2:-}"; shift 2 ;;
+      *) usage ;;
+    esac
+  done
+  [[ "$action" =~ ^[a-z][a-z0-9_]*$ ]] || usage
+  set +e
+  output="$(autonomy_decision "$action" "$payload")"
+  rc=$?
+  set -e
+  space_hint="${DATARIM_ACTIVE_SPACE:-${DATARIM_SPACE_NAME:-}}"
+  if [[ -z "$space_hint" ]]; then
+    space_hint="$(_autonomy_marker_name 2>/dev/null || true)"
+  fi
+  [[ "$space_hint" =~ ^[a-z0-9][a-z0-9_-]*$ ]] || space_hint=""
+  event="$(jq -c \
+    --arg ts "$(date -u +%FT%TZ)" \
+    --arg actor "${DR_AUTONOMY_ACTOR:-${USER:-agent}}" \
+    --arg task_id "${DATARIM_TASK_ID:-}" \
+    --arg space "$space_hint" \
+    '. + {timestamp:$ts,actor:$actor,task_id:$task_id}
+      | if (.space // "") == "" then .space = $space else . end' <<<"$output")"
+  local audit="${DR_AUTONOMY_AUDIT:-${DR_ORCH_AUTONOMY_AUDIT:-$HOME/.local/share/datarim/autonomy.jsonl}}"
+  mkdir -p "$(dirname "$audit")"
+  printf '%s\n' "$event" >> "$audit"
+  printf '%s\n' "$event"
+  return "$rc"
+}
+
+command_name="${1:-}"
+shift || true
+case "$command_name" in
+  gate) gate "$@" ;;
+  *) usage ;;
+esac

--- a/plugins/dr-orchestrate/README.md
+++ b/plugins/dr-orchestrate/README.md
@@ -59,6 +59,11 @@ Resolver outputs below the confidence threshold (or `chain_exhausted`) route to
 - **dev-bot** — stub returning exit 99 with WARN until a real consumer service
   lands.
 
+Resolver JSON may also include `action_kind` and `action_payload`.
+`cmd_run.sh` sends these through `scripts/action_gate.sh` before execution.
+The gate reads explicit per-space `autonomy.policy`, writes its audit record
+first, and fails closed on missing, malformed, unknown, or unresolved policy.
+
 ## Security Floor
 
 Перед любым `tmux send-keys` и перед любым autonomous decision выполняется

--- a/plugins/dr-orchestrate/agents/dr-orchestrate-resolver.md
+++ b/plugins/dr-orchestrate/agents/dr-orchestrate-resolver.md
@@ -44,6 +44,8 @@ If none parses, the backend is treated as a miss and the chain continues.
   "action": "<slash-command-or-empty>",
   "confidence": 0.0,
   "reason": "<short-string>",
+  "action_kind": "<optional-operational-kind>",
+  "action_payload": {},
   "backend_used": "<backend-name-or-none>",
   "subagent_model": "<model-name-or-empty>"
 }
@@ -57,7 +59,11 @@ When the chain is exhausted without a successful parse, the resolver returns:
 
 ## Fail-Closed Semantics
 
-The resolver **never** decides to act. It is a classifier — the autonomous-vs-escalate decision belongs to `cmd_run.sh`:
+The resolver **never** decides to act. It is a classifier — the
+autonomous-vs-escalate decision belongs to `cmd_run.sh`. When a pane requests
+an operational action, the resolver also classifies `action_kind` and any
+required boolean discriminator payload; `cmd_run.sh` sends those fields through
+the per-space action gate before execution:
 
 - `confidence ≥ 0.80` ⇒ caller may pane-send the action via the Phase 1 security pipeline (whitelist + escape block + cooldown).
 - `confidence < 0.80` ⇒ caller routes the resolver output (including raw `confidence` and `reason`) to `escalation_backend.sh`.

--- a/plugins/dr-orchestrate/commands/dr-orchestrate.md
+++ b/plugins/dr-orchestrate/commands/dr-orchestrate.md
@@ -31,7 +31,11 @@ Phase 2 — Subagent Inference Layer (v2.4.0).
 5. **Miss (confidence == 0)** — Phase 2 path:
    - `subagent_resolver.sh resolve` — multi-backend chain (coworker → claude → codex), 15s per backend, lenient JSON parse, FD-3 close.
    - Confidence threshold gate (default `0.80`):
-     - Pass → audit `outcome: resolved` (schema v2); decision-cooldown 60s enforces a single autonomous decision per pane per minute.
+     - Pass → when resolver JSON includes `action_kind`, call
+       `scripts/action_gate.sh` before autonomous execution. Space-policy
+       `auto` proceeds; `operator` or invalid policy routes to escalation.
+       Then audit `outcome: resolved` (schema v2); decision-cooldown 60s
+       enforces a single autonomous decision per pane per minute.
      - Fail / chain_exhausted → `escalation_backend.sh emit` (mock JSONL by default; the `dev-bot` backend remains a stub until a real consumer service exists) + audit `outcome: escalated`.
 6. Every `tmux send-keys` still passes through the security floor: whitelist → escape-block → micro-cooldown (500 ms) + decision-cooldown (60 s) → fail-closed.
 

--- a/plugins/dr-orchestrate/rules/fb-rules.yaml
+++ b/plugins/dr-orchestrate/rules/fb-rules.yaml
@@ -1,4 +1,5 @@
 # fb-rules.yaml — Autonomous Agent Operating Rules (FB-1..FB-8) policy block.
+# FB means Feedback Behaviour; it is unrelated to Facebook or Publisher.
 # Canonical text: /Users/ug/arcanada/CLAUDE.md § Autonomous Agent Operating Rules Mandate.
 # Source insight:  Projects/Datarim/datarim/insights/INSIGHTS-TUNE-0185-fb-rules.md.
 # Consumer: scripts/rules_loader.sh § load_fb_policy() (TUNE-0185 Phase 4).
@@ -24,7 +25,7 @@
 
 rules:
   - rule_id: FB-1
-    title: "Исследовать доступные варианты решения"
+    title: "Research available solution options"
     enforcement_layer: 2
     tier: rule-based
     default_action: auto
@@ -33,7 +34,7 @@ rules:
     conflicts_with_law: null
 
   - rule_id: FB-2
-    title: "Сравнить варианты по best practices / security / maintainability"
+    title: "Compare options for security and maintainability"
     enforcement_layer: 2
     tier: rule-based
     default_action: auto
@@ -42,7 +43,7 @@ rules:
     conflicts_with_law: null
 
   - rule_id: FB-3
-    title: "Консилиум по ролям (architect / dev / DevOps / security / QA / PO)"
+    title: "Run a role-based consilium when needed"
     enforcement_layer: 4
     tier: subagent
     default_action: auto
@@ -51,7 +52,7 @@ rules:
     conflicts_with_law: null
 
   - rule_id: FB-4
-    title: "Выбрать вариант и записать reason в audit log"
+    title: "Choose an option and record the reason"
     enforcement_layer: 2
     tier: rule-based
     default_action: auto
@@ -60,7 +61,7 @@ rules:
     conflicts_with_law: 5
 
   - rule_id: FB-5
-    title: "Выполнить безопасно-выполнимые части задачи без оператора"
+    title: "Execute safely reversible work without the operator"
     enforcement_layer: 2
     tier: rule-based
     default_action: auto
@@ -69,7 +70,7 @@ rules:
     conflicts_with_law: 1
 
   - rule_id: FB-5a
-    title: "Не перекладывать на оператора обратимую работу; не отсрочивать без артефакта"
+    title: "Do not defer reversible work without an artifact"
     enforcement_layer: 2
     tier: rule-based
     default_action: auto
@@ -79,7 +80,7 @@ rules:
     anti_deferral: true
 
   - rule_id: FB-6
-    title: "Делать решения обратимыми при неопределённости"
+    title: "Keep decisions reversible under uncertainty"
     enforcement_layer: 6
     tier: rule-based
     default_action: auto
@@ -88,7 +89,7 @@ rules:
     conflicts_with_law: 4
 
   - rule_id: FB-7
-    title: "Заложить корректировку / откат / переделку после тестов"
+    title: "Provide correction and rollback after testing"
     enforcement_layer: 3
     tier: rule-based
     default_action: auto
@@ -97,7 +98,7 @@ rules:
     conflicts_with_law: 4
 
   - rule_id: FB-8
-    title: "Эскалировать только реально блокирующие вопросы"
+    title: "Escalate only genuinely blocking questions"
     enforcement_layer: 6
     tier: escalation
     default_action: escalate
@@ -121,6 +122,30 @@ hard_gated_actions:
   # Requires explicit --publish flag. Dry-run is the default mode.
   # Enforced by: scripts/content_consilium_gate.sh.
   - content_consilium_publish
+
+# Immutable Supreme-Directive floor. Per-space policy can never lift these.
+always_gated_floor:
+  - finance_action
+  - legal_action
+  - git_history_delete
+  - force_push_drops_commits
+  - irreversible_db_no_backup
+  - supreme_directive_forbidden
+
+# Runtime action kind → spaces/{name}/space.yml autonomy.policy key.
+action_autonomy_map:
+  feature_branch_push: feature_branch_push
+  merge_main: merge_main
+  prod_deploy: prod_deploy
+  publish_public: publish_public
+  public_communication: publish_public
+  content_consilium_publish: publish_public
+  public_package_release: publish_public
+  secret_rotation: secret_rotation
+  verify: verify
+  cross_project_write: cross_project_write
+  force_push: merge_main
+  irreversible_db_op: prod_deploy
 
 # Carve-out (set 2026-05-31): the public_package_release sub-case is autonomous
 # for patch/minor ONLY when escalate=false (all fail-closed gates green). A major

--- a/plugins/dr-orchestrate/scripts/action_gate.sh
+++ b/plugins/dr-orchestrate/scripts/action_gate.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Write-ahead gate for operational actions before dr-orchestrate execution.
+set -euo pipefail
+
+DR_ORCH_DIR="${DR_ORCH_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+REPO_ROOT="$(cd "$DR_ORCH_DIR/../.." && pwd)"
+RESOLVER="${DR_AUTONOMY_RESOLVER:-$REPO_ROOT/dev-tools/resolve-space-autonomy.sh}"
+export DR_AUTONOMY_RULES="${DR_AUTONOMY_RULES:-$DR_ORCH_DIR/rules/fb-rules.yaml}"
+
+gate() {
+  "$RESOLVER" gate "$@"
+}
+
+command_name="${1:-}"
+shift || true
+case "$command_name" in
+  gate) gate "$@" ;;
+  *) echo "usage: action_gate.sh gate --action <kind> [--payload <json>]" >&2; exit 2 ;;
+esac

--- a/plugins/dr-orchestrate/scripts/cmd_run.sh
+++ b/plugins/dr-orchestrate/scripts/cmd_run.sh
@@ -67,13 +67,15 @@ AUDIT_FILE="$AUDIT_DIR/audit-$(date -u +%Y-%m-%d).jsonl"
 # emits an audit v2 record with outcome=resolved or routes to escalation.
 resolve_and_route() {
   local text="$1"; local pane="$2"; local start_ms="$3"
-  local resolver_json conf action backend_used model end_ms dur
+  local resolver_json conf action action_kind action_payload backend_used model end_ms dur
   resolver_json="$(bash "$DR_ORCH_DIR/scripts/subagent_resolver.sh" resolve "$text" 2>/dev/null || true)"
   if [[ -z "$resolver_json" ]]; then
     resolver_json='{"action":"","confidence":0,"reason":"resolver_failed","backend_used":"none","subagent_model":""}'
   fi
   conf="$(printf '%s' "$resolver_json" | jq -r '.confidence // 0')"
   action="$(printf '%s' "$resolver_json" | jq -r '.action // ""')"
+  action_kind="$(printf '%s' "$resolver_json" | jq -r '.action_kind // ""')"
+  action_payload="$(printf '%s' "$resolver_json" | jq -c '.action_payload // {}')"
   backend_used="$(printf '%s' "$resolver_json" | jq -r '.backend_used // ""')"
   model="$(printf '%s' "$resolver_json" | jq -r '.subagent_model // ""')"
   end_ms="$(now_ms)"
@@ -84,6 +86,25 @@ resolve_and_route() {
   awk -v c="$conf" -v t="$CONFIDENCE_THRESHOLD" 'BEGIN{ exit !(c+0 >= t+0) }' && pass=1
 
   if (( pass )); then
+    if [[ -n "$action_kind" ]]; then
+      local gate_rc
+      set +e
+      bash "$DR_ORCH_DIR/scripts/action_gate.sh" gate \
+        --action "$action_kind" --payload "$action_payload" >/dev/null
+      gate_rc=$?
+      set -e
+      if (( gate_rc != 0 )); then
+        DR_ORCH_PROMPT_TEXT="$text" \
+          bash "$DR_ORCH_DIR/scripts/escalation_backend.sh" emit "$resolver_json" "$pane" || true
+        local gate_evt
+        gate_evt="$(make_event_v2 "$text" "$action" "$gate_rc" "$dur" "$pane" \
+          "$conf" "$model" "$backend_used" "${DR_ORCH_ESCALATION_BACKEND:-mock}" \
+          "escalate" "escalated_space_policy" "space autonomy gate denied action")"
+        emit "$AUDIT_FILE" "$gate_evt"
+        echo "dr-orchestrate: escalate | action_kind=$action_kind | reason=space_policy"
+        return 0
+      fi
+    fi
     local outcome="resolved"
     if ! check_cooldown "$pane" decision 2>/dev/null; then
       outcome="blocked_decision_cooldown"

--- a/plugins/dr-orchestrate/scripts/rules_loader.sh
+++ b/plugins/dr-orchestrate/scripts/rules_loader.sh
@@ -52,6 +52,26 @@ load_fb_hard_gates() {
   yq eval -o=json '.hard_gated_actions // []' "$src" 2>/dev/null || echo '[]'
 }
 
+load_always_gated_floor() {
+  local src="${1:-$DR_ORCH_FB_RULES}"
+  [[ -f "$src" && -s "$src" ]] || return 2
+  yq eval -e -o=json '.always_gated_floor | select(type == "!!seq" and length > 0)' \
+    "$src" 2>/dev/null || return 2
+}
+
+load_action_autonomy_map() {
+  local src="${1:-$DR_ORCH_FB_RULES}"
+  [[ -f "$src" && -s "$src" ]] || return 2
+  yq eval -e -o=json '.action_autonomy_map | select(type == "!!map" and length > 0)' \
+    "$src" 2>/dev/null || return 2
+}
+
+resolve_space_autonomy() {
+  local resolver="$DR_ORCH_DIR/../../dev-tools/resolve-space-autonomy.sh"
+  [[ -x "$resolver" ]] || return 2
+  "$resolver" gate "$@"
+}
+
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   fn="${1:-}"; shift || true
   [[ -n "$fn" ]] || { echo "usage: rules_loader.sh <fn> [args]" >&2; exit 2; }

--- a/plugins/dr-orchestrate/scripts/subagent_resolver.sh
+++ b/plugins/dr-orchestrate/scripts/subagent_resolver.sh
@@ -207,15 +207,23 @@ _extract_json() {
 _build_prompt() {
   local pane_text="$1"
   local rules; rules="$(load)"
-  local actions
+  local actions action_kinds
   actions="$(printf '%s' "$rules" | jq -r '[.[].action] | unique | join(" ")')"
+  action_kinds="$(load_action_autonomy_map 2>/dev/null \
+    | jq -r 'keys | join(" ")' 2>/dev/null || true)"
   cat <<PROMPT
 You are a strict classifier for a Datarim CLI pipeline pane.
 Pick the single most likely intended slash-command from this closed set:
   ${actions}
 
 Respond with ONLY a JSON object — no prose, no markdown fences:
-  {"action":"/dr-...","confidence":<float 0..1>,"reason":"<short>"}
+  {"action":"/dr-...","confidence":<float 0..1>,"reason":"<short>",
+   "action_kind":"<optional operational kind>","action_payload":{}}
+
+When the pane requests a normally gated operational action, set action_kind
+from this closed set and include required booleans in action_payload:
+  ${action_kinds}
+Otherwise omit action_kind or set it to an empty string.
 
 If no command applies, set "confidence" to 0 and "action" to "".
 

--- a/plugins/dr-orchestrate/tests/test_action_gate.bats
+++ b/plugins/dr-orchestrate/tests/test_action_gate.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+
+setup() {
+  export PLUGIN_ROOT
+  PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  export REPO_ROOT
+  REPO_ROOT="$(cd "$PLUGIN_ROOT/../.." && pwd)"
+  export DATARIM_SPACES_ROOT="$BATS_TEST_TMPDIR/spaces"
+  export DR_AUTONOMY_RULES="$BATS_TEST_TMPDIR/fb-rules.yaml"
+  export DR_ORCH_AUTONOMY_AUDIT="$BATS_TEST_TMPDIR/autonomy.jsonl"
+  mkdir -p "$DATARIM_SPACES_ROOT/arcanada"
+  cat > "$DATARIM_SPACES_ROOT/arcanada/space.yml" <<'YAML'
+space:
+  name: arcanada
+autonomy:
+  schema_version: 1
+  policy:
+    merge_main: auto
+YAML
+  cat > "$DR_AUTONOMY_RULES" <<'YAML'
+always_gated_floor: [finance_action]
+action_autonomy_map:
+  merge_main: merge_main
+YAML
+}
+
+@test "action gate allows configured automatic action and writes audit first" {
+  run env DATARIM_ACTIVE_SPACE=arcanada \
+    "$PLUGIN_ROOT/scripts/action_gate.sh" gate --action merge_main
+  [ "$status" -eq 0 ] \
+    && [ -s "$DR_ORCH_AUTONOMY_AUDIT" ] \
+    && [ "$(jq -r '.decision' "$DR_ORCH_AUTONOMY_AUDIT")" = auto ]
+}
+
+@test "action gate blocks floor action even in permissive space" {
+  run env DATARIM_ACTIVE_SPACE=arcanada \
+    "$PLUGIN_ROOT/scripts/action_gate.sh" gate --action finance_action
+  [ "$status" -eq 10 ] \
+    && [ "$(jq -r '.floor_hit' "$DR_ORCH_AUTONOMY_AUDIT")" = true ]
+}
+
+@test "action gate fails safe when active space is unresolved" {
+  run env DATARIM_ACTIVE_SPACE=missing \
+    "$PLUGIN_ROOT/scripts/action_gate.sh" gate --action merge_main
+  [ "$status" -eq 10 ] \
+    && [ "$(jq -r '.reason_code' "$DR_ORCH_AUTONOMY_AUDIT")" = unresolved_space ]
+}
+
+@test "cmd_run wires action_kind through action_gate before autonomous resolution" {
+  grep -qF 'action_kind="$(printf' "$PLUGIN_ROOT/scripts/cmd_run.sh" \
+    && grep -qF 'scripts/action_gate.sh" gate' "$PLUGIN_ROOT/scripts/cmd_run.sh" \
+    && grep -qF 'escalated_space_policy' "$PLUGIN_ROOT/scripts/cmd_run.sh"
+}
+
+@test "action gate defaults to the bundled policy file" {
+  unset DR_AUTONOMY_RULES
+  run env DATARIM_ACTIVE_SPACE=arcanada \
+    "$PLUGIN_ROOT/scripts/action_gate.sh" gate --action merge_main
+  [ "$status" -eq 0 ]
+}

--- a/plugins/dr-orchestrate/tests/test_rules_loader.bats
+++ b/plugins/dr-orchestrate/tests/test_rules_loader.bats
@@ -101,3 +101,31 @@ YAML
     n=$(echo "$output" | jq 'length')
     [ "$n" -ge 10 ]
 }
+
+@test "TUNE-0436: loader exposes immutable floor" {
+    export DR_ORCH_FB_RULES="$TMP_RULES_DIR/fb.yaml"
+    cat > "$DR_ORCH_FB_RULES" <<'YAML'
+always_gated_floor: [finance_action, legal_action]
+YAML
+    run bash "$DR_ORCH_DIR/scripts/rules_loader.sh" load_always_gated_floor
+    [ "$status" -eq 0 ] \
+      && [ "$(jq -r 'length' <<<"$output")" -eq 2 ]
+}
+
+@test "TUNE-0436: loader rejects missing immutable floor" {
+    export DR_ORCH_FB_RULES="$TMP_RULES_DIR/fb.yaml"
+    printf 'rules: []\n' > "$DR_ORCH_FB_RULES"
+    run bash "$DR_ORCH_DIR/scripts/rules_loader.sh" load_always_gated_floor
+    [ "$status" -eq 2 ]
+}
+
+@test "TUNE-0436: loader exposes action autonomy map" {
+    export DR_ORCH_FB_RULES="$TMP_RULES_DIR/fb.yaml"
+    cat > "$DR_ORCH_FB_RULES" <<'YAML'
+action_autonomy_map:
+  merge_main: merge_main
+YAML
+    run bash "$DR_ORCH_DIR/scripts/rules_loader.sh" load_action_autonomy_map
+    [ "$status" -eq 0 ] \
+      && [ "$(jq -r '.merge_main' <<<"$output")" = merge_main ]
+}

--- a/skills/autonomous-mode/SKILL.md
+++ b/skills/autonomous-mode/SKILL.md
@@ -133,7 +133,7 @@ Consumed by `/dr-archive` Step 0.5 (pre-reflection): the inline-log surfaces as 
 **Carve-out (consumer mandate § Carve-out):** the consumer's `autonomous-agents.md` MAY define narrowly-scoped exceptions to this list. The reference Arcanada mandate carves out **autonomous public-package release of patch / minor versions** when every fail-closed pre-publish gate is green (`escalate=false`); `major` and any `0.x` breaking change still escalate, with a GitHub conditional `environment` as a second backstop. The machine-readable shape is `plugins/dr-orchestrate/rules/fb-rules.yaml` § `hard_gate_carve_outs`. Read the consumer mandate's carve-out section before treating a release action as hard-gated — do not quote the carve-out from memory.
 
 Before escalation, resolve the action through
-`dev-tools/resolve-space-autonomy.sh gate --action <kind> --payload <json>`.
+`${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/resolve-space-autonomy.sh gate --action <kind> --payload <json>`.
 The resolver returns `0` for autonomous execution, `10` for operator
 escalation, and `2` for an invalid policy invariant. Missing or malformed
 policy always resolves to operator escalation.

--- a/skills/autonomous-mode/SKILL.md
+++ b/skills/autonomous-mode/SKILL.md
@@ -28,7 +28,12 @@ task_id: TUNE-XXXX
 activated_at: 2026-05-24T12:00:00Z
 activated_by: /dr-auto
 mode: continue|bootstrap
+space: arcanada
 ```
+
+`space` binds the cycle to a registered space for autonomy-policy resolution.
+If it is absent and no deterministic workspace match exists, operational
+actions remain operator-gated.
 
 **24h TTL.** If the marker was created more than 24 hours ago → silently purge it (the agent deletes the file or ignores it). Only `/dr-auto` re-creates the marker.
 
@@ -127,13 +132,25 @@ Consumed by `/dr-archive` Step 0.5 (pre-reflection): the inline-log surfaces as 
 
 **Carve-out (consumer mandate § Carve-out):** the consumer's `autonomous-agents.md` MAY define narrowly-scoped exceptions to this list. The reference Arcanada mandate carves out **autonomous public-package release of patch / minor versions** when every fail-closed pre-publish gate is green (`escalate=false`); `major` and any `0.x` breaking change still escalate, with a GitHub conditional `environment` as a second backstop. The machine-readable shape is `plugins/dr-orchestrate/rules/fb-rules.yaml` § `hard_gate_carve_outs`. Read the consumer mandate's carve-out section before treating a release action as hard-gated — do not quote the carve-out from memory.
 
-Under `/dr-auto`, these actions **never auto-execute** (except where a consumer-mandate carve-out applies and all its preconditions are met):
+Before escalation, resolve the action through
+`dev-tools/resolve-space-autonomy.sh gate --action <kind> --payload <json>`.
+The resolver returns `0` for autonomous execution, `10` for operator
+escalation, and `2` for an invalid policy invariant. Missing or malformed
+policy always resolves to operator escalation.
 
-1. The agent recognises the action as hard-gated (against the verbatim list or as a cross-project boundary crossing).
-2. Escalate via Ladder L5: call `AskUserQuestion` and state explicitly "This action is hard-gated per autonomous-agents.md:32. Operator approval required before execution."
-3. Log the operator response via `"${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/append-init-task-qa.sh" --decided-by operator --question "<question text>" --answer "<operator response>"`.
+The immutable floor is checked first and cannot be lifted by any space:
+finance/legal actions, irreversible database operations without a verified
+backup, git-history deletion, force-pushes that drop commits, and Supreme
+Directive violations. A signed fast-forward update to `main` is `merge_main`,
+not history deletion.
 
-**Cross-project boundary (additional rule):** any action that touches repositories outside the task's project scope (the scope is defined by the Task Prefix Registry — `Arcanada/CLAUDE.md` or `documentation/architecture/task-prefix-registry.md`) is also hard-gated. Example: a task with prefix `SUP-` tries to edit `Projects/Verdicus/` → hard-gated.
+When the resolver returns `0`, execute without `AskUserQuestion`; the
+write-ahead audit record is mandatory. When it returns `10` or `2`, escalate
+via Ladder L5 and log the response through `append-init-task-qa.sh`.
+
+**Cross-project boundary:** resolve `cross_project_write` through the same
+space policy. Unresolved ownership or an unknown target fails closed to the
+operator.
 
 **Workspace branch discipline (pre-file-edit check):** before editing any file in a workspace-root repository (one outside the task's own code repo — e.g. a shared mandate or doc tree), confirm `git branch --show-current` matches the active task. In a shared workspace with several parallel task branches checked out, a routine edit otherwise lands on whichever branch happens to be current and travels with the wrong merge. If the current branch does not match the task, create a task-named branch (or escalate) before writing — do not edit on a sibling task's branch.
 

--- a/tests/dr-auto-marker-resilience.bats
+++ b/tests/dr-auto-marker-resilience.bats
@@ -126,3 +126,17 @@ YAML
     [ "$status" -eq 0 ]
     [ "$output" = "non-auto" ]
 }
+
+@test "reassert writes the resolved space binding" {
+    run "$HELPER" reassert --root "$FAKE_ROOT" --task-id "$TASK_ID" --space arcanada
+    [ "$status" -eq 0 ]
+    [ "$(yq eval -r '.space' "$MARKER")" = arcanada ]
+}
+
+@test "reassert replaces a marker with the wrong space binding" {
+    _seed_marker "$TASK_ID"
+    printf 'space: aether\n' >> "$MARKER"
+    run "$HELPER" reassert --root "$FAKE_ROOT" --task-id "$TASK_ID" --space arcanada
+    [ "$status" -eq 0 ]
+    [ "$(yq eval -r '.space' "$MARKER")" = arcanada ]
+}

--- a/tests/space-autonomy.bats
+++ b/tests/space-autonomy.bats
@@ -1,0 +1,244 @@
+#!/usr/bin/env bats
+
+setup() {
+  export REPO_ROOT
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  export SPACES_ROOT="$BATS_TEST_TMPDIR/spaces"
+  export RULES_FILE="$BATS_TEST_TMPDIR/fb-rules.yaml"
+  export DR_AUTONOMY_AUDIT="$BATS_TEST_TMPDIR/autonomy.jsonl"
+  export DATARIM_TASK_ID="TUNE-0436"
+  export DR_AUTONOMY_ACTOR="bats-agent"
+  mkdir -p "$SPACES_ROOT/arcanada" "$SPACES_ROOT/aether"
+  mkdir -p "$BATS_TEST_TMPDIR/escape"
+
+  cat > "$SPACES_ROOT/arcanada/space.yml" <<'YAML'
+space:
+  name: arcanada
+  status: active
+autonomy:
+  schema_version: 1
+  policy:
+    feature_branch_push: auto
+    merge_main: auto
+    prod_deploy: auto
+    publish_public: auto
+    secret_rotation: auto
+    verify: auto
+    cross_project_write: auto
+YAML
+
+  cat > "$SPACES_ROOT/aether/space.yml" <<'YAML'
+space:
+  name: aether
+  status: active
+autonomy:
+  schema_version: 1
+  policy:
+    feature_branch_push: auto
+    merge_main: operator
+    prod_deploy: operator
+    publish_public: operator
+    secret_rotation: operator
+    verify: auto
+    cross_project_write: operator
+YAML
+
+  cat > "$BATS_TEST_TMPDIR/escape/space.yml" <<'YAML'
+space:
+  name: escape
+autonomy:
+  schema_version: 1
+  policy:
+    merge_main: auto
+YAML
+
+  cat > "$RULES_FILE" <<'YAML'
+always_gated_floor:
+  - finance_action
+  - legal_action
+  - git_history_delete
+  - force_push_drops_commits
+  - irreversible_db_no_backup
+action_autonomy_map:
+  feature_branch_push: feature_branch_push
+  merge_main: merge_main
+  prod_deploy: prod_deploy
+  publish_public: publish_public
+  secret_rotation: secret_rotation
+  verify: verify
+  cross_project_write: cross_project_write
+  public_package_release: publish_public
+  force_push: merge_main
+  irreversible_db_op: prod_deploy
+YAML
+}
+
+gate() {
+  local payload='{}'
+  if [[ $# -ge 3 ]]; then
+    payload="$3"
+  fi
+  run env \
+    DATARIM_SPACES_ROOT="$SPACES_ROOT" \
+    DATARIM_ACTIVE_SPACE="$1" \
+    DR_AUTONOMY_RULES="$RULES_FILE" \
+    "$REPO_ROOT/dev-tools/resolve-space-autonomy.sh" gate \
+      --action "$2" --payload "$payload"
+}
+
+@test "Arcanada merge_main resolves auto" {
+  gate arcanada merge_main
+  [ "$status" -eq 0 ] && [ "$(jq -r '.decision' <<<"$output")" = auto ]
+}
+
+@test "Aether merge_main remains operator-gated" {
+  gate aether merge_main
+  [ "$status" -eq 10 ] && [ "$(jq -r '.decision' <<<"$output")" = operator ]
+}
+
+@test "feature branch push is explicitly auto in both existing spaces" {
+  gate arcanada feature_branch_push
+  [ "$status" -eq 0 ]
+  gate aether feature_branch_push
+  [ "$status" -eq 0 ]
+}
+
+@test "finance floor overrides Arcanada auto policy" {
+  gate arcanada finance_action
+  [ "$status" -eq 10 ] \
+    && [ "$(jq -r '.floor_hit' <<<"$output")" = true ] \
+    && [ "$(jq -r '.precedence_layer' <<<"$output")" = P0 ] \
+    && [ "$(jq -r '.space' <<<"$output")" = arcanada ]
+}
+
+@test "commit-dropping force push is always gated" {
+  gate arcanada force_push '{"drops_commits":true}'
+  [ "$status" -eq 10 ] \
+    && [ "$(jq -r '.effective_action_kind' <<<"$output")" = force_push_drops_commits ]
+}
+
+@test "non-dropping main update follows merge_main policy" {
+  gate arcanada force_push '{"drops_commits":false,"target_branch":"main"}'
+  [ "$status" -eq 0 ]
+  gate aether force_push '{"drops_commits":false,"target_branch":"main"}'
+  [ "$status" -eq 10 ]
+}
+
+@test "non-dropping feature force push follows feature branch policy" {
+  gate aether force_push '{"drops_commits":false,"target_branch":"feat/safe-rewrite"}'
+  [ "$status" -eq 0 ] \
+    && [ "$(jq -r '.effective_action_kind' <<<"$output")" = feature_branch_push ]
+}
+
+@test "irreversible DB operation without backup is always gated" {
+  gate arcanada irreversible_db_op '{"backup_verified":false}'
+  [ "$status" -eq 10 ] \
+    && [ "$(jq -r '.effective_action_kind' <<<"$output")" = irreversible_db_no_backup ]
+}
+
+@test "DB operation with verified backup follows space policy" {
+  gate arcanada irreversible_db_op '{"backup_verified":true}'
+  [ "$status" -eq 0 ]
+  gate aether irreversible_db_op '{"backup_verified":true}'
+  [ "$status" -eq 10 ]
+}
+
+@test "missing autonomy block fails safe to operator" {
+  yq -i 'del(.autonomy)' "$SPACES_ROOT/arcanada/space.yml"
+  gate arcanada merge_main
+  [ "$status" -eq 10 ] \
+    && [ "$(jq -r '.reason_code' <<<"$output")" = invalid_or_missing_autonomy ]
+}
+
+@test "one malformed policy value invalidates the whole block" {
+  yq -i '.autonomy.policy.secret_rotation = "yes"' "$SPACES_ROOT/arcanada/space.yml"
+  gate arcanada merge_main
+  [ "$status" -eq 10 ] \
+    && [ "$(jq -r '.reason_code' <<<"$output")" = invalid_or_missing_autonomy ]
+}
+
+@test "unresolved space fails safe to operator" {
+  gate missing merge_main
+  [ "$status" -eq 10 ] \
+    && [ "$(jq -r '.reason_code' <<<"$output")" = unresolved_space ]
+}
+
+@test "missing immutable floor is an invariant error" {
+  yq -i 'del(.always_gated_floor)' "$RULES_FILE"
+  gate arcanada merge_main
+  [ "$status" -eq 2 ] \
+    && [ "$(jq -r '.reason_code' <<<"$output")" = invalid_rules ]
+}
+
+@test "unknown action kind fails safe to operator" {
+  gate arcanada unknown_action
+  [ "$status" -eq 10 ] \
+    && [ "$(jq -r '.reason_code' <<<"$output")" = unmapped_action ]
+}
+
+@test "patch package release requires both release carve-out and space publish policy" {
+  gate arcanada public_package_release \
+    '{"bump_level":"patch","escalate":false,"zero_x_breaking":false}'
+  [ "$status" -eq 0 ]
+  gate aether public_package_release \
+    '{"bump_level":"patch","escalate":false,"zero_x_breaking":false}'
+  [ "$status" -eq 10 ]
+}
+
+@test "major package release remains operator-gated in Arcanada" {
+  gate arcanada public_package_release \
+    '{"bump_level":"major","escalate":false,"zero_x_breaking":false}'
+  [ "$status" -eq 10 ] \
+    && [ "$(jq -r '.reason_code' <<<"$output")" = release_carveout_denied ] \
+    && [ "$(jq -r '.precedence_layer' <<<"$output")" = P1 ]
+}
+
+@test "0.x breaking package release remains operator-gated" {
+  gate arcanada public_package_release \
+    '{"bump_level":"minor","escalate":false,"zero_x_breaking":true}'
+  [ "$status" -eq 10 ] \
+    && [ "$(jq -r '.reason_code' <<<"$output")" = release_carveout_denied ]
+}
+
+@test "core resolver writes the decision audit before returning" {
+  gate arcanada merge_main
+  [ "$status" -eq 0 ] \
+    && [ -s "$DR_AUTONOMY_AUDIT" ] \
+    && [ "$(tail -1 "$DR_AUTONOMY_AUDIT" | jq -r '.decision')" = auto ] \
+    && [ "$(tail -1 "$DR_AUTONOMY_AUDIT" | jq -r '.timestamp | length > 0')" = true ] \
+    && [ "$(tail -1 "$DR_AUTONOMY_AUDIT" | jq -r '.actor')" = bats-agent ] \
+    && [ "$(tail -1 "$DR_AUTONOMY_AUDIT" | jq -r '.task_id')" = TUNE-0436 ]
+}
+
+@test "active space name rejects path traversal" {
+  gate '../escape' merge_main
+  [ "$status" -eq 10 ] \
+    && [ "$(jq -r '.reason_code' <<<"$output")" = unresolved_space ]
+}
+
+@test "force push without an explicit no-loss discriminator fails safe" {
+  gate arcanada force_push '{}'
+  [ "$status" -eq 10 ] \
+    && [ "$(jq -r '.effective_action_kind' <<<"$output")" = force_push_drops_commits ]
+}
+
+@test "non-dropping force push without a target branch fails safe" {
+  gate arcanada force_push '{"drops_commits":false}'
+  [ "$status" -eq 10 ] \
+    && [ "$(jq -r '.reason_code' <<<"$output")" = unmapped_action ]
+}
+
+@test "dr-auto marker space field resolves the active space" {
+  mkdir -p "$BATS_TEST_TMPDIR/work/datarim"
+  cat > "$BATS_TEST_TMPDIR/work/datarim/.auto-mode-active" <<'YAML'
+task_id: TUNE-0436
+space: arcanada
+YAML
+  run bash -c "cd '$BATS_TEST_TMPDIR/work' && \
+    DATARIM_SPACES_ROOT='$SPACES_ROOT' \
+    DR_AUTONOMY_RULES='$RULES_FILE' \
+    DR_AUTONOMY_AUDIT='$DR_AUTONOMY_AUDIT' \
+    '$REPO_ROOT/dev-tools/resolve-space-autonomy.sh' gate --action merge_main"
+  [ "$status" -eq 0 ] \
+    && [ "$(jq -r '.space' <<<"$output")" = arcanada ]
+}


### PR DESCRIPTION
Per-space autonomy flags lifting framework operational blockers. Source of truth: `spaces/{name}/space.yml` `autonomy:` block. Floor (finance/legal, irreversible-db-no-backup, git-history-delete) is non-overridable. Fail-safe default = operator.

QA: PASS (92/92 affected bats, ShellCheck/Semgrep clean, English-only PASS, yq valid). Compliance: COMPLIANT. Live sim: Arcanada merge_main→auto, Aether merge_main→operator, Arcanada finance→operator (floor).

Report: datarim/reports/TUNE-0436-report.md. Signed commit, FF-merge to main per signed-commit recipe.