### PR TITLE
fix(dr-plugin,install): reconcile docs with implemented subcommands + bundled-plugin hint [TUNE-0439]

### DIFF
--- a/commands/dr-auto.md
+++ b/commands/dr-auto.md
@@ -102,7 +102,7 @@ violations. Other operational actions ask only when the resolved
 
 - Exploratory work where the operator's intent is going to be refined as the task progresses.
 - High-risk changes to the framework's operating model, where each stage gate is genuinely a decision point that needs the operator present.
-- Coordinating work across multiple repositories. Use `/dr-orchestrate` for that — it is built for parallel multi-task execution and `/dr-auto` is not.
+- Coordinating work across multiple repositories. Use `/dr-orchestrate` for that — it is built for parallel multi-task execution and `/dr-auto` is not. **Note:** `/dr-orchestrate` ships as an opt-in plugin (`plugins/dr-orchestrate/`); it resolves only after `/dr-plugin enable <abs-path>/plugins/dr-orchestrate` in the workspace. If the command is unknown, enable the plugin first.
 
 ## Stage Snapshot Emission (Mandatory Terminal Step)
 
@@ -119,4 +119,4 @@ This snapshot overwrites the last delegated sub-stage snapshot — the intended 
 
 - Skill: `skills/autonomous-mode/SKILL.md` — the operating rules every stage loads.
 - Mandate: `documentation/mandates/autonomous-agents.md` — the source-of-truth rules for autonomous behaviour.
-- Commands: `/dr-next` (the underlying mechanism for resume mode), `/dr-orchestrate` (parallel multi-task, complementary).
+- Commands: `/dr-next` (the underlying mechanism for resume mode), `/dr-orchestrate` (parallel multi-task, complementary — opt-in plugin, enable via `/dr-plugin enable <abs-path>/plugins/dr-orchestrate`).

--- a/commands/dr-plugin.md
+++ b/commands/dr-plugin.md
@@ -1,7 +1,7 @@
 # /dr-plugin — Datarim Plugin System CLI
 
 **Source:** plugin-system core PRD and plan (see workspace `datarim/prd/` and `datarim/plans/` indexes).
-**Status (Phase A scaffold):** `list` + first-run bootstrap implemented; `enable`/`disable`/`sync`/`doctor` deferred to next iterations.
+**Status:** `list` + first-run bootstrap, `enable`, `disable`, `sync`, and `doctor` are all implemented and covered by `tests/dr-plugin.bats` + `tests/dr-plugin-coverage.bats`. Git-URL clone for `enable` (Phase A4) remains the only deferred path.
 
 ## Purpose
 
@@ -19,10 +19,10 @@ Templates: `${DATARIM_RUNTIME:-$HOME/.claude}/templates/plugin.yaml.template`, `
 
 ```
 /dr-plugin list                  # show active plugins (bootstraps datarim-core on first run)
-/dr-plugin enable <id|path|url>  # activate a plugin (Phase A3 — pending)
-/dr-plugin disable <id>          # deactivate (Phase A3 — pending; refuses datarim-core)
-/dr-plugin sync                  # reconcile filesystem with manifest (Phase C — pending)
-/dr-plugin doctor [--fix]        # diagnose inconsistent state (Phase D — pending)
+/dr-plugin enable <abs-path>     # activate a plugin from an absolute path (git-URL clone deferred — Phase A4)
+/dr-plugin disable <id>          # deactivate (refuses datarim-core)
+/dr-plugin sync                  # reconcile filesystem with manifest
+/dr-plugin doctor [--fix]        # diagnose inconsistent state (8 checks)
 /dr-plugin --help                # usage
 ```
 
@@ -43,7 +43,7 @@ Helpers in `scripts/lib/plugin-system.sh`:
 | 0 | success |
 | 1 | validation/conflict error |
 | 2 | I/O / filesystem error |
-| 3 | concurrent invocation (lock held; Phase A3+) |
+| 3 | concurrent invocation (lock held) |
 | 64 | usage error |
 
 ## Environment overrides (testing)
@@ -55,13 +55,14 @@ Helpers in `scripts/lib/plugin-system.sh`:
 
 ## Tests
 
-`tests/dr-plugin.bats` — 28 cases, GREEN on macOS bash 3.2 + Linux bash 5+.
+`tests/dr-plugin.bats` (77+ cases) + `tests/dr-plugin-coverage.bats` (4 reachability/coverage gates) — GREEN on macOS bash 3.2 + Linux bash 5+.
 
 ## Roadmap
 
-- **Phase A3** — `enable`/`disable` happy paths + first-run inventory backfill for `datarim-core`.
-- **Phase B** — `overrides:` mechanism + conflict pre-scan.
-- **Phase C** — snapshot/rollback + `sync`.
-- **Phase D** — `doctor` (8 checks).
+- **Phase A3** — ✅ done. `enable`/`disable` happy paths + first-run inventory backfill for `datarim-core`.
+- **Phase B** — ✅ done. `overrides:` mechanism + conflict pre-scan.
+- **Phase C** — ✅ done. snapshot/rollback + `sync`.
+- **Phase D** — ✅ done. `doctor` (8 checks).
+- **Phase A4** — `enable` from a git URL (clone-and-activate). Deferred.
 - **Phase E** — Class B public surface (CLAUDE.md, README, datarim.club).
 - **Phase F** — author guide + bats coverage ≥80%.

--- a/install.sh
+++ b/install.sh
@@ -1187,6 +1187,22 @@ fanout_runtime() {
     echo "  3. Start Claude Code and run: /dr-init <task description>"
     echo ""
 
+    # Bundled opt-in plugins (TUNE-0439): install distributes only the canonical
+    # scopes; plugins under plugins/ are opt-in per-workspace via /dr-plugin enable
+    # and are deliberately NOT auto-distributed. Surface them so operators know the
+    # bundled commands (e.g. /dr-orchestrate) exist and how to activate them —
+    # otherwise a shipped-but-unactivated plugin reads as a missing command.
+    if [ -d "$SCRIPT_DIR/plugins" ]; then
+        bundled_plugins=$(find "$SCRIPT_DIR/plugins" -mindepth 2 -maxdepth 2 -name plugin.yaml 2>/dev/null | sed 's#/plugin.yaml$##' | sort)
+        if [ -n "$bundled_plugins" ]; then
+            echo "Bundled opt-in plugins (activate per-workspace with /dr-plugin enable):"
+            printf '%s\n' "$bundled_plugins" | while IFS= read -r p; do
+                [ -n "$p" ] && echo "  /dr-plugin enable $p"
+            done
+            echo ""
+        fi
+    fi
+
     if [ "$SKIPPED" -gt 0 ] && [ "$FORCE" = false ] && [ "$INSTALL_MODE" = "copy" ]; then
         echo "Note: $SKIPPED file(s) were skipped because they already exist."
         echo "      Use --force to overwrite (safe: a backup is taken automatically"

--- a/scripts/dr-plugin.sh
+++ b/scripts/dr-plugin.sh
@@ -82,10 +82,10 @@ USAGE:
 
 COMMANDS:
   list                  Show active plugins (bootstraps datarim-core on first run)
-  enable <id|path|url>  Activate a plugin (Phase A3 — not yet implemented)
-  disable <id>          Deactivate a plugin (Phase A3 — not yet implemented)
-  sync                  Reconcile filesystem with manifest (Phase C — not yet implemented)
-  doctor [--fix]        Diagnose inconsistent state (Phase D — not yet implemented)
+  enable <abs-path>     Activate a plugin from an absolute path (git-URL clone deferred — Phase A4)
+  disable <id>          Deactivate a plugin (refuses datarim-core)
+  sync                  Reconcile filesystem with manifest
+  doctor [--fix]        Diagnose inconsistent state (8 checks)
   --help                Show this message
 
 EXIT CODES:


### PR DESCRIPTION
## TUNE-0439 — Plugin-system activation gap (core fix)

**Root cause (verified both Mac + arcana-dev):** `dr-orchestrate` ships as opt-in plugin but was never activated on any machine — and `/dr-plugin` docs advertised enable/disable/sync/doctor as 'not yet implemented' while all four are fully implemented (cmd_enable:299, cmd_disable:537, cmd_sync:630, cmd_doctor:1040) with 77+ bats cases. NOT a Mac↔dev sync drift.

### Changes
- `commands/dr-plugin.md` — Status/subcommands/roadmap/exit-codes/test-count reconciled to reality (only git-URL clone, Phase A4, stays deferred).
- `scripts/dr-plugin.sh` — `--help` no longer lies about the 4 subcommands.
- `install.sh` — completion now prints a bundled-opt-in-plugins hint (`/dr-plugin enable <path>`) so operators discover `/dr-orchestrate`; plugins stay opt-in by design (not auto-distributed).
- `commands/dr-auto.md` — both `/dr-orchestrate` references guarded with enable-first note.

### Verification
- shellcheck -S error: clean
- dr-plugin.bats: 77/77 · dr-plugin-coverage.bats: 4/4 · install.bats: 29/29
- Live: `/dr-plugin enable` activates dr-orchestrate (symlink resolves), `disable` rolls back cleanly.

### Out of scope (operator-gated, separate)
- tmux orchestration rules + rollout to all machines (+Hermes) → TUNE-0104/0438
- 18-branch + 22-dirty-file workspace sweep → per-branch operator review