### PR TITLE
TUNE-0449 follow-up: provenance convention + evolution-log

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,7 +370,7 @@ This governs the language of **runtime artefacts** Datarim generates per task �
 5. **Context before code** — Gather requirements before implementing
 6. **One thing at a time** — Implement one method/stub per iteration
 7. **Human in the loop** — Evolution proposals need approval
-8. **Rules are stack- AND history-agnostic** — Task IDs MUST NOT appear in `skills/*.md`, `agents/*.md`, `commands/*.md`, `templates/*.md`. Provenance lives in `docs/evolution-log.md`, `documentation/archive/`, git log. Gates: `scripts/stack-agnostic-gate.sh` (stack terms) and `scripts/task-id-gate.sh` (history). Contracts: `skills/evolution/stack-agnostic-gate.md` and `skills/evolution/history-agnostic-gate.md`.
+8. **Rules are stack- AND history-agnostic** — Task IDs MUST NOT appear in `skills/*.md`, `agents/*.md`, `commands/*.md`, `templates/*.md`. Provenance lives in `docs/evolution-log.md`, `documentation/archive/`, git log. Gates: `scripts/stack-agnostic-gate.sh` (stack terms) and `scripts/task-id-gate.sh` (history). Contracts: `skills/evolution/stack-agnostic-gate.md` and `skills/evolution/history-agnostic-gate.md`. **Corollary for shipped data files (`dev-tools/rules/*.yaml`):** header comments in shipped policy-data files MUST cite provenance via `docs/evolution-log.md`, never via an `insights/INSIGHTS-{TASK-ID}-*.md` filename — insight files are gitignored, ephemeral runtime artefacts, whereas a shipped file's header is a public contract and carrying a task ID in it is the same history leak the gate forbids elsewhere.
 
 ---
 

--- a/docs/evolution-log.md
+++ b/docs/evolution-log.md
@@ -1,5 +1,14 @@
 # Evolution Log
 
+## 2026-06-23 — TUNE-0449 — Orchestration autonomy policy → core (Option C) + provenance convention (Class A applied)
+
+- Promoted the autonomy policy data + loader from the opt-in `dr-orchestrate` plugin into core `dev-tools/` (Option C, consilium-decided, operator-approved). The hard-gated safety floor and action-autonomy map now resolve from core without enabling any plugin; the transport runner stays an opt-in plugin via thin shims.
+- `dev-tools/rules/fb-rules.yaml` (moved) + `dev-tools/fb-policy-loader.sh` (new); plugin `rules_loader.sh`/`action_gate.sh` → thin shims (prefer-core, one-cycle deprecation fallback).
+- Stripped `plugin:`/`task:` frontmatter from `commands/dr-orchestrate.md`; `dr-auto.md` + `autonomous-mode/SKILL.md` no longer tell the operator to enable the plugin for the core path.
+- **Class A applied (Critical Rule #8 corollary):** header comments in shipped `dev-tools/rules/*.yaml` MUST cite provenance via `docs/evolution-log.md`, never via an `insights/INSIGHTS-{TASK-ID}-*.md` filename (gitignored ephemeral artefact). Source: TUNE-0449 reflection F1.
+- Class B held for backlog: task-id-gate scope expansion to `dev-tools/rules/` (needs false-positive assessment); `/dr-auto` independent-compliance-agent guideline for framework self-modification.
+- VERSION 2.44.0 → 2.45.0. Archive: `documentation/archive/framework/archive-TUNE-0449.md`.
+
 Append-only log of framework changes accepted from `/dr-archive` Step 0.5 reflection or curated runtime → repo updates.
 
 ## 2026-05-25 — TUNE-0303 — Codex CLI coworker-hook coverage parity (Class A applied)


### PR DESCRIPTION
Class A from TUNE-0449 reflection. Critical Rule #8 corollary: shipped `dev-tools/rules/*.yaml` headers cite provenance via `docs/evolution-log.md`, not insight filenames. + evolution-log entry for the orchestration-core promotion. Class B proposals filed as TUNE-0452/0453. Doc-only.