### PR TITLE
TUNE-0449 fix: /dr-orchestrate row in docs/commands.md (doc-fanout)

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -65,6 +65,7 @@ Source: TUNE-0032. Spec: `skills/cta-format/SKILL.md`. Template: `templates/cta-
 | `/dr-dream` | Maintenance | librarian | Knowledge base maintenance: organize, lint, index, cross-reference. Emits CTA. |
 | `/dr-optimize` | Maintenance | optimizer | Audit framework, prune unused, merge duplicates, sync docs. Emits CTA. |
 | `/dr-plugin` | Extension | -- | Manage opt-in plugin system: list active plugins, enable/disable third-party modules. Phase A (TUNE-0101). Emits CTA. |
+| `/dr-orchestrate run` | Core + Plugin | -- | Self-driving pipeline runner. **The command and its autonomy policy are core** — the hard-gated safety floor and action-autonomy map live in `dev-tools/rules/fb-rules.yaml` and resolve via `dev-tools/fb-policy-loader.sh` without enabling any plugin. Phase 2 adds multi-backend subagent inference for unknown prompts (autonomy L1 → L2). **The transport runner is the opt-in plugin** (terminal-multiplexer driver, inference-backend chain, bot/HTTP interface, audit backends) — enable via `/dr-plugin enable <path>/plugins/dr-orchestrate` only to drive panes. Security floor: whitelist + escape-block + micro/decision cooldown; JSONL audit, hash-only credentials. |
 
 ## Utility Commands (5)
 


### PR DESCRIPTION
Fixes the bats 'every dr-* command file appears in docs/commands.md' failure on main. Promoting dr-orchestrate to a core command made the doc-fanout coverage linter require its row; it was absent (previously plugin-only, unlisted). Doc-only n-way sync surface for the core promotion.