### PR TITLE
compliance: Report-cited-SHA resolution probe (Step 6) [TUNE-0459]

### DIFF
--- a/docs/evolution-log.md
+++ b/docs/evolution-log.md
@@ -1963,3 +1963,15 @@ gained a "Doc-Only QA Stub" item stating the stub satisfies QA-presence, so comp
 longer emits a "QA report absent" advisory for that class; every other class still requires a
 full QA report. The edit also removed a pre-existing duplicate "Operator-Only Runbooks"
 heading in the same checklist (numbering now sequential).
+
+**DEV-1547-FU-api-url-writeback** (Aether space; applied 2026-06-23) — `skills/compliance/SKILL.md`
+Software Checklist Step 6 (Test Execution) gained a **Report-cited-SHA resolution probe**. When a
+QA/compliance report cites commit SHAs or merge-request numbers, compliance must `git cat-file -t
+<sha>`; a SHA absent both locally and on the remote is a genuine fabrication finding (NON-COMPLIANT),
+while a SHA absent locally but present on the remote branch is the expected stale-clone case in a
+remote-first project — fetch read-only and verify the diff against `FETCH_HEAD` (no checkout, so a
+shared clone parked on another branch stays undisturbed). Class A (content-only, stack-neutral;
+stack-agnostic gate PASS). Recurrence-promoted (`incident_class: report-cites-sha-absent-on-local-clone`;
+prior occurrences in reflection-DEV-1476 / reflection-DEV-1517 fetch-remote-to-verify class). Operator-approved.
+Targeted bats green (check-skill-frontmatter, check-skill-layout, dr-compliance-deferral-gate,
+stack-agnostic-gate, tune-0255-compliance-template-shape, check-frontmatter-english).

--- a/skills/compliance/SKILL.md
+++ b/skills/compliance/SKILL.md
@@ -87,6 +87,10 @@ Read `datarim/tasks.md` and `datarim/activeContext.md` to determine task type:
 <!-- gate:history-allowed -->
 Prior incident: two test failures traced to pre-task commits and foreign dirty hunks — neither introduced by the task under compliance review. Recurrence: the same hand-written discrimination note for a regression-invariant test whose scope had no task commits surfaced repeatedly across tasks until it was made deterministic via the classifier above.
 <!-- /gate:history-allowed -->
+- **Report-cited-SHA resolution probe (fabrication vs stale-clone).** When a QA or compliance report cites commit SHAs or merge-request numbers, do not trust them on faith nor reject them as fabricated without a probe. Run `git cat-file -t <sha>`; if the object is absent locally, run `git ls-remote origin` and `git fetch origin <branch>` read-only, then verify the diff against `FETCH_HEAD`. A SHA absent **both** locally and on the remote is a genuine fabrication finding — **NON-COMPLIANT**. A SHA absent locally but present on the remote branch is the expected stale-clone case in a remote-first project (the work was pushed from another machine and the local clone never fetched): fetch read-only and verify the actual diff — never block, never reject. Verify against `FETCH_HEAD`, do not check out, so a shared clone parked on another task's branch stays undisturbed.
+<!-- gate:history-allowed -->
+Prior incident: a QA report cited two commit SHAs invalid on the local clone (`git cat-file` reported them as unknown objects); both resolved on the remote feature branch and the implemented work was real — the local clone was simply stale in a remote-first workflow. Compliance fetched the branches read-only and verified the diffs against `FETCH_HEAD`.
+<!-- /gate:history-allowed -->
 
 ### 7. CI/CD Impact Analysis
 - Detect: new dependencies, changed env vars, new build steps


### PR DESCRIPTION
Lands the parked evo/compliance-sha-probe experiment through the pipeline (closes the last non-main branch).

Step 6 of the compliance skill: when a QA/compliance report cites commit SHAs or MR numbers, probe with `git cat-file` — a SHA absent both locally and on the remote is a fabrication finding (NON-COMPLIANT); a SHA absent locally but present on the remote branch is the expected stale-clone case in a remote-first project (fetch read-only, verify vs FETCH_HEAD, no checkout). Class A, operator-approved, recurrence-promoted from a prior api-url-writeback follow-up.

Doc-only (+16 lines: skills/compliance/SKILL.md Step 6 + docs/evolution-log.md). Coexists with the Step 5 CI-linter-scope rule. task-id-gate + English-surface clean; bats 1599 unchanged.