### PR TITLE
SEC-0015: re-pin dtolnay/rust-toolchain to a real upstream commit (fix zizmor impostor-commit)

### DIFF
--- a/.github/workflows/reusable-security-audit.yml
+++ b/.github/workflows/reusable-security-audit.yml
@@ -86,7 +86,7 @@ jobs:
       # which are present on the runner.
       - name: Setup Rust toolchain (rust_cargo profile only)
         if: inputs.stack == 'rust_cargo'
-        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
 
       - name: Run stack-specific audit
         env:


### PR DESCRIPTION
## What

`reusable-security-audit.yml:89` pinned `dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8`, a commit that **does not exist** among the action's refs (verified `git ls-remote`). zizmor flagged it **impostor-commit (High)** + **ref-version-mismatch (warning)** — a supply-chain risk (the SHA could resolve to an attacker-controlled commit outside the org).

Re-pinned to **`4be7066ada62dd38de10e7b70166bc74ed198c30`** — the live `refs/heads/stable` HEAD, matching the existing `# stable` comment intent.

Discovered during MAINT-0022 PR #139 CI (zizmor is a non-required check today, so the bad pin shipped silently).

## Verification
- New SHA confirmed present in `dtolnay/rust-toolchain` (`git ls-remote` → refs/heads/stable)
- `zizmor .github/workflows/reusable-security-audit.yml` local → **No findings to report** (was 1 high + 1 warning)
- `actionlint` clean
- Audited all 8 external action pins in the repo — only this one was out-of-org (the rest carry valid version comments and passed zizmor)
- Commit SSH-signed (branch protection)

Provenance: backlog SEC-0015.