### PR TITLE
ci(security): fix semgrep findings — SHA-pin upload-artifact + dependabot cooldown

### DIFF
--- a/.github/actions/preflight-check/action.yml
+++ b/.github/actions/preflight-check/action.yml
@@ -105,7 +105,7 @@ runs:
         "${{ github.action_path }}/../../../dev-tools/preflight-check.sh"
     - name: Upload report
       if: always()
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: preflight-report-${{ inputs.service-name }}-${{ inputs.target-host }}
         path: ${{ steps.run.outputs.report-path }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,10 @@ updates:
       day: "monday"
       time: "06:00"
       timezone: "Etc/UTC"
+    # Delay PRs for freshly-released versions so a compromised release has time
+    # to be discovered and yanked before it reaches CI (supply-chain hardening).
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 5
     labels:
       - "dependencies"
@@ -43,6 +47,10 @@ updates:
       day: "monday"
       time: "06:00"
       timezone: "Etc/UTC"
+    # Delay PRs for freshly-released versions so a compromised release has time
+    # to be discovered and yanked before it reaches CI (supply-chain hardening).
+    cooldown:
+      default-days: 7
     open-pull-requests-limit: 3
     labels:
       - "dependencies"


### PR DESCRIPTION
## What

Clears the **3 pre-existing semgrep blocking findings** that predated SEC-0015 (semgrep is a non-required check, so they had been shipping red on main).

1. **`github-actions-mutable-action-tag`** — `.github/actions/preflight-check/action.yml:108` pinned `actions/upload-artifact@v4` (mutable major tag). SHA-pinned to `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1` — the exact pin already used elsewhere in the repo's workflows (verified real via `git ls-remote`).
2. **`dependabot-missing-cooldown`** (×2) — `.github/dependabot.yml` github-actions + pip update groups gained a `cooldown: { default-days: 7 }` block, so freshly-released versions wait before reaching CI (supply-chain hardening against compromised releases).

## Verification
- `semgrep` local with the CI config (`p/default p/python p/secrets p/github-actions p/security-audit`) → **0 findings** (was 3 blocking)
- `zizmor` on the touched action → **No findings**
- New artifact SHA confirmed in `actions/upload-artifact` upstream (tag v7.0.1)
- dependabot.yml + action.yml validated as YAML
- Commit SSH-signed (branch protection)

Discovered during SEC-0015 / MAINT-0022 CI. No runtime/test code touched.