### PR TITLE
ci(security): remove dead pip ecosystem from dependabot.yml (No files found)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,11 @@
 # Dependabot configuration.
 # Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
-# Scope: keep GitHub Actions pinned to verified SHAs and surface
-# vulnerabilities in any pip-managed tooling used by CI / pre-commit.
-# The framework itself ships no runtime package manifests; this stays
-# tight to CI/tooling surfaces.
+# Scope: keep GitHub Actions pinned to verified SHAs. The framework ships no
+# runtime package manifests, and CI/lint tooling (bandit, semgrep, etc.) is
+# installed inline in the workflows rather than from a pinned requirements file,
+# so there is no pip manifest for Dependabot to track — the pip ecosystem was
+# removed (it had no files to update and failed every run with "No files found").
 
 version: 2
 
@@ -35,36 +36,6 @@ updates:
           - "minor"
           - "patch"
       actions-security:
-        applies-to: security-updates
-        patterns:
-          - "*"
-
-  # Pip-managed CI/lint tooling (bandit, semgrep, pre-commit, etc.).
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "monday"
-      time: "06:00"
-      timezone: "Etc/UTC"
-    # Delay PRs for freshly-released versions so a compromised release has time
-    # to be discovered and yanked before it reaches CI (supply-chain hardening).
-    cooldown:
-      default-days: 7
-    open-pull-requests-limit: 3
-    labels:
-      - "dependencies"
-      - "python"
-    commit-message:
-      prefix: "deps"
-      include: "scope"
-    groups:
-      pip-minor-and-patch:
-        applies-to: version-updates
-        update-types:
-          - "minor"
-          - "patch"
-      pip-security:
         applies-to: security-updates
         patterns:
           - "*"


### PR DESCRIPTION
## What

The `pip` Dependabot ecosystem in `.github/dependabot.yml` pointed at `directory: "/"` but the repo has **no pip manifest** — CI/lint tooling (bandit, semgrep, schemathesis, jsonschema, pip-audit) is `pip install`-ed inline in the workflows, not from a pinned `requirements.txt`. Dependabot's pip job therefore failed **every run** with:

```
ERROR Error during file fetching; aborting: No files found in /
```

surfacing as a permanent red `Dependabot` status on main. It managed nothing and has no successful run in history. Removed; the `github-actions` ecosystem (with the `cooldown` added in the prior PR) is retained.

Discovered while verifying the semgrep-cooldown fix (#141) — Dependabot accepted the cooldown config fine; the failure was this independent dead-config.

## Verification
- `.github/dependabot.yml` valid YAML; only `github-actions` ecosystem remains
- semgrep local → 0 findings (cooldown intact on the retained ecosystem)
- Commit SSH-signed

If pinned pip tooling is introduced later, re-add the ecosystem pointed at the real manifest directory.