### PR TITLE
docs: tighten coworker routing and tag signing guidance

### DIFF
--- a/dev-tools/datarim-stage-probe-coworker-echo.sh
+++ b/dev-tools/datarim-stage-probe-coworker-echo.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# datarim-stage-probe-coworker-echo.sh — probe coworker datarim profile awareness.
+# datarim-stage-probe-coworker-echo.sh — probe coworker doc-read context awareness.
 #
 # Sends a fixed question to coworker (`List 3 Datarim conventions you must
 # follow when editing this file.`) using the active profile, captures the

--- a/documentation/how-to/datarim-harness.md
+++ b/documentation/how-to/datarim-harness.md
@@ -54,14 +54,19 @@ Fail-soft: a journal-write failure never aborts the snapshot itself (V-AC-7 cont
 
 ## Coworker echo probe
 
-To verify the `coworker --profile datarim` system_prompt actually transmits Datarim conventions to the external LLM:
+To verify that the lightweight `coworker ask --profile doc-read` path still
+surfaces Datarim conventions from the task-description context:
 
 ```text
 dev-tools/datarim-stage-probe-coworker-echo.sh <TASK-ID>
 # ok: keywords=4 (response saved to /tmp/datarim-test-<TASK-ID>/coworker-echo.txt)
 ```
 
-The probe sends a fixed question (`List 3 Datarim conventions you must follow when editing this file.`) with the task-description as `--paths`, captures the response, and counts how many mandate keywords appear (Stage Header, append-log, expectations, snapshot, frontmatter, mandate, Supreme Directive, Diátaxis, wish_id, history-agnostic).
+The probe sends a fixed question (`List 3 Datarim conventions you must follow
+when editing this file.`) with the task-description as `--paths`, captures the
+response, and counts how many mandate keywords appear (Stage Header,
+append-log, expectations, snapshot, frontmatter, mandate, Supreme Directive,
+Diátaxis, wish_id, history-agnostic).
 
 **Refusal on sensitive markers** — if the task-description contains tokens like `password`, `api_key`, `/etc/shadow`, `vault token`, `client_secret`, or `private_key`, the probe records `skipped:sensitive-markers` in the journal and exits 0 without invoking coworker.
 

--- a/documentation/how-to/release-process.md
+++ b/documentation/how-to/release-process.md
@@ -85,9 +85,33 @@ After merge, on a clean `main`:
 ```bash
 git checkout main
 git pull --ff-only
+
+# Preflight: `git tag -s` must be able to sign in the configured format.
+# SSH signing is valid when gpg.format=ssh and user.signingkey points at an
+# available private SSH key; GPG signing is valid when a matching GPG secret key
+# exists locally. Do not downgrade to an annotated-only tag silently.
+git config --get gpg.format
+git config --get user.signingkey
+git tag -s "vX.Y.Z-signing-probe" -m "release signing probe"
+git tag -v "vX.Y.Z-signing-probe"
+git tag -d "vX.Y.Z-signing-probe"
+
 git tag -s "vX.Y.Z" -m "release vX.Y.Z"   # signed tag
 git push origin "vX.Y.Z"
 ```
+
+If the signing probe fails, fix the maintainer machine first or have a
+maintainer with a working signing setup cut the tag. For SSH signing, the local
+minimum is:
+
+```bash
+git config gpg.format ssh
+git config user.signingkey /path/to/signing-key.ed25519
+git config gpg.ssh.allowedSignersFile /path/to/allowed_signers
+```
+
+The `allowed_signers` file must contain the public key identity Git should trust
+when `git tag -v` verifies the probe tag.
 
 For a release candidate, use a suffix accepted by the tag-format gate:
 

--- a/skills/coworker-context/SKILL.md
+++ b/skills/coworker-context/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: coworker-context
 description: Canonical conventions an external LLM (via coworker delegation) must follow when generating or editing Datarim artifacts (stage header, frontmatter, etc.).
-loaded_by: coworker-profile-datarim, /dr-write, /dr-archive
+loaded_by: coworker-profile-datarim-write, /dr-write, /dr-archive
 ---
 
 # Coworker Context — Datarim Conventions Reference
 
-Single entry point for any external LLM invoked through `coworker ask` / `coworker write` with `--profile datarim`. The profile's `system_prompt` references this skill; read top-to-bottom before generating or editing any artifact under `datarim/`.
+Single entry point for any external LLM invoked through `coworker write` with
+`--profile datarim-write`. The profile's `system_prompt` references this skill;
+read top-to-bottom before generating or editing any artifact under `datarim/`.
 
 History-agnostic: this skill names contract surfaces, not specific task IDs.
 

--- a/templates/coworker-delegation.mdc
+++ b/templates/coworker-delegation.mdc
@@ -20,7 +20,12 @@ CLI binary: `~/.local/bin/coworker`. Four subcommands:
 - `coworker stats --since 7d --by profile`
 - `coworker rtk {install|enable|disable|status}` (optional plugin — see RTK section)
 
-Profiles: `code` (default, generic analysis), `datarim` (Datarim artifacts), `social` (posts), `write` (boilerplate). Cost-sensitive tasks → `--provider deepseek` (~14x cheaper output vs Moonshot).
+Profiles: `doc-read` (literal documentation extraction/summarization,
+DeepSeek v4-flash), `classifier` (short routing/classification, DeepSeek
+v4-flash), `datarim-write` (schema-aware Datarim drafts, DeepSeek v4-pro),
+and `write` (generic meaningful file generation, DeepSeek v4-pro). Legacy
+`code`, `codex`, `datarim`, and `social` profiles are fail-closed in Arcanada
+runtime config; do not use them as defaults.
 
 ## ALWAYS delegate via coworker ask when ANY trigger fires
 


### PR DESCRIPTION
## Summary
- sync Cursor coworker delegation template with the doc-read/classifier/datarim-write/write profile matrix
- update live coworker harness/context docs away from legacy datarim profile naming
- add a release-process signing probe so tag creation does not silently downgrade to annotated-only

## Verification
- SSH tag signing probe: pass
- git log --show-signature -1: pass (SSH signature)
- bats tests/check-stale-runtime.bats tests/check-template-path-convention.bats tests/coworker-guard-kb-backup.bats tests/check-routing-drift.bats: 43/43 pass
- whitespace scan on changed files: pass

Known pre-existing noise:
- dev-tools/doc-fanout-lint.sh reports existing datarim.club/reference drift
- check-body-english --scope skills reports existing non-English body content in expectations-checklist and publishing skills
