### PR TITLE
TUNE-0187: dr-orchestrate enable refuses without FB-rules mandate mirror

### DIFF
--- a/commands/dr-plugin.md
+++ b/commands/dr-plugin.md
@@ -1,7 +1,7 @@
 # /dr-plugin — Datarim Plugin System CLI
 
 **Source:** plugin-system core PRD and plan (see workspace `datarim/prd/` and `datarim/plans/` indexes).
-**Status:** `list` + first-run bootstrap, `enable`, `disable`, `sync`, and `doctor` are all implemented and covered by `tests/dr-plugin.bats` + `tests/dr-plugin-coverage.bats`. Git-URL clone for `enable` (Phase A4) remains the only deferred path.
+**Status:** `list` + first-run bootstrap, `enable`, `disable`, `sync`, and `doctor` are all implemented and covered by `tests/dr-plugin.bats` + `tests/dr-plugin-coverage.bats`. Git-URL clone for `enable` (Phase A4) remains the only deferred path. `enable dr-orchestrate` additionally refuses (exit 1) unless the consumer workspace's `CLAUDE.md` already contains the string "Autonomous Agent Operating Rules" — the plugin ships FB-rules enforcement and assumes the mandate text is already mirrored at rank-1 level (TUNE-0187).
 
 ## Purpose
 

--- a/commands/dr-plugin.md
+++ b/commands/dr-plugin.md
@@ -1,7 +1,7 @@
 # /dr-plugin — Datarim Plugin System CLI
 
 **Source:** plugin-system core PRD and plan (see workspace `datarim/prd/` and `datarim/plans/` indexes).
-**Status:** `list` + first-run bootstrap, `enable`, `disable`, `sync`, and `doctor` are all implemented and covered by `tests/dr-plugin.bats` + `tests/dr-plugin-coverage.bats`. Git-URL clone for `enable` (Phase A4) remains the only deferred path. `enable dr-orchestrate` additionally refuses (exit 1) unless the consumer workspace's `CLAUDE.md` already contains the string "Autonomous Agent Operating Rules" — the plugin ships FB-rules enforcement and assumes the mandate text is already mirrored at rank-1 level (TUNE-0187).
+**Status:** `list` + first-run bootstrap, `enable`, `disable`, `sync`, and `doctor` are all implemented and covered by `tests/dr-plugin.bats` + `tests/dr-plugin-coverage.bats`. Git-URL clone for `enable` (Phase A4) remains the only deferred path. `enable dr-orchestrate` additionally refuses (exit 1) unless the consumer workspace's `CLAUDE.md` already contains the string "Autonomous Agent Operating Rules" — the plugin ships FB-rules enforcement and assumes the mandate text is already mirrored at rank-1 level.
 
 ## Purpose
 

--- a/scripts/dr-plugin.sh
+++ b/scripts/dr-plugin.sh
@@ -385,6 +385,19 @@ cmd_enable() {
         return 1
     fi
 
+    # TUNE-0187: dr-orchestrate ships fb-rules enforcement that assumes the
+    # consumer's own CLAUDE.md already mirrors the canonical Autonomous Agent
+    # Operating Rules mandate text at rank-1 level. Refuse enable rather than
+    # activate a plugin whose enforced rules the workspace hasn't adopted.
+    if [ "$id" = "dr-orchestrate" ]; then
+        local ws_preflight
+        ws_preflight="$(resolve_workspace)" || return 2
+        if ! grep -q "Autonomous Agent Operating Rules" "$ws_preflight/CLAUDE.md" 2>/dev/null; then
+            echo "dr-plugin enable: dr-orchestrate requires this workspace's CLAUDE.md to mirror the canonical Autonomous Agent Operating Rules mandate (see documentation/mandates/autonomous-agents.md) before enabling (TUNE-0187). Not found in $ws_preflight/CLAUDE.md." >&2
+            return 1
+        fi
+    fi
+
     local ws repo manifest
     ws="$(resolve_workspace)"
     repo="$(resolve_repo_root "$ws")"

--- a/tests/dr-plugin.bats
+++ b/tests/dr-plugin.bats
@@ -283,6 +283,33 @@ EOF
     grep -q "id: demo" "$TMPROOT/datarim/enabled-plugins.md"
 }
 
+@test "T53a enable refuses dr-orchestrate when consumer CLAUDE.md lacks the FB-rules mandate text (TUNE-0187)" {
+    local src
+    src="$(make_plugin_source "dr-orchestrate" "alpha.md")"
+    echo "# Some workspace CLAUDE.md without the mandate" > "$TMPROOT/CLAUDE.md"
+    run "$PLUGIN_SH" enable "$src"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Autonomous Agent Operating Rules"* ]]
+    [ ! -e "$TMPROOT/datarim/enabled-plugins.md" ] || ! grep -q "id: dr-orchestrate" "$TMPROOT/datarim/enabled-plugins.md"
+}
+
+@test "T53b enable allows dr-orchestrate once consumer CLAUDE.md mirrors the FB-rules mandate text (TUNE-0187)" {
+    local src
+    src="$(make_plugin_source "dr-orchestrate" "alpha.md")"
+    echo "# Autonomous Agent Operating Rules Mandate" > "$TMPROOT/CLAUDE.md"
+    run "$PLUGIN_SH" enable "$src"
+    [ "$status" -eq 0 ]
+    grep -q "id: dr-orchestrate" "$TMPROOT/datarim/enabled-plugins.md"
+}
+
+@test "T53c enable is unaffected by the dr-orchestrate preflight for other plugin ids" {
+    local src
+    src="$(make_plugin_source "demo" "alpha.md")"
+    rm -f "$TMPROOT/CLAUDE.md" 2>/dev/null || true
+    run "$PLUGIN_SH" enable "$src"
+    [ "$status" -eq 0 ]
+}
+
 @test "T54 enable second time is idempotent — no duplicate manifest entry" {
     local src
     src="$(make_plugin_source "demo" "alpha.md")"


### PR DESCRIPTION
## Summary
- TUNE-0185 Phase 4 shipped the Autonomous Agent Operating Rules mandate + `fb-rules.yaml` contract but explicitly deferred rollout/enforcement tooling to TUNE-0187.
- `dr-plugin enable dr-orchestrate` now refuses (exit 1) unless the consumer workspace CLAUDE.md already contains the string "Autonomous Agent Operating Rules" — dr-orchestrate enforces FB-rules and assumes the mandate text is already mirrored at rank-1 level.
- Other plugin ids are unaffected (T53c).

## Test plan
- [x] `bats tests/dr-plugin.bats` — 3 new cases (T53a/b/c) + all 80 pass
- [x] `bats tests/` full suite — 1700 assertions green
- [x] shellcheck on scripts/dr-plugin.sh — no new warnings introduced

Part of TUNE-p2 backlog sweep (TUNE-0187).