### PR TITLE
TUNE-0415: point release.yml env-policy comment at provision-release-env.sh

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,14 +77,15 @@ jobs:
     # Conditional environment (TUNE-0351): a major bump routes to release-manual
     # (required reviewer); patch/minor flows through release-auto (no reviewer).
     #
-    # REQUIRED ENVIRONMENT POLICY (repo Settings → Environments, not in this file):
-    # both `release-auto` and `release-manual` MUST allow deployments from the
-    # `v*` tag pattern. This workflow triggers on tag pushes (`on: push: tags`),
-    # and a tag is NOT a protected branch — so an environment whose deployment
-    # branch policy is "Protected branches only" rejects every tagged release at
-    # job start (~2s, no steps run). Set deployment_branch_policy to
-    # custom_branch_policies and add a `v*` tag rule. Tracked for IaC by a
-    # follow-up backlog task (see CHANGELOG / evolution-log).
+    # REQUIRED ENVIRONMENT POLICY: both `release-auto` and `release-manual` MUST
+    # allow deployments from the `v*` tag pattern. This workflow triggers on tag
+    # pushes (`on: push: tags`), and a tag is NOT a protected branch — so an
+    # environment whose deployment branch policy is "Protected branches only"
+    # rejects every tagged release at job start (~2s, no steps run). IaC'd via
+    # `dev-tools/provision-release-env.sh --repo <owner/name> --env <name> --apply`
+    # (idempotent; add `--reviewers User:<id>` for release-manual) — re-run it
+    # after any environment recreate instead of fixing the policy live via the
+    # API/UI.
     environment:
       name: ${{ (needs.classify.outputs.bump_level == 'major' && 'release-manual') || 'release-auto' }}
     permissions:


### PR DESCRIPTION
Backlog TUNE-0415 flagged the release deployment-environment branch-policy (`v*` tag allow-list on `release-auto`/`release-manual`) as fixed only live via API during TUNE-0388, not reproducible/version-controlled.

Verify-first: live GH API check confirms both environments already have `custom_branch_policies=true` + a `{name: v*, type: tag}` policy (previously fixed). The IaC gap is *also* already closed — `dev-tools/provision-release-env.sh` (idempotent gh-api provisioner, dry-run by default) does exactly this and has 13 regression cases in `tests/provision-release-env.bats` (see CHANGELOG.md).

The only live gap: `release.yml`'s inline comment still pointed at a vague "follow-up backlog task" instead of the script that already exists. This PR fixes the comment to cite the actual reproduction command.

No functional change to the workflow; YAML re-validated with `yaml.safe_load`.