### PR TITLE
TUNE-0419: /dr-plan Step 6.6 — auth-parameter widening axis enumeration

### DIFF
--- a/commands/dr-plan.md
+++ b/commands/dr-plan.md
@@ -130,6 +130,13 @@ This command generates a detailed implementation plan in `datarim/tasks.md`, str
 <!-- /gate:history-allowed -->
     -   Rationale: a 30-second grep at planning time prevents 10–30 minute investigations during `/dr-do`. A plan that names a method as the fix surface but the method does not exist (e.g. behaviour was implemented inline in a different module) requires in-flight redirect — a single grep at `/dr-plan` time would have caught it.
 
+6.6.  **Auth-Parameter Widening Axis Enumeration (MANDATORY when the plan widens the accepted values of an authentication parameter — e.g. accepting a second `aud`, an additional `iss`, a broader `scope`, or an additional `alg`)**:
+    -   Enumerate every JWT claim the widened code path touches — `iss`, `aud`, `scope`, `alg`, `exp` — plus any additional claim the specific widening reads.
+    -   For each enumerated claim, confirm the plan documents how it is handled on BOTH the accept path and the reject path, not just the one axis being changed.
+    -   Add one dedicated spec case per axis variant to the Validation Checklist: an accept case for the newly-widened value, and a reject case for every other value on that axis.
+    -   Rationale: prevents pass-for-wrong-reason. A widening that touches only one axis (e.g. `aud`) can still ship a hole on an orthogonal axis (e.g. `iss`) if that axis is never independently exercised — a spec that only varies the changed axis passes while a token that is wrong on the untouched axis slips through unexamined.
+    -   Example: widening `aud` from `["auth.example.com"]` to `["auth.example.com", "auth.example.org"]` requires spec cases for `aud=.com` accept, `aud=.org` accept, `aud=other` reject, AND `iss=.com` / `iss=.org` verified independently on both accept paths — not assumed correct because the `aud` cases passed.
+
 7.  **Installer / Deploy-Script Content-Type Audit (MANDATORY when plan touches install.sh, sync-script, or any deploy/copy tool)**:
     -   Grep the file-type filter (`case "*.md"`, `find ... -name`, extension whitelist, etc.) in the target script.
     -   List every supported extension explicitly in the plan's Technology Validation or Architecture Impact section.

--- a/tests/tune-0419-dr-plan-auth-axis-enumeration.bats
+++ b/tests/tune-0419-dr-plan-auth-axis-enumeration.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+#
+# /dr-plan Step 6.6 "Auth-Parameter Widening Axis Enumeration" regression guard.
+#
+# Stage-rule contract: commands/dr-plan.md MUST keep the axis-enumeration
+# sub-step for auth-parameter-widening plans — it requires every JWT claim
+# the widened code touches to be enumerated and independently spec-covered
+# on both accept and reject paths, preventing a plan from passing on the
+# strength of the one axis it changed while an orthogonal axis ships a hole.
+#
+# Three cases cover the three operative signals — section presence, the
+# enumerated claim set, and the per-axis spec-case requirement.
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+DR_PLAN_DOC="$REPO_ROOT/commands/dr-plan.md"
+
+@test "T1: dr-plan.md contains the Auth-Parameter Widening Axis Enumeration step" {
+    [ -f "$DR_PLAN_DOC" ]
+    run grep -F "Auth-Parameter Widening Axis Enumeration" "$DR_PLAN_DOC"
+    [ "$status" -eq 0 ]
+}
+
+@test "T2: axis enumeration step names all five JWT claims" {
+    run grep -F '`iss`, `aud`, `scope`, `alg`, `exp`' "$DR_PLAN_DOC"
+    [ "$status" -eq 0 ]
+}
+
+@test "T3: axis enumeration step requires one spec case per axis variant, both paths" {
+    run grep -F "one dedicated spec case per axis variant" "$DR_PLAN_DOC"
+    [ "$status" -eq 0 ]
+    run grep -F "accept path and the reject path" "$DR_PLAN_DOC"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Reflection AUTH-0102 (Class A) — AUTH-0102 nearly shipped a widening that changed only `aud` while `.ai`-issued tokens also carry a distinct `iss`; a spec covering only the changed axis would have falsely passed a wrong-issuer token.

Adds `/dr-plan` Step 6.6: MANDATORY for any plan widening an accepted auth-parameter value. Enumerates the 5 JWT claims (`iss`/`aud`/`scope`/`alg`/`exp`), requires both accept+reject handling to be documented per claim, and requires one Validation-Checklist spec case per axis variant. Includes a worked example.

3 new bats regression cases mirroring the existing `tune-0279` Step 6.5 guard pattern — verified green locally alongside the pre-existing suite.