### PR TITLE
TUNE-0384: compliance Infra checklist — concurrent-session check

### DIFF
--- a/skills/compliance/SKILL.md
+++ b/skills/compliance/SKILL.md
@@ -247,6 +247,14 @@ When an expectation's success criterion or an acceptance criterion names two or 
 - A clean result on root A plus an unchecked root B is a partial verification, not a pass. Surface root B explicitly as unverified rather than inferring it from root A.
 - Source: prior incident — a "no working-branch-X references anywhere in trees A and B" criterion was verified only by the in-repo checker living in tree A; tree B (a separate registry) still carried working references and reached QA as a blocker.
 
+### 10. Concurrent-Session Check (shared infra)
+
+When a task modifies access to a resource that parallel sessions might also touch (NAS, Vault, a shared CI runner, or any other credential/provisioning surface shared across sessions), grep for active `datarim/.auto-mode-active` markers across sibling workspaces before applying the change, and flag provisioning-conflict risk if any are found.
+
+- Two independent sessions restoring or rotating admin access to the same shared resource concurrently can race each other's provisioning steps (e.g. two SSH-key rotations against the same NAS), each assuming exclusive access.
+- Surface a hit as an Open Item rather than blocking outright — the operator or the concurrent session may already be coordinating.
+- Source: prior incident — two independent sessions restored admin access to the same shared NAS concurrently, an SSH-provisioning conflict risk that neither session's checklist caught (Multi-Agent Workspace Discipline mandate).
+
 ---
 
 ## Output

--- a/tests/tune-0384-compliance-concurrent-session-check.bats
+++ b/tests/tune-0384-compliance-concurrent-session-check.bats
@@ -1,0 +1,29 @@
+#!/usr/bin/env bats
+#
+# Compliance Infrastructure Checklist "Concurrent-Session Check" regression guard.
+#
+# Stage-rule contract: skills/compliance/SKILL.md § Infrastructure Checklist
+# MUST keep the concurrent-session check — when a task modifies access to
+# shared infra (NAS, Vault, shared runner), grep active
+# datarim/.auto-mode-active markers across sibling workspaces and flag
+# provisioning-conflict risk. Prevents two parallel sessions from racing
+# each other's provisioning steps against the same resource.
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+COMPLIANCE_SKILL="$REPO_ROOT/skills/compliance/SKILL.md"
+
+@test "T1: compliance SKILL.md contains the Concurrent-Session Check item" {
+    [ -f "$COMPLIANCE_SKILL" ]
+    run grep -F "Concurrent-Session Check (shared infra)" "$COMPLIANCE_SKILL"
+    [ "$status" -eq 0 ]
+}
+
+@test "T2: check greps active auto-mode-active markers" {
+    run grep -F "datarim/.auto-mode-active" "$COMPLIANCE_SKILL"
+    [ "$status" -eq 0 ]
+}
+
+@test "T3: check names the shared-infra examples (NAS, Vault, shared runner)" {
+    run grep -F "NAS, Vault, a shared CI runner" "$COMPLIANCE_SKILL"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Reflection INFRA-0280 Stage G (Class A) — INFRA-0280 Stage G and PAXBT-0008 independently restored admin access to the same shared NAS, a provisioning-conflict risk (Multi-Agent Workspace Discipline) neither compliance run caught.

Adds Infrastructure Checklist item 10: when a task modifies access to shared infra (NAS, Vault, shared CI runner), grep active `datarim/.auto-mode-active` markers across sibling workspaces before applying the change and flag conflict risk as an Open Item (non-blocking — surfaced for awareness, not a hard stop).

3 new bats regression cases; existing compliance-skill bats suite (`tune-0255-compliance-template-shape`, `dr-compliance-deferral-gate`) re-run green, confirming no structural breakage from the insertion.