### PR TITLE
TUNE-0370: fix spec-vs-actual drift in dr-doctor.md and dr-edit.md

### DIFF
--- a/commands/dr-doctor.md
+++ b/commands/dr-doctor.md
@@ -12,7 +12,7 @@ description: Diagnose and repair Datarim operational files — migrate to thin o
 ## When to Run
 
 - **Manually** — when `tasks.md` / `backlog.md` / `progress.md` grow huge or mix block-style entries with thin one-liners.
-- **Auto-suggested by `/dr-init` Step 0.6** — when structural compliance probe (`datarim-doctor.sh --quiet`) returns exit 1.
+- **Auto-suggested by `/dr-init` Step 2.4** — when structural compliance probe (`datarim-doctor.sh --quiet`) returns exit 1.
 - **After upgrading to Datarim v1.19.0+** — first run migrates legacy block-style tasks to the canonical thin schema.
 - **Before `/dr-archive`** — `pre-archive-check.sh` line-format gate may direct here on non-compliant operational files.
 
@@ -23,7 +23,7 @@ Not a periodic cleanup. Idempotent: a second run on a compliant tree is a no-op.
 1. **LOAD**: Read `$HOME/.claude/agents/planner.md` and adopt that persona.
 2. **RESOLVE PATH**: Walk up from cwd to find `datarim/`. If not found anywhere → tell user to run `/dr-init`. Do NOT create. See `$HOME/.claude/skills/datarim-system/SKILL.md` § Path Resolution Rule.
 3. **LOAD SKILL**: Read `$HOME/.claude/skills/datarim-doctor/SKILL.md` for schema spec, conflict resolution, and edge-case handling.
-4. **PARSE ARGS** (passed by user or by `/dr-init` Step 0.6):
+4. **PARSE ARGS** (passed by user or by `/dr-init` Step 2.4):
     - `--fix` — apply migration. Default: dry-run (report findings only).
     - `--scope=<scope>` — `tasks|backlog|active|progress|descriptions|all`. Default `all`.
     - `--task-id=<id>` — limit to one task ID (debug).
@@ -50,7 +50,7 @@ Not a periodic cleanup. Idempotent: a second run on a compliant tree is a no-op.
     - Y → re-invoke `scripts/datarim-doctor.sh --root="$DATARIM_ROOT" --fix`.
     - n → print warning and exit 0.
     - Non-tty (`! [ -t 0 ]`) → never prompt; if invoked without `--fix`, just exit 1 with finding count.
-    - **`/dr-init` Step 0.6 path**: caller passes `--quiet`; this command must not prompt — it just runs the probe and reports exit code.
+    - **`/dr-init` Step 2.4 path**: caller passes `--quiet`; this command must not prompt — it just runs the probe and reports exit code.
 8. **APPLY** (when `--fix` is set):
     - Execute `scripts/datarim-doctor.sh --root="$DATARIM_ROOT" --fix`.
     - Tool acquires `flock` on `$DATARIM_ROOT/.dr-doctor.lock` (exit 3 if concurrent run).
@@ -125,7 +125,7 @@ Never touches `documentation/archive/`, `datarim/prd/`, `datarim/plans/`, `datar
 
 ## Failure Modes
 
-- **Lock held (exit 3)** → another `/dr-doctor` or `/dr-init` Step 0.6 probe is running. Wait, then retry.
+- **Lock held (exit 3)** → another `/dr-doctor` or `/dr-init` Step 2.4 probe is running. Wait, then retry.
 - **Migration error (exit 2)** → tool aborted mid-flight; partial writes are atomic per file. Inspect `git status -s datarim/`, `git restore datarim/{file}.md` to roll back individual files, then re-run.
 - **Path traversal (exit 4)** → `tasks.md` or similar contains a relative path that resolves outside `$DATARIM_ROOT`. Inspect the offending entry manually before re-running.
 - **All zeros, but `/dr-archive` still blocks** → file may have a non-compliant line that doctor's regex doesn't classify (e.g. comment line). Run `pre-archive-check.sh --no-schema-check` to surface the exact line.

--- a/commands/dr-edit.md
+++ b/commands/dr-edit.md
@@ -32,7 +32,7 @@ effort: high
     - Extract all verifiable factual claims.
     - Verify each claim against authoritative sources using WebSearch and WebFetch.
     - Assign verdicts: ACCURATE, INACCURATE, OUTDATED, MISLEADING, UNVERIFIABLE, NEEDS_CONTEXT.
-    - For critical claims, cross-reference with 2+ independent sources.
+    - Cross-reference source count per claim importance level — see `$HOME/.claude/skills/factcheck/SKILL.md` § Importance levels (do not restate the thresholds here; they drift independently otherwise).
 
     ### Phase 2: AI Pattern Removal
     - Scan for AI writing patterns: banned vocabulary, structural tells, formatting artifacts.

--- a/tests/tune-0370-doc-drift.bats
+++ b/tests/tune-0370-doc-drift.bats
@@ -1,0 +1,44 @@
+#!/usr/bin/env bats
+#
+# Regression test for TUNE-0370 (agent/command/skill spec vs actual-behaviour
+# drift, surfaced by CONTENT-0003/0004/0005 factcheck).
+#
+# Two concrete drifts closed by this task:
+#   1. commands/dr-doctor.md cited "/dr-init Step 0.6" as its auto-suggest
+#      trigger; the actual structural-compliance-check step in
+#      commands/dr-init.md is numbered 2.4. Any future dr-init renumbering
+#      must keep dr-doctor.md's cross-reference in sync.
+#   2. commands/dr-edit.md restated a fact-check source-count threshold
+#      ("2+ independent sources") that diverged from the canonical
+#      skills/factcheck/SKILL.md table (critical -> 3+ sources). The fix
+#      removes the restated number so the two files cannot drift again.
+
+ROOT="${BATS_TEST_DIRNAME}/.."
+
+@test "dr-doctor.md does not cite a stale /dr-init step number" {
+    run grep -c 'Step 0\.6' "${ROOT}/commands/dr-doctor.md"
+    [ "$status" -ne 0 ]
+}
+
+@test "dr-doctor.md cites the actual dr-init structural-compliance step (2.4)" {
+    run grep -c "Step 2\.4" "${ROOT}/commands/dr-doctor.md"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+
+    # The cited step must actually exist as a numbered step in dr-init.md.
+    run grep -qE '^2\.4\.' "${ROOT}/commands/dr-init.md"
+    [ "$status" -eq 0 ]
+}
+
+@test "dr-edit.md does not hardcode a fact-check source-count threshold" {
+    # The canonical threshold table lives in skills/factcheck/SKILL.md.
+    # dr-edit.md must defer to it, not restate a number that can drift.
+    run grep -cE '[0-9]\+ (independent )?sources?' "${ROOT}/commands/dr-edit.md"
+    [ "$status" -ne 0 ]
+}
+
+@test "skills/factcheck/SKILL.md still defines the critical-claim threshold dr-edit.md defers to" {
+    run grep -c 'Must verify with 3+ sources' "${ROOT}/skills/factcheck/SKILL.md"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+}


### PR DESCRIPTION
Closes the mechanical part of TUNE-0370 (agent/command/skill spec vs actual-behaviour audit).

- dr-doctor.md cited "/dr-init Step 0.6" (4 occurrences); the actual structural-compliance step in dr-init.md is 2.4. Fixed all references.
- dr-edit.md hardcoded "2+ independent sources" for critical claims, diverging from the canonical skills/factcheck/SKILL.md threshold table (critical -> 3+ sources). Now defers to the loaded skill instead of restating a number that can drift again.
- The strategist-at-dr-design claim from the same source reflection was checked live and found NOT currently true (strategist.md is only referenced by dr-plan.md, matching its own "When invoked" line) -- verify-first, not acted on.
- The writer/LinkedIn-English claim is policy judgment (what the rule should be), not a mechanical spec-drift fix -- left open for a follow-up task if still wanted.

Bats: 4/4 green (new tests/tune-0370-doc-drift.bats).

Autonomous P3 backlog sweep (chunk 2), no operator in the loop this pass.