### PR TITLE
TUNE-0407: close gate-mishandled 'type: security' value

### DIFF
--- a/dev-tools/network-exposure-gate.sh
+++ b/dev-tools/network-exposure-gate.sh
@@ -36,6 +36,7 @@ SEC_INFRA_TYPES=(
     framework-hardening
     security-baseline
     auth-mandate
+    security
 )
 
 usage() {

--- a/skills/network-exposure-baseline/SKILL.md
+++ b/skills/network-exposure-baseline/SKILL.md
@@ -192,7 +192,7 @@ Pipeline commands read the task-description frontmatter and pick one of three de
 | Priority | Type                                                                                    | Network surface touched? | Decision        |
 |----------|-----------------------------------------------------------------------------------------|--------------------------|-----------------|
 | `P0`     | (any)                                                                                   | (any)                    | `hard_block`    |
-| `P1`     | `security-incident` / `infrastructure` / `infra` / `framework-hardening` / `security-baseline` / `auth-mandate` | (any)         | `hard_block`    |
+| `P1`     | `security-incident` / `infrastructure` / `infra` / `framework-hardening` / `security-baseline` / `auth-mandate` / `security` | (any)         | `hard_block`    |
 | `P1`     | others                                                                                  | (any)                    | `advisory_warn` |
 | `P2`/`P3`/`P4`| (any)                                                                              | yes                      | `advisory_warn` |
 | `P2`/`P3`/`P4`| (any)                                                                              | no                       | `skip`          |

--- a/tests/check-gate-token-registry-sync.bats
+++ b/tests/check-gate-token-registry-sync.bats
@@ -24,6 +24,11 @@ setup() {
     [[ "$output" == *"sec"* ]]
 }
 
+@test "checker: exact 'security' type is no longer flagged (TUNE-0407 fix) -> exit 0" {
+    run "$SCRIPT" --gate "$GATE" --corpus-dir "$F/security-exact" --quiet
+    [ "$status" -eq 0 ]
+}
+
 @test "checker: unrelated free-form type is NOT flagged -> exit 0" {
     # a free-form type with no prefix relation to any gating token must be ignored
     run "$SCRIPT" --gate "$GATE" --corpus-dir "$F/unrelated" --quiet

--- a/tests/fixtures/gate-token-registry-sync/security-exact/t1.md
+++ b/tests/fixtures/gate-token-registry-sync/security-exact/t1.md
@@ -1,0 +1,7 @@
+---
+id: SAMPLE-0012
+priority: P1
+type: security
+---
+type: security is now an exact SEC_INFRA_TYPES member (TUNE-0407 fix) — must
+NOT be flagged as an unhandled short-form sibling anymore.

--- a/tests/fixtures/network-exposure-gate/p1-security.md
+++ b/tests/fixtures/network-exposure-gate/p1-security.md
@@ -1,0 +1,10 @@
+---
+id: SAMPLE-0011
+title: 'P1 security'
+status: in_progress
+priority: P1
+type: security
+project: SampleProject
+---
+
+P1 + short-form sec type: hard_block (TUNE-0407 — `security` sibling of `security-incident`/`security-baseline` was absent from SEC_INFRA_TYPES).

--- a/tests/network-exposure-gate.bats
+++ b/tests/network-exposure-gate.bats
@@ -59,6 +59,12 @@ setup() {
     [ "$output" = "hard_block" ]
 }
 
+@test "gate: P1 + security -> hard_block (TUNE-0407 short-form gap)" {
+    run "$SCRIPT" --task-description "$F/p1-security.md" --quiet
+    [ "$status" -eq 0 ]
+    [ "$output" = "hard_block" ]
+}
+
 # --- Advisory warn ---
 
 @test "gate: P1 + feature -> advisory_warn" {


### PR DESCRIPTION
check-gate-token-registry-sync.sh run against the live AUTH-* corpus flags 3 unhandled frontmatter values. Per-value decision:

- `type: security` -> added to SEC_INFRA_TYPES (script) + Tiered Gate Rules decision table (skill, kept in sync per the script's own header contract). Fixed.
- `priority: critical` / `priority: high` -> NOT changed. Both the canonical schema (skills/datarim-system/SKILL.md, priority enum P0-P3) and the gate's own documented contract (fail-closed on malformed) treat these as intentional fail-closed behaviour, not a gate defect. The 8 corpus files using these legacy values are mostly in-progress AUTH-* tasks owned by a different project -- renaming them is data hygiene for that project's own backlog, out of scope for a cross-project TUNE framework sweep.

The checker itself is a standalone diagnostic (not wired into any pipeline command or CI), so neither gap was live-blocking.

Bats: 36/36 green (network-exposure-gate.bats + check-gate-token-registry-sync.bats; 2 new regression cases + 1 new fixture).

Autonomous P3 backlog sweep (chunk 2), no operator in the loop this pass.