### PR TITLE
TUNE-0133: add legacy-hardware-probe-checklist template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to the Datarim framework are documented here. Format follows
 
 ### Added
 
+- **`templates/legacy-hardware-probe-checklist.md`** _(NEW)_ — 7-step probe checklist for legacy embedded
+  Linux integrations (CPU architecture, `/dev/net/tun`, free RAM, OpenSSL PBKDF2 support, BusyBox applet
+  availability, cron spool permissions, machine-identity sources). Run before committing to an architectural
+  approach in `/dr-plan` — replaces speculative toolchain assumptions with a 30-minute probe. Class A
+  evolution proposal from `reflection-INFRA-0073` (approved 2026-05-08). New regression test
+  `tests/tune-0133-legacy-hardware-probe-checklist.bats` (5 cases). (TUNE-0133)
 - **`/dr-plan` Step 6.5 History-agnostic runtime-body probe** — shifts the history-agnostic gate (task-ID-provenance rejection on shipped `skills/` / `agents/` / `commands/` / `templates/` bodies) left from `/dr-qa` and `/dr-compliance` to plan review, before approve. When Implementation Steps name a framework runtime body as an edit/create target, the planner dry-runs `scripts/task-id-gate.sh` against the plan's cited paths and any example text it will ship, and resolves every cited path through the `skills/plan-path-validator/SKILL.md` exists + deprecation ladder — reusing both existing gates rather than re-deriving them. Adds a Transition Checkpoint item and a `commands/dr-plan.md` plan-time trigger to `skills/evolution/history-agnostic-gate.md`. New regression test `tests/dr-plan-step-6-5-history-agnostic-probe.bats` (8 cases). (TUNE-0283)
 
 ## [2.53.0] — 2026-07-10

--- a/templates/legacy-hardware-probe-checklist.md
+++ b/templates/legacy-hardware-probe-checklist.md
@@ -1,0 +1,118 @@
+# Legacy Hardware Probe Checklist
+
+A reusable 7-step probe checklist for legacy embedded Linux integrations (routers, NAS appliances,
+IoT gateways running vendor-frozen firmware). Run this **before** committing to an architectural
+approach in `/dr-plan` — a 30-minute probe replaces speculative toolchain assumptions with facts.
+
+Reference: `$HOME/.claude/skills/probing.md`.
+
+---
+
+## Step 1 — CPU Architecture
+
+```bash
+uname -m && cat /proc/cpuinfo
+```
+
+Confirms actual instruction set (e.g. `armv5l` vs `arm` vs `mips`) — do not infer from vendor marketing copy.
+
+---
+
+## Step 2 — TUN/TAP Device Availability
+
+```bash
+test -c /dev/net/tun; echo $?
+```
+
+**0**: device node present — userspace VPN tooling (WireGuard-in-userspace, Tailscale userspace mode, etc.)
+can attach. **Non-zero**: no TUN device — kernel module missing or disabled; userspace networking will not work
+without a firmware change.
+
+---
+
+## Step 3 — Free RAM
+
+```bash
+free -m | head -2
+```
+
+Legacy appliances often ship with 64–256 MB total RAM. Confirm headroom before adding any long-running
+background process.
+
+---
+
+## Step 4 — OpenSSL Version and PBKDF2 Support
+
+```bash
+openssl version && openssl enc -pbkdf2 -help 2>&1 | head -1
+```
+
+Old firmware frequently bundles `openssl 1.0.2` or earlier, which lacks `-pbkdf2`. Any encryption scheme
+that assumes PBKDF2 key derivation must first confirm the flag exists — otherwise fall back to a
+vendored/static binary or an alternative KDF.
+
+---
+
+## Step 5 — BusyBox Applet Availability
+
+```bash
+busybox --list | grep -E 'nohup|start-stop-daemon|setsid|crontab|crond'
+```
+
+Confirms which of the five applets a background-process / cron-based integration needs are actually
+compiled into this BusyBox build. A missing `nohup` or `crond` blocks the naive approach and forces an
+alternative (e.g. `setsid` substitution, or a persistent init script instead of cron).
+
+---
+
+## Step 6 — Cron Spool Permissions
+
+```bash
+ls -la /var/spool/cron/crontabs/
+```
+
+Some vendor defaults ship this directory or the `root` crontab world-writable (mode `666`). Treat this as
+a security finding — document it, and do not add cron entries without first tightening the permission if
+the fix is in scope.
+
+---
+
+## Step 7 — Machine-Identity Sources
+
+```bash
+ls -la /etc/zyxel/ 2>/dev/null || find / -xdev -name '*serial*' -o -name '*board*' 2>/dev/null
+```
+
+Board-serial files are not guaranteed to exist across vendors/firmware revisions. Confirm an actual
+machine-identity source before designing around it — fall back to a MAC-address-derived identity
+(`ip link show` / `/sys/class/net/*/address`) when no serial file is present.
+
+---
+
+## Reporting Template
+
+Append to the plan / creative doc:
+
+```markdown
+### Legacy Hardware Probe
+
+| Step | Result |
+|------|--------|
+| 1. CPU architecture | `<uname -m output>` |
+| 2. /dev/net/tun | present / absent |
+| 3. Free RAM | `<N> MB` |
+| 4. OpenSSL PBKDF2 | supported / unsupported (`<version>`) |
+| 5. BusyBox applets | `<matched applets>` / missing: `<list>` |
+| 6. Cron spool perms | `<mode>` |
+| 7. Machine-identity source | board-serial / MAC-derived / none found |
+
+**Architectural implication**: `<one line — which approach the probe results rule in or out>`
+```
+
+---
+
+## Anti-Pattern to Refuse
+
+Do not draft an architecture doc for a legacy embedded target from vendor documentation or memory alone.
+Vendor docs describe the shipped firmware version at release time, not the specific unit's actual state.
+Run this checklist first; let the probe results — not assumptions — drive the design.

--- a/tests/tune-0133-legacy-hardware-probe-checklist.bats
+++ b/tests/tune-0133-legacy-hardware-probe-checklist.bats
@@ -1,0 +1,47 @@
+#!/usr/bin/env bats
+# tune-0133-legacy-hardware-probe-checklist.bats — TUNE-0133 regression.
+#
+# Class A evolution proposal from reflection-INFRA-0073 (approved 2026-05-08):
+# a 7-step probe checklist for legacy embedded Linux integrations, run before
+# committing to an architectural approach in /dr-plan.
+
+TEMPLATE="$BATS_TEST_DIRNAME/../templates/legacy-hardware-probe-checklist.md"
+GATE="$BATS_TEST_DIRNAME/../scripts/stack-agnostic-gate.sh"
+
+@test "T1 template file exists" {
+    [ -f "$TEMPLATE" ]
+}
+
+@test "T2 all 7 probe steps present in order" {
+    local s1 s2 s3 s4 s5 s6 s7
+    s1=$(grep -n '^## Step 1 —' "$TEMPLATE" | cut -d: -f1)
+    s2=$(grep -n '^## Step 2 —' "$TEMPLATE" | cut -d: -f1)
+    s3=$(grep -n '^## Step 3 —' "$TEMPLATE" | cut -d: -f1)
+    s4=$(grep -n '^## Step 4 —' "$TEMPLATE" | cut -d: -f1)
+    s5=$(grep -n '^## Step 5 —' "$TEMPLATE" | cut -d: -f1)
+    s6=$(grep -n '^## Step 6 —' "$TEMPLATE" | cut -d: -f1)
+    s7=$(grep -n '^## Step 7 —' "$TEMPLATE" | cut -d: -f1)
+    [ -n "$s1" ] && [ -n "$s2" ] && [ -n "$s3" ] && [ -n "$s4" ] && [ -n "$s5" ] && [ -n "$s6" ] && [ -n "$s7" ]
+    [ "$s1" -lt "$s2" ] && [ "$s2" -lt "$s3" ] && [ "$s3" -lt "$s4" ] && [ "$s4" -lt "$s5" ] && [ "$s5" -lt "$s6" ] && [ "$s6" -lt "$s7" ]
+}
+
+@test "T3 covers the 7 probe domains named in the backlog spec" {
+    grep -qi 'uname' "$TEMPLATE"
+    grep -q '/dev/net/tun' "$TEMPLATE"
+    grep -qi 'free -m' "$TEMPLATE"
+    grep -qi 'pbkdf2' "$TEMPLATE"
+    grep -qi 'busybox' "$TEMPLATE"
+    grep -q '/var/spool/cron' "$TEMPLATE"
+    grep -qi 'serial' "$TEMPLATE"
+    grep -qi 'MAC' "$TEMPLATE"
+}
+
+@test "T4 stack-agnostic gate passes on the template" {
+    [ -x "$GATE" ]
+    run "$GATE" "$TEMPLATE"
+    [ "$status" -eq 0 ]
+}
+
+@test "T5 reporting template block present" {
+    grep -q '### Legacy Hardware Probe' "$TEMPLATE"
+}


### PR DESCRIPTION
Adds `templates/legacy-hardware-probe-checklist.md` — 7-step probe checklist for legacy embedded Linux integrations, run before committing to an architectural approach in `/dr-plan`.

Class A evolution proposal from `reflection-INFRA-0073` (approved 2026-05-08). Backlog: TUNE-0133.

- New regression test `tests/tune-0133-legacy-hardware-probe-checklist.bats` (5 cases, all passing)
- `scripts/stack-agnostic-gate.sh` and `scripts/task-id-gate.sh` clean
- CHANGELOG.md entry added