### PR TITLE
TUNE-0235: build-rs-version.rs template (git SHA capture, no vergen)

### DIFF
--- a/templates/build-rs-version.rs
+++ b/templates/build-rs-version.rs
@@ -1,0 +1,23 @@
+// Reusable Cargo build.rs template: capture the short git SHA at build time
+// without a `vergen` dependency. Copy into a crate's `build.rs`, adjust the
+// `println!("cargo:rustc-env=...")` name if the crate needs a different env
+// var than `ARCANA_GIT_SHA`.
+//
+// Integration: read the value at runtime via `env!("ARCANA_GIT_SHA")`.
+// Falls back to "0000000" (preserves the `[0-9a-f]{7}` regex shape) when the
+// crate is built from a crates.io tarball with no `.git` directory.
+
+fn main() {
+    let sha = std::process::Command::new("git")
+        .args(["rev-parse", "--short=7", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "0000000".to_string());
+
+    println!("cargo:rustc-env=ARCANA_GIT_SHA={sha}");
+    println!("cargo:rerun-if-changed=../../.git/HEAD");
+    println!("cargo:rerun-if-changed=../../.git/refs/heads");
+}

--- a/tests/tune-0235-build-rs-version-shape.bats
+++ b/tests/tune-0235-build-rs-version-shape.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+# tune-0235-build-rs-version-shape.bats — build-rs-version.rs template shape guards.
+
+TEMPLATE="$BATS_TEST_DIRNAME/../templates/build-rs-version.rs"
+
+# ---------- T1 template exists, no vergen dependency ----------
+
+@test "T1 build-rs-version.rs exists and does not use the vergen crate" {
+    [ -f "$TEMPLATE" ]
+    ! grep -q 'vergen::' "$TEMPLATE"
+}
+
+# ---------- T2 fallback preserves the [0-9a-f]{7} regex shape ----------
+
+@test "T2 fallback literal is a 7-char lowercase-hex-shaped placeholder" {
+    grep -q '"0000000"' "$TEMPLATE"
+    fallback=$(grep -o '"0000000"' "$TEMPLATE" | head -1 | tr -d '"')
+    [ "${#fallback}" -eq 7 ]
+    [[ "$fallback" =~ ^[0-9a-f]{7}$ ]]
+}
+
+# ---------- T3 rerun-if-changed directives present for .git/HEAD and refs/heads ----------
+
+@test "T3 emits cargo:rerun-if-changed for .git/HEAD and .git/refs/heads" {
+    grep -q 'cargo:rerun-if-changed=../../.git/HEAD' "$TEMPLATE"
+    grep -q 'cargo:rerun-if-changed=../../.git/refs/heads' "$TEMPLATE"
+}
+
+# ---------- T4 sets ARCANA_GIT_SHA via rustc-env ----------
+
+@test "T4 sets ARCANA_GIT_SHA via cargo:rustc-env" {
+    grep -q 'cargo:rustc-env=ARCANA_GIT_SHA=' "$TEMPLATE"
+}
+
+# ---------- T5 no unwrap/expect (workspace-lint friendly) ----------
+
+@test "T5 no unwrap/expect calls (workspace-lint friendly)" {
+    ! grep -qE '\.unwrap\(\)|\.expect\(' "$TEMPLATE"
+}


### PR DESCRIPTION
Adds `templates/build-rs-version.rs` — 12-line Cargo build.rs capturing the short git SHA via `git rev-parse --short=7 HEAD`, fallback `"0000000"` (preserves `[0-9a-f]{7}` shape for crates.io tarballs without `.git`), no `vergen` dep, no unwrap/expect (workspace-lint friendly), rerun-if-changed on `.git/HEAD` + `.git/refs/heads`, sets `ARCANA_GIT_SHA` env.

bats: `tests/tune-0235-build-rs-version-shape.bats` (5 cases).

Class A — content addition. Stack-agnostic gate: PASS (per-stack template).

Source: reflection-ARAS-0002 evolution-proposal #1; approved 2026-05-16. P3 sweep chunk 6 (TUNE-0235).