### PR TITLE
TUNE-0244: override-indent concrete-syntax example + bats fixture

### DIFF
--- a/skills/expectations-checklist/SKILL.md
+++ b/skills/expectations-checklist/SKILL.md
@@ -115,6 +115,27 @@ invocation. Migration recipe: add `evidence_type: empirical` (or
 _(empty on first write)_
 ```
 
+### `override` indent — concrete syntax
+
+`dev-tools/check-expectations-checklist.sh` matches the override line with the
+exact regex `^  - override:` — 2 spaces, same indent level as `wish_id` /
+`Что хочу проверить` / `Связанный AC из PRD`. A misplaced `override` nested at
+the 4-space level (the indent used by `#### Текущий статус` sub-items) is
+invisible to the regex: the validator finds no override and silently returns
+`BLOCKED` for a partial/missed wish, with no diagnostic pointing at the indent.
+
+Correct (2-space, matches the regex):
+
+```markdown
+  - override: soak period not yet complete, see follow-up TASK-1234
+```
+
+Incorrect (4-space, silently ignored by the validator):
+
+```markdown
+    - override: soak period not yet complete, see follow-up TASK-1234
+```
+
 ### Item rules
 
 - **`wish_id`** is a kebab-slug derived from the title. Cyrillic letters,

--- a/skills/expectations-checklist/SKILL.md
+++ b/skills/expectations-checklist/SKILL.md
@@ -127,13 +127,13 @@ invisible to the regex: the validator finds no override and silently returns
 Correct (2-space, matches the regex):
 
 ```markdown
-  - override: soak period not yet complete, see follow-up TASK-1234
+  - override: soak period not yet complete, see follow-up TASK-XXXX
 ```
 
 Incorrect (4-space, silently ignored by the validator):
 
 ```markdown
-    - override: soak period not yet complete, see follow-up TASK-1234
+    - override: soak period not yet complete, see follow-up TASK-XXXX
 ```
 
 ### Item rules

--- a/tests/tune-0244-override-indent.bats
+++ b/tests/tune-0244-override-indent.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+#
+# TUNE-0244: override-indent concrete-syntax regression.
+#
+# dev-tools/check-expectations-checklist.sh matches override lines with the
+# exact regex `^  - override:` (2-space, item-bullet level). A misplaced
+# 4-space override (the indent used under `#### Текущий статус`) is invisible
+# to the regex and must silently degrade to "no override present" — BLOCKED
+# for a partial wish — rather than being mis-parsed as present.
+
+setup() {
+    SCRIPT="$BATS_TEST_DIRNAME/../dev-tools/check-expectations-checklist.sh"
+    WORK="$(mktemp -d)"
+    mkdir -p "$WORK/datarim/tasks"
+    EXP="$WORK/datarim/tasks/FAKE-9200-expectations.md"
+    cat > "$WORK/datarim/backlog.md" <<'EOF'
+# Backlog
+EOF
+    cat > "$WORK/datarim/tasks.md" <<'EOF'
+# Tasks
+## Active
+EOF
+}
+
+teardown() {
+    rm -rf "$WORK"
+}
+
+write_exp() {
+    local override_block="$1"
+    cat > "$EXP" <<EOF
+---
+task_id: FAKE-9200
+artifact: expectations
+schema_version: 2
+captured_at: 2026-05-30
+captured_by: /dr-prd
+status: canonical
+---
+
+# FAKE-9200 — Ожидания оператора
+
+## Ожидания
+
+- **1. Что-то должно работать.**
+  - wish_id: chto-to-rabotaet
+  - Что хочу проверить: что фича работает.
+  - Как проверить (success criterion): команда возвращает 0.
+  - Связанный AC из PRD: «—»
+  - evidence_type: empirical
+${override_block}
+  - #### История статусов
+    - 2026-05-30T00:00:00Z / 2026-05-30 · /dr-do · pending → partial · reason: частично сделано
+  - #### Текущий статус
+    - partial
+
+<!-- end -->
+
+## Append-log (operator amendments)
+
+_(пусто)_
+EOF
+}
+
+# ---------- correct 2-space override is recognized ----------
+
+@test "2-space override (operator-authored) → CONDITIONAL_PASS" {
+    write_exp "  - override: soak period not yet complete, operator-approved deferral
+  - override_by: operator"
+    run "$SCRIPT" --verify FAKE-9200 --root "$WORK"
+    [[ "$output" == *"CONDITIONAL_PASS"* ]]
+}
+
+# ---------- misplaced 4-space override is silently invisible to the validator ----------
+
+@test "4-space override (misplaced indent) → BLOCKED, not CONDITIONAL_PASS" {
+    write_exp "    - override: soak period not yet complete, operator-approved deferral
+    - override_by: operator"
+    run "$SCRIPT" --verify FAKE-9200 --root "$WORK"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"BLOCKED"* ]]
+    [[ "$output" != *"CONDITIONAL_PASS"* ]]
+}


### PR DESCRIPTION
Adds a concrete-syntax example to `skills/expectations-checklist/SKILL.md` showing the correct 2-space `override` indent (`  - override:`, matches `check-expectations-checklist.sh` regex `^  - override:`) vs. an incorrect 4-space indent (silently invisible to the validator — degrades to BLOCKED with no diagnosis).

bats: `tests/tune-0244-override-indent.bats` — 2-space recognized (CONDITIONAL_PASS), 4-space silently ignored (BLOCKED). Pre-existing `tests/check-expectations-override-authorship.bats` still green (6/6).

Class A — content addition.

Source: reflection-INFRA-0201 Class A 2; approved 2026-05-16. P3 sweep chunk 6 (TUNE-0244).