### PR TITLE
TUNE-0201: docs-probe before alternative implementation

### DIFF
--- a/skills/research-workflow/SKILL.md
+++ b/skills/research-workflow/SKILL.md
@@ -67,6 +67,16 @@ Mark affected checkpoints as `[OFFLINE — based on local context only]` in the 
 
 ---
 
+## Docs-Probe Before Alternative Implementation
+
+When the operator references a deprecated, archived, or legacy tool by name, run a Context7 + npm-search (or PyPI / crates.io equivalent) probe **before** designing an alternative implementation. Built-in successors are common — e.g. the legacy `microsoft/playwright-cli` package was superseded by `@playwright/cli`, now built into modern Playwright.
+
+A 5-minute docs-probe can save hours of unnecessary scaffolding: check whether the named tool already has a maintained successor, or whether the "missing" capability shipped as a built-in of the current major version, before scoping a replacement build.
+
+Source: INFRA-0144 reflection Class A proposal NS3.
+
+---
+
 ## Gap Discovery Protocol
 
 For use from `/dr-do` when implementation hits an unknown.

--- a/skills/research-workflow/SKILL.md
+++ b/skills/research-workflow/SKILL.md
@@ -73,7 +73,7 @@ When the operator references a deprecated, archived, or legacy tool by name, run
 
 A 5-minute docs-probe can save hours of unnecessary scaffolding: check whether the named tool already has a maintained successor, or whether the "missing" capability shipped as a built-in of the current major version, before scoping a replacement build.
 
-Source: INFRA-0144 reflection Class A proposal NS3.
+Source: a prior reflection Class A proposal (NS3).
 
 ---
 


### PR DESCRIPTION
Adds a rule to `skills/research-workflow/SKILL.md`: when the operator references a deprecated/archived/legacy tool by name, run a Context7 + npm-search (or PyPI/crates.io equivalent) probe before designing an alternative implementation. Built-in successors are common — a 5-minute docs-probe can save hours of unnecessary scaffolding.

`scripts/stack-agnostic-gate.sh` PASS, `dev-tools/check-body-english.sh --scope skills` PASS (125 files).

Source: INFRA-0144 reflection Class A proposal NS3.