### PR TITLE
TUNE-0205: portable latency-measurement snippet in skills/testing.md

### DIFF
--- a/skills/testing/bats-and-spec-lint.md
+++ b/skills/testing/bats-and-spec-lint.md
@@ -246,8 +246,10 @@ start=$(python3 -c 'import time; print(time.perf_counter())')
 # ... operation under test ...
 end=$(python3 -c 'import time; print(time.perf_counter())')
 elapsed=$(python3 -c "print(${end} - ${start})")
+# assert the duration bound (this is what the measurement is for):
+awk "BEGIN { exit !(${elapsed} < 2.0) }" || echo "duration ${elapsed}s exceeded 2.0s bound"
 ```
 
 Use this in any bats test that asserts a duration bound (timeout regression, performance-floor check) instead of `date +%s%N` subtraction.
 
-Source: deferred from TUNE-0202 Step 0.5 (Class A2).
+Source: deferred from a prior task Step 0.5 (Class A2).

--- a/skills/testing/bats-and-spec-lint.md
+++ b/skills/testing/bats-and-spec-lint.md
@@ -234,3 +234,20 @@ When the script under test resolves untrusted input (compose `${VAR}` tokens, a 
 Pair the canary check with a **battery of distinct injection vectors** — command substitution `$(…)`, backticks, statement chaining `;`, pipes `|`, redirection `>`/`<`, backgrounding `&` — because a guard that blocks one metacharacter often misses another. One `@test` (or a `for`-loop inside one) per vector, each re-arming and re-checking the canary.
 
 Source: a first-draft injection test asserted only `status -ne 0`; the script was already inert but happened to exit 0 with a warning, so the exit-code assertion was simultaneously wrong AND weaker than the real security property. The canary-absence assertion is what actually proves the command never ran.
+
+### Portable latency measurement
+
+`date +%s%N` is not portable — BSD `date` (macOS, and any Bats run on a Mac dev box) does not support the `%N` nanosecond directive and returns the literal string `N` instead of digits, silently corrupting any duration arithmetic built on it.
+
+Prefer a Python one-liner, which is portable across GNU and BSD environments:
+
+```bash
+start=$(python3 -c 'import time; print(time.perf_counter())')
+# ... operation under test ...
+end=$(python3 -c 'import time; print(time.perf_counter())')
+elapsed=$(python3 -c "print(${end} - ${start})")
+```
+
+Use this in any bats test that asserts a duration bound (timeout regression, performance-floor check) instead of `date +%s%N` subtraction.
+
+Source: deferred from TUNE-0202 Step 0.5 (Class A2).


### PR DESCRIPTION
Adds a `### Portable latency measurement` subsection to `skills/testing/bats-and-spec-lint.md` recommending `python3 -c 'import time; time.perf_counter()'` over `date +%s%N` — BSD `date` (macOS) does not support `%N` and returns the literal string instead of digits, silently corrupting duration arithmetic.

Deferred from TUNE-0202 (skills/testing.md was mid-flight in a parallel TUNE-0164 evolution-apply session at the time); this fresh clone off current main confirms the fragment is clean.

`scripts/stack-agnostic-gate.sh --diff-only` PASS, `dev-tools/check-body-english.sh --scope skills` PASS.

Source: TUNE-0202 reflection Class A2.