### PR TITLE
TUNE-0174: framework component counts-drift enforcer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1002,7 +1002,7 @@ datarim/
   agents/            # Agent personas (19 agents)
   skills/            # Knowledge modules (64 skills)
   commands/          # Slash commands (27 commands)
-  templates/         # Task and document templates (19 templates)
+  templates/         # Task and document templates (22 templates)
   documentation/              # Extended documentation and use cases
   CLAUDE.md          # Framework rules (copy to your project)
   install.sh         # Automated installer

--- a/dev-tools/check-component-counts.sh
+++ b/dev-tools/check-component-counts.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# check-component-counts.sh — framework component counts-drift enforcer (TUNE-0174).
+#
+# Repo-self-consistency check, distinct from check-repo-site-sync.sh's
+# repo-vs-site drift detection (which needs an external cross-repo registry).
+# This script has NO cross-repo dependency: it enforces that the component
+# counts claimed in THIS repo's own CLAUDE.md / README.md ("NN agents",
+# "NN skills", "NN commands", "NN templates" — parenthesized declaration
+# form, e.g. "(19 agents)") match the actual on-disk counts:
+#
+#   commands   find commands  -mindepth 1 -maxdepth 1 -name '*.md' | wc -l
+#   agents     find agents    -mindepth 1 -maxdepth 1 -name '*.md' | wc -l
+#   skills     find skills    -mindepth 1 -maxdepth 1 -type d      | wc -l   (one dir per skill, SKILL.md inside)
+#   templates  find templates -mindepth 1 -maxdepth 1 -name '*.md' | wc -l
+#
+# KNOWN GAP (out of scope for this script, tracked as a follow-up): this
+# check does NOT extend to the public site (datarim.club — pages/about.php,
+# content/en.php, content/ru.php). That is a repo-vs-site check and belongs
+# in check-repo-site-sync.sh's registry-driven mechanism (would need a new
+# registry.yml entry/field in the separate arcanada workspace, which this
+# repo's dev-tools cannot and must not touch). See TUNE-0174 PR body.
+#
+# Dependency floor: pure bash + find + grep + wc. No yq, no python.
+#
+# Usage:
+#   check-component-counts.sh [--check | --report] [--root <dir>]
+#
+# Exit codes:
+#   0  clean (all claims match actual counts, or no claims found)
+#   1  at least one category has a claim/actual mismatch
+#   2  usage error
+#   3  root not found (no CLAUDE.md / README.md at resolved root)
+#
+# Read-only: no writes, no network.
+
+set -uo pipefail
+
+SCRIPT_NAME="check-component-counts.sh"
+MODE="check"            # check | report
+ROOT=""
+
+print_usage() {
+    cat <<EOF
+Usage: $SCRIPT_NAME [--check | --report] [--root <dir>]
+
+  --check        exit 0 = all counts match, 1 = drift found (default)
+  --report       human-readable per-category findings
+  --root <dir>   repo root (default: walk up from cwd to find CLAUDE.md)
+  --help         this message
+
+Exit: 0 clean | 1 drift | 2 usage error | 3 root not found
+EOF
+}
+
+# ---- arg parse ----
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --check)  MODE="check"; shift ;;
+        --report) MODE="report"; shift ;;
+        --root)   ROOT="${2:-}"; shift 2 ;;
+        -h|--help) print_usage; exit 0 ;;
+        *) echo "ERROR: unknown argument: $1" >&2; print_usage >&2; exit 2 ;;
+    esac
+done
+
+# ---- resolve repo root ----
+if [ -z "$ROOT" ]; then
+    d="$PWD"
+    while [ "$d" != "/" ]; do
+        if [ -f "$d/CLAUDE.md" ]; then ROOT="$d"; break; fi
+        d="$(dirname "$d")"
+    done
+fi
+if [ -z "$ROOT" ] || [ ! -f "$ROOT/CLAUDE.md" ]; then
+    echo "ERROR: repo root not found (no CLAUDE.md)" >&2
+    exit 3
+fi
+
+CATEGORIES="commands agents skills templates"
+
+# Actual on-disk count for a category. Echoes an integer (0 if dir absent).
+actual_count() {  # $1=category
+    local cat="$1" dir="$ROOT/$1"
+    [ -d "$dir" ] || { echo 0; return; }
+    case "$cat" in
+        skills) find "$dir" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ' ;;
+        *)      find "$dir" -mindepth 1 -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ' ;;
+    esac
+}
+
+# Claimed count for a category in a given doc file. Parenthesized
+# declaration form only, e.g. "(19 agents)" / "(64 skills, ...)" — this is
+# the format both CLAUDE.md and README.md use at their canonical count
+# declaration points, and it avoids false positives from illustrative
+# prose elsewhere (e.g. "Documentation says 15 agents but disk has 12",
+# ">20 skills" threshold examples — neither is parenthesized).
+# Echoes the first match's number, or nothing if no claim found.
+claimed_count() {  # $1=file $2=category
+    local file="$1" cat="$2"
+    [ -f "$file" ] || return
+    grep -oE "\([0-9]+ ${cat}\b" "$file" 2>/dev/null | head -1 | grep -oE '[0-9]+'
+}
+
+FINDINGS=""   # accumulates "<file>|<category>|<claimed>|<actual>"
+add_finding() { FINDINGS="${FINDINGS}${1}|${2}|${3}|${4}"$'\n'; }
+
+for doc in "$ROOT/CLAUDE.md" "$ROOT/README.md"; do
+    [ -f "$doc" ] || continue
+    doc_name="$(basename "$doc")"
+    for cat in $CATEGORIES; do
+        claim="$(claimed_count "$doc" "$cat")"
+        [ -n "$claim" ] || continue
+        actual="$(actual_count "$cat")"
+        if [ "$claim" != "$actual" ]; then
+            add_finding "$doc_name" "$cat" "$claim" "$actual"
+        fi
+    done
+done
+
+DRIFT="$(printf '%s' "$FINDINGS" | awk -F'|' 'NF>=4 {c++} END{print c+0}')"
+
+if [ "$MODE" = "report" ]; then
+    if [ -z "$FINDINGS" ]; then
+        echo "OK: all component-count claims match on-disk counts."
+    else
+        printf '%s' "$FINDINGS" | awk -F'|' 'NF>=4 {printf "%-12s %-10s claims %-4s actual %-4s\n", $1, $2, $3, $4}'
+    fi
+fi
+
+[ "$DRIFT" -gt 0 ] && exit 1
+exit 0

--- a/documentation/how-to/evolution-log.md
+++ b/documentation/how-to/evolution-log.md
@@ -2062,3 +2062,52 @@ declined as redundant.
 
 **Verification:** stack-agnostic-gate PASS, task-id-gate PASS, no Cyrillic introduced,
 `bats tests/` → 1652 tests, 0 failures.
+
+---
+
+## 2026-07-10 — TUNE-0174 — Framework component counts-drift enforcer (repo-self-consistency)
+
+**Category:** add-mechanical-ci-gate. **Target:** new `dev-tools/check-component-counts.sh`
++ `tests/check-component-counts.bats`.
+
+**Context:** TUNE-0154 ("mechanical CI enforcer for repo-vs-site count drift") was archived
+DONE but its scope narrowed during the ARCA-0142/ARCA-0143 consolidation into
+`dev-tools/check-repo-site-sync.sh`. That script's `feature_count_repo`/`feature_count_site`
+mechanism checks exactly one category (`commands`) against one external site page, driven by
+a cross-repo registry (`documentation/ecosystem-sync/registry.yml`) that lives outside this
+repo. It never checked `skills`/`agents`/`templates` counts, and it never checked this repo's
+OWN `CLAUDE.md`/`README.md` prose claims against the actual on-disk component counts — a
+different, repo-self-consistency class of drift, orthogonal to the repo-vs-site class.
+
+**What:** Added `dev-tools/check-component-counts.sh`, a self-contained (no registry, no
+cross-repo dependency) gate that: (1) counts on-disk components per category — `commands`/
+`agents`/`templates` via `find -maxdepth 1 -name '*.md' | wc -l`, `skills` via
+`find -maxdepth 1 -type d | wc -l` (one directory per skill, `SKILL.md` inside — verified
+this is how the repo actually lays out skills, unlike the flat-`.md` agents/commands/templates
+dirs); (2) extracts the parenthesized count-claim form (`"(NN category)"`, e.g. `(19 agents)`)
+from this repo's own `CLAUDE.md` and `README.md` — chosen over a bare `NN category` grep
+because the repo also uses that wording in illustrative/threshold prose that is NOT a count
+claim (e.g. README's optimizer-example table row "Documentation says 15 agents but disk has
+12", and the `>20 skills` / `>25 commands` health-metric threshold example — neither
+parenthesized, both would have been false positives under a naive grep); (3) exits 1 with a
+per-category diagnostic (file, category, claimed, actual) on any mismatch.
+
+**Found + fixed a real, pre-existing drift while building this:** README.md's Directory
+Structure block claimed `(19 templates)` but the on-disk `templates/` dir actually has 22
+`.md` files (drift accumulated silently — no gate existed to catch it). Fixed the claim to
+22 so the new gate starts green rather than immediately red on merge.
+
+**Explicitly out of scope for this PR (deferred, cross-repo):** extending the repo-vs-site
+check in `check-repo-site-sync.sh` to also compare `skills`/`agents`/`templates` counts
+against `datarim.club`'s `pages/about.php`/`content/en.php`/`content/ru.php`. That requires
+adding fields to `documentation/ecosystem-sync/registry.yml`, which lives in the separate
+`arcanada` workspace — out of reach for a sweep confined to a clone of this repo. Left a
+one-line comment in the new script pointing at the gap; flagged in the PR body as a follow-up
+candidate task.
+
+**Verification:** new `tests/check-component-counts.bats` — 10/10 green (fully-consistent
+fixture passes; one corrupted-claim-per-category fixture fails with exit 1 and the
+category/claimed/actual named in `--report` output, for each of the 4 categories; no-claim
+fixture is a no-op pass; `--root` auto-walk-up verified). `tests/check-repo-site-sync.bats` —
+12/12 green, no regression from the sibling script being read as prior art. Full `bats tests/`
+run — see PR body for the pass/fail count captured at PR-open time.

--- a/tests/check-component-counts.bats
+++ b/tests/check-component-counts.bats
@@ -1,0 +1,110 @@
+#!/usr/bin/env bats
+# check-component-counts.bats — V-AC matrix for the framework component
+# counts-drift enforcer (TUNE-0174). Each test builds a throwaway fixture
+# root (CLAUDE.md + README.md + commands/agents/skills/templates dirs) and
+# asserts detector behaviour. Repo-self-consistency only — no registry, no
+# cross-repo dependency (contrast with check-repo-site-sync.bats).
+
+setup() {
+    DETECTOR="${BATS_TEST_DIRNAME}/../dev-tools/check-component-counts.sh"
+    KB="$(mktemp -d)"
+    mkdir -p "$KB/commands" "$KB/agents" "$KB/skills/skill-a" "$KB/skills/skill-b" "$KB/templates"
+    : > "$KB/commands/a.md"; : > "$KB/commands/b.md"                       # 2 commands
+    : > "$KB/agents/x.md"                                                 # 1 agent
+    : > "$KB/skills/skill-a/SKILL.md"; : > "$KB/skills/skill-b/SKILL.md"  # 2 skills (one dir each)
+    : > "$KB/templates/t1.md"                                             # 1 template
+    write_docs 2 1 2 1   # default: fully-consistent claims (commands agents skills templates)
+}
+
+teardown() { rm -rf "$KB"; }
+
+# Helper: write CLAUDE.md + README.md with parenthesized count claims.
+write_docs() {  # $1=commands $2=agents $3=skills $4=templates
+    cat > "$KB/CLAUDE.md" <<EOF
+# CLAUDE.md fixture
+Agent files: \`\$HOME/.claude/agents/{name}.md\` ($2 agents)
+Skill files: \`\$HOME/.claude/skills/{name}/SKILL.md\` ($3 skills, fixture)
+Command files: \`\$HOME/.claude/commands/{name}.md\` ($1 commands, fixture)
+EOF
+    cat > "$KB/README.md" <<EOF
+# README fixture
+\`\`\`
+datarim/
+  agents/            # Agent personas ($2 agents)
+  skills/            # Knowledge modules ($3 skills)
+  commands/          # Slash commands ($1 commands)
+  templates/         # Task and document templates ($4 templates)
+\`\`\`
+EOF
+}
+
+@test "help exits 0" {
+    run bash "$DETECTOR" --help
+    [ "$status" -eq 0 ]
+}
+
+@test "unknown flag exits 2" {
+    run bash "$DETECTOR" --bogus --root "$KB"
+    [ "$status" -eq 2 ]
+}
+
+@test "missing root (no CLAUDE.md) exits 3" {
+    rm -f "$KB/CLAUDE.md"
+    run bash "$DETECTOR" --check --root "$KB"
+    [ "$status" -eq 3 ]
+}
+
+@test "fully consistent fixture: --check exits 0 (V-AC-1)" {
+    run bash "$DETECTOR" --check --root "$KB"
+    [ "$status" -eq 0 ]
+}
+
+@test "corrupted templates claim: --check exits 1, --report names category+claim+actual (V-AC-2)" {
+    write_docs 2 1 2 19   # templates claim corrupted to 19, actual is still 1
+    run bash "$DETECTOR" --check --root "$KB"
+    [ "$status" -eq 1 ]
+    run bash "$DETECTOR" --report --root "$KB"
+    [[ "$output" == *templates* ]]
+    [[ "$output" == *"claims 19"* ]]
+    [[ "$output" == *"actual 1"* ]]
+}
+
+@test "corrupted skills claim: --check exits 1 (V-AC-2)" {
+    write_docs 2 1 99 1   # skills claim corrupted, actual dirs still 2
+    run bash "$DETECTOR" --check --root "$KB"
+    [ "$status" -eq 1 ]
+    run bash "$DETECTOR" --report --root "$KB"
+    [[ "$output" == *skills* ]]
+    [[ "$output" == *"claims 99"* ]]
+    [[ "$output" == *"actual 2"* ]]
+}
+
+@test "corrupted commands claim: --check exits 1 (V-AC-2)" {
+    write_docs 5 1 2 1   # commands claim corrupted, actual still 2
+    run bash "$DETECTOR" --check --root "$KB"
+    [ "$status" -eq 1 ]
+}
+
+@test "corrupted agents claim: --check exits 1 (V-AC-2)" {
+    write_docs 2 7 2 1   # agents claim corrupted, actual still 1
+    run bash "$DETECTOR" --check --root "$KB"
+    [ "$status" -eq 1 ]
+}
+
+@test "no parenthesized claim present: not a drift (skip), exits 0" {
+    cat > "$KB/CLAUDE.md" <<EOF
+# CLAUDE.md fixture with no count claims at all
+Nothing to see here.
+EOF
+    cat > "$KB/README.md" <<EOF
+# README fixture with no count claims
+EOF
+    run bash "$DETECTOR" --check --root "$KB"
+    [ "$status" -eq 0 ]
+}
+
+@test "--root defaults to walking up from cwd to find CLAUDE.md" {
+    mkdir -p "$KB/nested/deeper"
+    run bash -c "cd '$KB/nested/deeper' && bash '$DETECTOR' --check"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

- Adds `dev-tools/check-component-counts.sh`: a self-contained (no cross-repo registry dependency) gate enforcing that the component counts claimed in THIS repo's own `CLAUDE.md`/`README.md` (parenthesized declaration form, e.g. `(19 agents)`) match the actual on-disk counts for `commands`/`agents`/`templates` (`find -maxdepth 1 -name '*.md' | wc -l`) and `skills` (`find -maxdepth 1 -type d | wc -l` — skills are one-directory-per-skill with `SKILL.md` inside, verified against actual repo layout, unlike the flat-`.md` other three categories).
- Chose the parenthesized-claim grep pattern specifically to avoid false positives: this repo's own docs use `NN category` wording in illustrative/threshold prose that is NOT a real count claim (e.g. README's optimizer-example table row "Documentation says 15 agents but disk has 12", and the `>20 skills` / `>25 commands` health-metric threshold example) — neither is parenthesized, so a naive bare-`NN category` grep would have false-positived on both.
- **Found + fixed a real, pre-existing drift while building this**: README.md's Directory Structure block claimed `(19 templates)` but `templates/` actually has 22 `.md` files. Fixed the claim to 22 so the new gate starts green.
- This is a repo-**self**-consistency check, distinct from `dev-tools/check-repo-site-sync.sh`'s repo-**vs-site** drift detection (TUNE-0154, consolidated via ARCA-0142/ARCA-0143). That script's `feature_count_repo`/`feature_count_site` mechanism only checks `commands` against one external site page via a registry (`documentation/ecosystem-sync/registry.yml`) that lives outside this repo.

## Explicitly deferred (cross-repo, out of scope for this PR)

Extending `check-repo-site-sync.sh` to also compare `skills`/`agents`/`templates` counts against `datarim.club`'s `pages/about.php`/`content/en.php`/`content/ru.php` requires adding fields to `documentation/ecosystem-sync/registry.yml`, which lives in the separate `arcanada` workspace (out of reach for this sweep, which is confined to a clone of this repo only). Left a one-line comment in the new script pointing at the gap, and an evolution-log entry.

## Test plan

- [x] New `tests/check-component-counts.bats` (10 tests) — green. Covers: help/usage-error/root-not-found exit codes, fully-consistent fixture passes, one corrupted-claim-per-category fixture fails with exit 1 + category/claimed/actual named in `--report` for each of the 4 categories, no-claim fixture is a no-op pass, `--root` auto-walk-up.
- [x] `bats tests/check-component-counts.bats` → `10/10` green.
- [x] `bats tests/check-repo-site-sync.bats` → `12/12` green, no regression (sibling script untouched, read only as prior-art for fixture-isolation style).
- [x] Full `bats tests/` (156 files, 1744 tests) → 1737 passed, 7 failed. All 7 failures verified **pre-existing and unrelated**: reproduced identically via `git stash` on a clean checkout of this branch's base commit (before any of this PR's changes), in `tests/test-fleet-evolution-gates.bats` (run-all-gates, seed roles.yaml validation), `tests/test-role-registry.bats` (context_budget_tokens checks), and `tests/test-fleet-evolution-loop.bats` (coworker-loop dry-run/env-var-expansion) — none touch README.md/CLAUDE.md counts or dev-tools/check-component-counts.sh.
- [x] `shellcheck dev-tools/check-component-counts.sh` — clean, no warnings.
- [x] Evolution log entry appended: `documentation/how-to/evolution-log.md` (2026-07-10, TUNE-0174).

🤖 Generated as part of an autonomous P3 backlog sweep.