### PR TITLE
TUNE-0247: /dr-plan Step 11 license-policy checkpoint

### DIFF
--- a/commands/dr-plan.md
+++ b/commands/dr-plan.md
@@ -165,6 +165,15 @@ This command generates a detailed implementation plan in `datarim/tasks.md`, str
         -   Python ecosystem: install runtime deps, then `pip-audit --strict`
         -   Rust ecosystem: `cargo audit --deny warnings`
     <!-- /gate:example-only -->
+    -   **License-policy checkpoint (alongside the audit gate, same stub)**: vulnerability audits are advisory-only and do not check license compatibility — a transitive dependency can carry a copyleft/restrictive license the plan never declared. Run the project's package-manager-native license checker against the same stub.
+    <!-- gate:example-only -->
+    -   Concrete recipes (illustrative — substitute the project's actual package manager and disallowed-license list):
+        -   Node ecosystem: `license-checker --production --failOn <disallowed-list>`
+        -   Python ecosystem: `pip-licenses --fail-on <disallowed-list>`
+        -   Rust ecosystem: `cargo deny check licenses`
+        -   Ruby ecosystem: `license_finder`
+    <!-- /gate:example-only -->
+    -   A license-policy mismatch is handled the same way as an audit failure below: re-pin to a compatible version, or open a backlog item with an explicit accepted-risk sign-off.
     -   **If the audit gate fails on the proposed lock**, before promoting the plan to `/dr-do`:
         -   (a) Bump version pins in the plan (and any cited PRD constraint) until the gate passes; OR
         -   (b) Open a backlog item describing the unfixable CVE chain and document it in the plan's Security Summary as an **explicit accepted risk** with sign-off line.

--- a/tests/tune-0247-dr-plan-step11-license-checker.bats
+++ b/tests/tune-0247-dr-plan-step11-license-checker.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+#
+# /dr-plan Step 11 Live Audit Checkpoint — license-policy checkpoint regression
+# guard (TUNE-0247). `cargo audit` is advisory-only (vulnerabilities), not a
+# license check; a transitive dependency (e.g. MPL-2.0 `option-ext` pulled by
+# `directories`) can violate license policy without tripping the audit gate.
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+DR_PLAN_DOC="$REPO_ROOT/commands/dr-plan.md"
+
+@test "T1: dr-plan.md Step 11 contains 'License-policy checkpoint' sub-bullet" {
+    [ -f "$DR_PLAN_DOC" ]
+    run grep -F "License-policy checkpoint" "$DR_PLAN_DOC"
+    [ "$status" -eq 0 ]
+}
+
+@test "T2: license checkpoint names package-manager-native license checkers" {
+    run grep -F "cargo deny check licenses" "$DR_PLAN_DOC"
+    [ "$status" -eq 0 ]
+    run grep -F "pip-licenses --fail-on" "$DR_PLAN_DOC"
+    [ "$status" -eq 0 ]
+    run grep -F "license-checker --production" "$DR_PLAN_DOC"
+    [ "$status" -eq 0 ]
+}
+
+@test "T3: license checkpoint recipes are wrapped in gate:example-only markers" {
+    awk '/License-policy checkpoint/{flag=1} flag && /cargo deny check licenses/{found=1} flag && /<!-- \/gate:example-only -->/{exit} END{exit !found}' "$DR_PLAN_DOC"
+}
+
+@test "T4: license checkpoint sits inside Step 11 Live Audit Checkpoint block" {
+    awk '/^11\.  \*\*Live Audit Checkpoint/{flag=1} flag && /License-policy checkpoint/{found=1} flag && /^11\.5\./{exit} END{exit !found}' "$DR_PLAN_DOC"
+}


### PR DESCRIPTION
Adds a license-policy checkpoint to Step 11 Live Audit Checkpoint, alongside the existing audit-gate stub. cargo audit / pip-audit / npm audit are vulnerability-advisory only and do not check license compatibility (ARAS-0005 archived a transitive MPL-2.0 dependency that a license checker would have caught at plan time). 4 new bats tests; stack-agnostic-gate.sh PASS.