### PR TITLE
TUNE-0246: /dr-plan external-crate version probe

### DIFF
--- a/commands/dr-plan.md
+++ b/commands/dr-plan.md
@@ -87,6 +87,14 @@ This command generates a detailed implementation plan in `datarim/tasks.md`, str
 6.  **Technology Validation**:
     -   Document technology stack selection.
     -   Verify dependencies and build configuration.
+    -   **External-crate version probe (MANDATORY when the plan introduces a NEW external library dependency not already present in the workspace manifest — `Cargo.toml` / `package.json` / `pyproject.toml` / `Gemfile` / etc.)**: query the package registry for the latest stable version using the project's package-manager-native lookup, record the chosen version + a one-sentence rationale in the plan's Component Breakdown, and — when a non-default feature/extra is named — probe that the feature/extra exists in the registry metadata before locking it into the plan.
+    <!-- gate:example-only -->
+    -   Concrete recipes (illustrative — substitute the project's actual package manager):
+        -   Rust ecosystem: `cargo search <crate>` (or crates.io API when `cargo search` is disabled on the configured registry)
+        -   Node ecosystem: `pnpm view <pkg> versions`
+        -   Python ecosystem: `pip index versions <pkg>`
+        -   Ruby ecosystem: `gem list -r <gem>`
+    <!-- /gate:example-only -->
 
 6.5.  **Symbol Existence Check (MANDATORY when the plan names a method, function, file, flag, env var, or CLI command as a fix target)**:
     -   For every named code surface in the plan (e.g. `module.foo`, `path/to/file.ext`, `--flag-name`, `$ENV_VAR`), grep the project to confirm it exists.

--- a/tests/tune-0246-dr-plan-external-crate-version-probe.bats
+++ b/tests/tune-0246-dr-plan-external-crate-version-probe.bats
@@ -1,0 +1,43 @@
+#!/usr/bin/env bats
+#
+# /dr-plan Step 6 Technology Validation — external-crate version probe
+# regression guard (TUNE-0246). When a plan introduces a NEW external
+# library dependency, the planner must query the package registry for the
+# latest stable version and record version + rationale, rather than guessing
+# or copying a pin from memory (ARAS-0004).
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+DR_PLAN_DOC="$REPO_ROOT/commands/dr-plan.md"
+
+@test "T1: dr-plan.md Step 6 contains 'External-crate version probe' sub-bullet" {
+    [ -f "$DR_PLAN_DOC" ]
+    run grep -F "External-crate version probe" "$DR_PLAN_DOC"
+    [ "$status" -eq 0 ]
+}
+
+@test "T2: probe trigger is scoped to a NEW dependency not already in the workspace manifest" {
+    run grep -F "NEW external library dependency not already present in the workspace manifest" "$DR_PLAN_DOC"
+    [ "$status" -eq 0 ]
+}
+
+@test "T3: probe requires recording chosen version + rationale in Component Breakdown" {
+    run grep -F "record the chosen version + a one-sentence rationale in the plan's Component Breakdown" "$DR_PLAN_DOC"
+    [ "$status" -eq 0 ]
+}
+
+@test "T4: probe names package-manager-native registry lookups across ecosystems" {
+    run grep -F "cargo search <crate>" "$DR_PLAN_DOC"
+    [ "$status" -eq 0 ]
+    run grep -F "pnpm view <pkg> versions" "$DR_PLAN_DOC"
+    [ "$status" -eq 0 ]
+    run grep -F "pip index versions <pkg>" "$DR_PLAN_DOC"
+    [ "$status" -eq 0 ]
+}
+
+@test "T5: probe bullet sits inside Step 6 Technology Validation, before Step 6.5" {
+    awk '/^6\.  \*\*Technology Validation\*\*/{flag=1} flag && /External-crate version probe/{found=1} flag && /^6\.5\./{exit} END{exit !found}' "$DR_PLAN_DOC"
+}
+
+@test "T6: registry-lookup recipes are wrapped in gate:example-only markers" {
+    awk '/External-crate version probe/{flag=1} flag && /cargo search <crate>/{found=1} flag && /<!-- \/gate:example-only -->/{exit} END{exit !found}' "$DR_PLAN_DOC"
+}


### PR DESCRIPTION
Adds a Step 6 Technology Validation sub-bullet: when a plan introduces a NEW external library dependency, query the package registry for the latest stable version and record version+rationale in the Component Breakdown, instead of guessing/copying a pin from memory. 6 new bats tests; stack-agnostic-gate.sh PASS. (Source: reflection-ARAS-0004 evolution-proposal #1)