### PR TITLE
TUNE-0260: /dr-do lint-on-the-spot in TDD loop

### DIFF
--- a/commands/dr-do.md
+++ b/commands/dr-do.md
@@ -40,6 +40,13 @@ description: Implement planned changes using TDD and AI quality principles
     - Implement one stub/method at a time.
     - Follow `datarim/history/patterns.md` and `datarim/style-guide.md`.
     - Apply quality rules: max 50 lines/method, max 7-9 objects in scope, tests before code.
+    - **Lint-on-the-spot (MANDATORY after each TDD Loop code-change step)**: auto-detect the project linter from the manifest present in the repo root (or nearest package boundary) and run it against the changed files before moving to the next stub/method. Fix findings immediately — do not carry lint debt forward to `/dr-compliance`; that stage assumes a clean baseline and is not a linter-fixup pass.
+    <!-- gate:example-only -->
+    -   Concrete recipes (illustrative — substitute the project's actual linter):
+        -   Rust ecosystem: `cargo clippy --all-targets -- -D warnings`
+        -   Node ecosystem: `eslint <changed-files>`
+        -   Python ecosystem: `ruff check <changed-files>`
+    <!-- /gate:example-only -->
 
 7.5 **GAP DISCOVERY** (during implementation):
     If you encounter an unknown that blocks progress (import failure, unexpected API behavior, docs ≠ reality, missing feature, compatibility issue):

--- a/tests/tune-0260-dr-do-lint-on-the-spot.bats
+++ b/tests/tune-0260-dr-do-lint-on-the-spot.bats
@@ -1,0 +1,34 @@
+#!/usr/bin/env bats
+#
+# /dr-do Step 7 ACTION — lint-on-the-spot regression guard (TUNE-0260).
+# Linter must run after each TDD Loop code-change step, not just be
+# deferred to /dr-compliance (reflection-TUNE-0258 § Class A A2 — 3
+# ruff-notation lint findings required a separate fixup commit c-208c027
+# because linting only happened at compliance time).
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+DR_DO_DOC="$REPO_ROOT/commands/dr-do.md"
+
+@test "T1: dr-do.md Step 7 ACTION contains 'Lint-on-the-spot' sub-bullet" {
+    [ -f "$DR_DO_DOC" ]
+    run grep -F "Lint-on-the-spot" "$DR_DO_DOC"
+    [ "$status" -eq 0 ]
+}
+
+@test "T2: lint rule triggers after each TDD Loop code-change step" {
+    run grep -F "MANDATORY after each TDD Loop code-change step" "$DR_DO_DOC"
+    [ "$status" -eq 0 ]
+}
+
+@test "T3: lint rule forbids deferring lint debt to /dr-compliance" {
+    run grep -F "do not carry lint debt forward to \`/dr-compliance\`" "$DR_DO_DOC"
+    [ "$status" -eq 0 ]
+}
+
+@test "T4: lint rule names linter recipes across ecosystems, wrapped in gate:example-only" {
+    awk '/Lint-on-the-spot/{flag=1} flag && /cargo clippy/{found_clippy=1} flag && /eslint <changed-files>/{found_eslint=1} flag && /ruff check <changed-files>/{found_ruff=1} flag && /<!-- \/gate:example-only -->/{exit} END{exit !(found_clippy && found_eslint && found_ruff)}' "$DR_DO_DOC"
+}
+
+@test "T5: lint-on-the-spot bullet sits inside Step 7 ACTION, before Step 7.5" {
+    awk '/^7\.  \*\*ACTION\*\*/{flag=1} flag && /Lint-on-the-spot/{found=1} flag && /^7\.5/{exit} END{exit !found}' "$DR_DO_DOC"
+}


### PR DESCRIPTION
Adds a Step 7 ACTION sub-bullet: run the auto-detected project linter after each TDD Loop code-change step and fix findings immediately, instead of leaving lint debt for /dr-compliance. 5 new bats tests; stack-agnostic-gate.sh PASS. (Source: reflection-TUNE-0258 § Class A A2)