### PR TITLE
TUNE-0338: runtime apply of reflection Class A A1/A2/A3

### DIFF
--- a/commands/dr-design.md
+++ b/commands/dr-design.md
@@ -29,7 +29,7 @@ description: Explore architectural and design decisions for complex features (Le
     - **Define problem** clearly and specifically.
     - **Explore 3+ options** with different approaches.
     - **Analyze tradeoffs** — pros, cons, complexity, effort for each option.
-    - **Make decision** with clear rationale.
+    - **Make decision** with clear rationale. If the decision only takes observable effect after a deploy/cutover (not merely after the code merges), mark it explicitly in the § Decision subsection — e.g. `**Deploy-gated:** yes — takes effect after <deploy step>` — so `/dr-plan` can cross-reference it via a `[deploy-gated — see creative-{TASK-ID}.md § Decision]` annotation on the dependent Implementation Step(s).
     - **Document implementation plan** — specific steps to realize the decision.
     - **Visualize** — include diagrams (mermaid) where helpful.
     - **Apply quality rules**: #6 Corner Cases, #7 Skeleton, #9 Cognitive Load, #13 Transactions (see `ai-quality.md` § Stage-Rule Mapping).

--- a/commands/dr-do.md
+++ b/commands/dr-do.md
@@ -25,6 +25,8 @@ description: Implement planned changes using TDD and AI quality principles
     -   Bypass is permitted ONLY when (a) the harness hook explicitly returned an allow decision (operator override at runtime) AND (b) the override reason is recorded in the same § Implementation Notes line. Silent bypass = process regression; `/dr-compliance` will surface it.
     -   Rationale: hook-enforced mandates exist because the operator decided the delegation matters — for token economics, for content review discipline, or for security. Working around the hook to save time negates the operator's design decision and creates inconsistent artefact provenance across the task lifecycle.
 
+5.6. **PLAN-EXTRACT RECOMMENDATION (coworker, advisory)**: after reading the plan in Step 5, check its size — `datarim/tasks/{TASK-ID}-task-description.md` § Implementation Notes for L1-L2, or `datarim/plans/{TASK-ID}-plan.md` for L3-L4. When the plan exceeds **400 lines** AND this session is expected to cover **≥2 implementation phases** (a multi-phase plan, or an explicit multi-session plan), recommend — do not mandate — a `coworker ask --profile datarim` bulk-extract pass before starting the TDD loop: distill the plan into a phase-by-phase checklist so the working context is not dominated by the full plan text for the whole session. Skip silently when the plan is ≤400 lines or the session covers a single phase — the delegation overhead is not worth it for short/simple plans.
+
 6.  **PRE-FLIGHT CHECK** (L3-L4 code tasks only):
     Before writing any code, verify readiness:
     ```

--- a/commands/dr-plan.md
+++ b/commands/dr-plan.md
@@ -41,6 +41,8 @@ This command generates a detailed implementation plan in `datarim/tasks.md`, str
     -   **Data Flow**: Trace input -> processing -> output.
     -   **Security Design**: Perform **Threat Modeling** and map to **Security Controls** (Appendix A).
 
+4.5. **Plan ↔ Creative Deploy-Dependency Cross-Reference** (MANDATORY when this task has a companion `datarim/creative/creative-{TASK-ID}-*.md` design doc that marks any Decision as deploy-gated — i.e. the decision only takes observable effect after a deploy/cutover, not merely after the code merges): for every Implementation Step whose completion depends on such a decision, annotate the step inline with `[deploy-gated — see creative-{TASK-ID}.md § Decision]`. This makes the deploy dependency visible to `/dr-qa` Layer 3 (Plan Completeness) and to the operator reading the plan, instead of surfacing only when a step marked "done" turns out to still be waiting on a deploy. Cost: one grep of the creative doc's § Decision sections for a deploy-gated marker. Saving: avoids a `/dr-qa` false-positive on a step that is code-complete but not yet effective.
+
 5.  **Create Implementation Plan (Phase 5)** — thin-index schema:
     -   **`datarim/tasks.md`** carries ONLY the one-liner pointer (canonical regex per `skills/datarim-system/SKILL.md` § Operational File Schema):
         ```

--- a/commands/dr-qa.md
+++ b/commands/dr-qa.md
@@ -24,7 +24,7 @@ description: Multi-layer quality verification — checks PRD alignment, design c
     -   When `--decided-by agent`: `--rationale-file <path>` MUST contain ≥ 50 non-whitespace characters of best-practice rationale. Layer 3b will verify each agent-decision against the implementation.
     -   On contradiction with an expectation: add `--conflict-with <wish_id>` (+ optional `--conflict-detail-file`); CTA MUST route back to `/dr-do --focus-items <wish_id>` for closure.
     -   Skip if no clarification rounds occurred.
-7.  **OUTPUT**: Write `datarim/qa/qa-report-{task-id}.md` with results.
+7.  **OUTPUT**: Write `datarim/qa/qa-report-{task-id}.md` with results, including the § Deferred Items (session-scoped) table below (empty/`None` by default; populate whenever a layer identifies a gap that this pass is knowingly not fixing).
 8.  **HUMAN SUMMARY**:
     - Load `$HOME/.claude/skills/human-summary/SKILL.md`.
     - Emit the `## Отчёт оператору` (RU) / `## Operator summary` (EN) section, with the four mandated sub-sections, between the QA-report write and the CTA block ([definition](../skills/cta-format/SKILL.md)). Language follows the most recent operator message. <!-- allow-non-ascii: literal-russian-section-name-token-from-human-summary-skill -->
@@ -454,6 +454,23 @@ Write to `datarim/qa/qa-report-{task-id}.md`:
 
 **Layers executed:** {N of 4}
 **Results:** {list of layer verdicts}
+
+## Deferred Items (session-scoped)
+
+Reviewer-identified gaps or defects that this QA pass is knowingly **not**
+fixing — a design fork, an out-of-scope finding, or an item blocked on an
+external dependency. Distinct from a Layer 3b `partial`/`missed` wish (those
+track operator-declared expectations, not reviewer-found gaps). Session-scoped:
+the table is cleared on the next `/dr-qa` re-run unless a row is carried
+forward into `datarim/backlog.md` as a fresh pending item — cite that
+TASK-ID in the last column so the deferral has a durable trail instead of
+evaporating with this report.
+
+| # | Item | Reason deferred | Blocked-by / follow-up | Carried to backlog.md? |
+|---|------|------------------|--------------------------|--------------------------|
+| 1 | {one-line gap} | {design-fork \| out-of-scope \| blocked-dependency} | {TASK-ID or "—"} | {yes → TASK-ID \| no} |
+
+`None — no deferrals this session` is the default and expected row when nothing was deferred.
 
 ## /dr-auto Mode (when `DATARIM_AUTO_MODE=1`)
 

--- a/tests/tune-0338-reflection-agent-0017-class-a.bats
+++ b/tests/tune-0338-reflection-agent-0017-class-a.bats
@@ -1,0 +1,103 @@
+#!/usr/bin/env bats
+# TUNE-0338 — Datarim framework runtime apply for AGENT-0017 reflection
+# Class A proposals A1/A2/A3 (stack-agnostic).
+#
+# A1 = Session-scoped Deferred-Items table in dr-qa.md QA report template.
+# A2 = Pre-/dr-do coworker plan-extract recommendation in dr-do.md
+#      (trigger: plan >400 lines + session covers >=2 phases).
+# A3 = Plan <-> Creative deploy-dependency cross-reference rule in dr-plan.md
+#      + dr-design.md (annotation `[deploy-gated — see creative-{ID}.md §
+#      Decision]`).
+
+DR_QA="$BATS_TEST_DIRNAME/../commands/dr-qa.md"
+DR_DO="$BATS_TEST_DIRNAME/../commands/dr-do.md"
+DR_PLAN="$BATS_TEST_DIRNAME/../commands/dr-plan.md"
+DR_DESIGN="$BATS_TEST_DIRNAME/../commands/dr-design.md"
+
+# ---------------------------------------------------------------------------
+# A1 — dr-qa.md Deferred-Items table
+# ---------------------------------------------------------------------------
+
+@test "A1: dr-qa.md QA report template has a Deferred Items section" {
+    run grep -ci 'Deferred Items' "$DR_QA"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+}
+
+@test "A1: Deferred Items section is explicitly session-scoped" {
+    run grep -i 'session-scoped' "$DR_QA"
+    [ "$status" -eq 0 ]
+}
+
+@test "A1: Deferred Items section documents carry-forward to backlog.md" {
+    run grep -i 'backlog.md' "$DR_QA"
+    [ "$status" -eq 0 ]
+}
+
+@test "A1: OUTPUT step wires the Deferred Items table into the report" {
+    run grep -A2 '\*\*OUTPUT\*\*: Write .datarim/qa/qa-report' "$DR_QA"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Deferred Items"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# A2 — dr-do.md coworker plan-extract recommendation
+# ---------------------------------------------------------------------------
+
+@test "A2: dr-do.md recommends a coworker plan-extract pass" {
+    run grep -ci 'plan-extract' "$DR_DO"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+}
+
+@test "A2: plan-extract recommendation cites coworker" {
+    run grep -i 'plan-extract' "$DR_DO"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"coworker"* ]]
+}
+
+@test "A2: plan-extract recommendation is trigger-gated on plan length (400 lines)" {
+    run grep -i 'plan-extract' "$DR_DO"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"400"* ]]
+}
+
+@test "A2: plan-extract recommendation is trigger-gated on multi-phase sessions" {
+    run grep -i 'plan-extract' "$DR_DO"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"phase"* ]] || [[ "$output" == *"Phase"* ]]
+}
+
+@test "A2: plan-extract recommendation is advisory, not mandatory" {
+    run grep -B2 -A2 -i 'plan-extract' "$DR_DO"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"advisory"* ]] || [[ "$output" == *"recommend"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# A3 — dr-plan.md / dr-design.md deploy-dependency cross-reference
+# ---------------------------------------------------------------------------
+
+@test "A3: dr-plan.md defines the deploy-gated annotation contract" {
+    run grep -ci 'deploy-gated' "$DR_PLAN"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+}
+
+@test "A3: dr-plan.md annotation cites the exact bracket token" {
+    run grep -c '\[deploy-gated — see creative-{TASK-ID}.md § Decision\]' "$DR_PLAN"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+}
+
+@test "A3: dr-plan.md cross-reference rule names the creative doc + Decision section" {
+    run grep -i 'deploy-gated' "$DR_PLAN"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"creative"* ]]
+}
+
+@test "A3: dr-design.md instructs marking a Decision as deploy-gated" {
+    run grep -ci 'deploy-gated' "$DR_DESIGN"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+}


### PR DESCRIPTION
**TUNE-0338** (P3, KB-Scrutator backlog sweep chunk 9). Applies AGENT-0017 reflection Class A proposals A1/A2/A3 to the framework runtime.

- **A1** — `commands/dr-qa.md`: new session-scoped § Deferred Items table in the QA report template.
- **A2** — `commands/dr-do.md`: new Step 5.6, advisory coworker plan-extract recommendation (trigger: plan >400 lines + session covers ≥2 phases).
- **A3** — `commands/dr-plan.md` (new Step 4.5) + `commands/dr-design.md`: Plan ↔ Creative deploy-dependency cross-reference, annotation `[deploy-gated — see creative-{TASK-ID}.md § Decision]`.

All three are stack-agnostic and history-agnostic by construction — verified with `scripts/stack-agnostic-gate.sh --diff-only` and `scripts/task-id-gate.sh` on all 4 touched files (PASS: clean on each).

**Tests run locally (not just authored):** new `tests/tune-0338-reflection-agent-0017-class-a.bats` (13 cases) — all green. Re-ran `tests/test-command-doc-coverage.bats` (4/4 green) and `scripts/check-doc-refs.sh --root . --quiet` (exit 0) to confirm no regression on the touched command files.
