### PR TITLE
TUNE-0382: cutover mandate — re-sync must cover all stateful storages

### DIFF
--- a/skills/infra-automation/SKILL.md
+++ b/skills/infra-automation/SKILL.md
@@ -305,6 +305,14 @@ $COMPOSE up -d --build
 
 **Anti-pattern.** Targeted `docker rm -f <container-name>` per service — duplicated work for multi-service compose projects and brittle against future service additions.
 
+## Cutover Re-sync Scope Rule
+
+The final re-sync inside a migration/cutover window MUST cover every stateful storage the service depends on (Postgres, Mongo, Vault data, any file-backend) — not just the primary database. Verify freshness of each store individually (e.g. compare a last-write timestamp or row/key count against the source) before declaring the new primary live.
+
+**Why.** A new primary can pass a DB-freshness check while a co-located stateful store (Vault's storage backend, a cache warm-set, a file-backend mirror) is still running off a stale snapshot. Vault re-issuing `secret_id`s against pre-cutover data while Postgres is current is invisible to a DB-only check — the failure only surfaces downstream as an auth 403, well after the window closed. Treat every stateful store as an independent freshness claim to verify, not an assumed side-effect of the DB sync.
+
+**Rule.** Before closing a cutover window, enumerate every stateful storage the migrating service(s) touch, and confirm each one's freshness explicitly. A cutover runbook or plan is incomplete if it names only the primary database as a verification target.
+
 ## Reusable Templates
 
 - `${DATARIM_RUNTIME:-$HOME/.claude}/templates/infra-cost-reduction-checklist.md` — pre-execution checklist for any VM/storage right-sizing, server consolidation, or unused-resource cleanup task. Distilled from prior infra cost-reduction tasks (SWC, Azure unused disks, memory guardrails). Use during `/dr-plan` when the task touches infrastructure costs.

--- a/tests/tune-0382-cutover-storage-resync.bats
+++ b/tests/tune-0382-cutover-storage-resync.bats
@@ -1,0 +1,32 @@
+#!/usr/bin/env bats
+# tune-0382-cutover-storage-resync.bats — reflection-INFRA-0280 EP-1.
+#
+# Covers: skills/infra-automation/SKILL.md carries a rule requiring the final
+# cutover-window re-sync to cover every stateful storage (not only the
+# primary database), so a new-primary-on-stale-snapshot incident class
+# (INFRA-0280: Vault re-issued secret_id against stale data) is prevented.
+
+SKILL="$BATS_TEST_DIRNAME/../skills/infra-automation/SKILL.md"
+
+@test "T1 infra-automation SKILL.md has the Cutover Re-sync Scope Rule heading" {
+    grep -qE '^## Cutover Re-sync Scope Rule' "$SKILL"
+}
+
+@test "T2 rule names Postgres, Mongo, and Vault as example stateful stores" {
+    awk '/^## Cutover Re-sync Scope Rule/{flag=1; next} /^## /{flag=0} flag' "$SKILL" \
+        | grep -q 'Postgres'
+    awk '/^## Cutover Re-sync Scope Rule/{flag=1; next} /^## /{flag=0} flag' "$SKILL" \
+        | grep -q 'Mongo'
+    awk '/^## Cutover Re-sync Scope Rule/{flag=1; next} /^## /{flag=0} flag' "$SKILL" \
+        | grep -q 'Vault'
+}
+
+@test "T3 rule states verification must not be DB-only" {
+    awk '/^## Cutover Re-sync Scope Rule/{flag=1; next} /^## /{flag=0} flag' "$SKILL" \
+        | grep -qi 'not just the primary database'
+}
+
+@test "T4 rule explains freshness must be verified per-store, not assumed" {
+    awk '/^## Cutover Re-sync Scope Rule/{flag=1; next} /^## /{flag=0} flag' "$SKILL" \
+        | grep -qi 'independent freshness claim'
+}


### PR DESCRIPTION
reflection-INFRA-0280 EP-1 (Class A). See commit message for full rationale.

Root cause: DB-only freshness check at cutover missed a stale Vault snapshot → secret_id re-issue against pre-cutover data → ~35min prod outage.

Fix: adds a stack-agnostic rule to `skills/infra-automation/SKILL.md` + bats gate `tests/tune-0382-cutover-storage-resync.bats`.