### PR TITLE
TUNE-0391: archive-adapter — support prose-header archive format

### DIFF
--- a/plugins/dr-fleet-evolution/adapters/archive-adapter.sh
+++ b/plugins/dr-fleet-evolution/adapters/archive-adapter.sh
@@ -2,13 +2,25 @@
 # adapters/archive-adapter.sh — emit eval-dataset records from task archives.
 #
 # Reads archive-*.md files in the directory passed as argv[1] and emits one
-# JSONL record per archive (source-adapter-contract.md). outcome is derived:
-#   success  — status: completed AND (n_a: true OR missed_by_verify == 0)
-#   failure  — anything else (missed regressions, non-completed status)
+# JSONL record per archive (source-adapter-contract.md). Two archive formats
+# are supported (qa-report-TUNE-0380 finding #1: ~40% of archives predate the
+# YAML-frontmatter convention):
 #
-# Frontmatter is parsed with sed/grep (no yq dependency — yq is absent on the
-# default CI runner). JSON is emitted via jsonl_emit_record (jq) for correct
-# escaping.
+#   YAML-frontmatter — id/status/verification_outcome read from the block
+#   between the first two '---' lines. outcome is derived:
+#     success  — status: completed AND (n_a: true OR missed_by_verify == 0)
+#     failure  — anything else (missed regressions, non-completed status)
+#
+#   prose-header — no frontmatter; the first markdown heading line carries
+#   the TASK-ID (and, best-effort, a title), and a bold-prose `**Status:**`
+#   line anywhere in the file carries completion state. outcome is derived:
+#     success  — status text contains "complet" (covers "Completed",
+#                "completed", "✅ Completed")
+#     failure  — anything else
+#
+# Frontmatter/heading text is parsed with sed/grep (no yq dependency — yq is
+# absent on the default CI runner). JSON is emitted via jsonl_emit_record
+# (jq) for correct escaping.
 
 set -o pipefail
 
@@ -44,16 +56,55 @@ _fm_vo() {
         | sed -E "s/^[[:space:]]+${key}:[[:space:]]*//; s/[[:space:]]+$//"
 }
 
+# true if the file uses the YAML-frontmatter convention (first line is '---').
+_has_frontmatter() {
+    [ "$(sed -n '1p' "$1")" = "---" ]
+}
+
+# TASK-ID from a prose archive's first heading line (e.g.
+# "# Archive: TUNE-0012 — title", "# Archive -- TUNE-0183: title",
+# "# Archive — TUNE-0010: title", "# TUNE-0052 — title").
+_prose_id() {
+    sed -n '1p' "$1" | grep -oE '[A-Z][A-Z0-9]*-[0-9]+' | head -n1
+}
+
+# Best-effort title: text on the heading line after the TASK-ID and its
+# separator punctuation. Falls back to empty (never fatal — task_input, not
+# title, is the eval-dataset key).
+_prose_title() {
+    local file=$1 id
+    id=$(_prose_id "$file")
+    [ -n "$id" ] || return 0
+    sed -n '1p' "$file" | sed -E "s/^.*${id}[[:space:]]*[:—-]+[[:space:]]*//"
+}
+
+# First `**Status:**` bold-prose line anywhere in the file (not confined to a
+# frontmatter block, since prose archives have none).
+_prose_status() {
+    grep -m1 -E '^\*\*Status:\*\*' "$1" \
+        | sed -E 's/^\*\*Status:\*\*[[:space:]]*//; s/[[:space:]]+$//'
+}
+
 archive_outcome() {
     local file=$1
-    local status n_a missed
-    status=$(_fm_scalar "$file" status)
-    n_a=$(_fm_vo "$file" n_a)
-    missed=$(_fm_vo "$file" missed_by_verify)
-    if [ "$status" = "completed" ] && { [ "$n_a" = "true" ] || [ "${missed:-0}" = "0" ]; }; then
-        echo "success"
+    if _has_frontmatter "$file"; then
+        local status n_a missed
+        status=$(_fm_scalar "$file" status)
+        n_a=$(_fm_vo "$file" n_a)
+        missed=$(_fm_vo "$file" missed_by_verify)
+        if [ "$status" = "completed" ] && { [ "$n_a" = "true" ] || [ "${missed:-0}" = "0" ]; }; then
+            echo "success"
+        else
+            echo "failure"
+        fi
     else
-        echo "failure"
+        local status
+        status=$(_prose_status "$file")
+        if printf '%s' "${status,,}" | grep -q 'complet'; then
+            echo "success"
+        else
+            echo "failure"
+        fi
     fi
 }
 
@@ -70,8 +121,13 @@ main() {
     # Stable order for reproducible datasets.
     while IFS= read -r file; do
         [ -n "$file" ] || continue
-        id=$(_fm_scalar "$file" id)
-        title=$(_fm_scalar "$file" title)
+        if _has_frontmatter "$file"; then
+            id=$(_fm_scalar "$file" id)
+            title=$(_fm_scalar "$file" title)
+        else
+            id=$(_prose_id "$file")
+            title=$(_prose_title "$file")
+        fi
         outcome=$(archive_outcome "$file")
         jsonl_emit_record \
             "$id" \

--- a/tests/fixtures/fleet-evolution/archive-prose/archive-FIX-0003.md
+++ b/tests/fixtures/fleet-evolution/archive-prose/archive-FIX-0003.md
@@ -1,0 +1,12 @@
+# Archive: FIX-0003 — Fixture — prose-format clean completion
+
+**Archived:** 2026-06-10
+**Status:** ✅ Completed
+**Complexity:** Level 1
+**Project:** Fixture
+
+---
+
+## Task Summary
+
+Prose-header archive (no YAML frontmatter) documenting a clean completion.

--- a/tests/fixtures/fleet-evolution/archive-prose/archive-FIX-0004.md
+++ b/tests/fixtures/fleet-evolution/archive-prose/archive-FIX-0004.md
@@ -1,0 +1,12 @@
+# Archive -- FIX-0004: Fixture -- prose-format non-completion
+
+**Archived:** 2026-06-11
+**Status:** Blocked — operator input required
+**Complexity:** Level 2
+**Project:** Fixture
+
+---
+
+## Task Summary
+
+Prose-header archive (no YAML frontmatter) documenting a non-completed task.

--- a/tests/tune-0391-archive-adapter-prose-format.bats
+++ b/tests/tune-0391-archive-adapter-prose-format.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+# tune-0391-archive-adapter-prose-format.bats — qa-report-TUNE-0380 finding #1.
+#
+# ~40% of archive-*.md files predate the YAML-frontmatter convention (prose
+# `# Archive: ID — title` heading + `**Status:**` bold-prose line, no
+# frontmatter block). Before this fix, archive-adapter.sh's frontmatter-only
+# parser returned an empty task_input and always derived outcome=failure for
+# these files. Covers: id/title extraction from the prose heading (several
+# separator punctuation variants) and outcome derivation from the bold-prose
+# Status line.
+
+setup() {
+    REPO="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    ARCHIVE_ADAPTER="$REPO/plugins/dr-fleet-evolution/adapters/archive-adapter.sh"
+    FIX="$REPO/tests/fixtures/fleet-evolution/archive-prose"
+    TMP="$BATS_TEST_TMPDIR"
+    if ! command -v jq >/dev/null 2>&1; then
+        skip "jq not available — adapters require jq for JSONL emission"
+    fi
+}
+
+@test "P1 archive-adapter emits a non-empty task_input for a prose-header archive" {
+    run "$ARCHIVE_ADAPTER" "$FIX"
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -F '"task_input":"FIX-0003"'
+}
+
+@test "P2 archive-adapter derives success from a bold-prose Completed status" {
+    run "$ARCHIVE_ADAPTER" "$FIX"
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -F '"task_input":"FIX-0003"' | jq -e '.outcome=="success"'
+}
+
+@test "P3 archive-adapter derives failure from a non-completed bold-prose status" {
+    run "$ARCHIVE_ADAPTER" "$FIX"
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -F '"task_input":"FIX-0004"' | jq -e '.outcome=="failure"'
+}
+
+@test "P4 archive-adapter extracts a non-empty title for both prose separator styles" {
+    run "$ARCHIVE_ADAPTER" "$FIX"
+    [ "$status" -eq 0 ]
+    printf '%s\n' "$output" | grep -F '"task_input":"FIX-0003"' | jq -e '.expected_output | length > 0'
+    printf '%s\n' "$output" | grep -F '"task_input":"FIX-0004"' | jq -e '.expected_output | length > 0'
+}
+
+@test "P5 archive-adapter emits exactly one record per prose archive" {
+    run "$ARCHIVE_ADAPTER" "$FIX"
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s\n' "$output" | grep -c .)" -eq 2 ]
+}


### PR DESCRIPTION
spawned-by TUNE-0380 /dr-qa finding #1 (Class A).

241/606 (40%) of archive-*.md files predate the YAML-frontmatter convention. The frontmatter-only parser gave these an empty task_input and hardcoded outcome=failure. Not a TUNE-0380 blocker — closes a coverage gap.

Fix: format-detects per-file (YAML vs prose heading + bold-prose Status line), extracts id/title/outcome from both. New fixtures + bats gate `tests/tune-0391-archive-adapter-prose-format.bats`; existing adapter tests unaffected (verified: 11/11 still pass). Spot-checked against 5 real archives from the KB (documentation/archive/framework/) — correct id/outcome extraction for all 5.