### PR TITLE
TUNE-0393: post-provision checklist — public IP must be recorded

### DIFF
--- a/skills/infra-automation/SKILL.md
+++ b/skills/infra-automation/SKILL.md
@@ -21,6 +21,17 @@ Reusable patterns for SSH-based operations across Arcana servers.
 
 > Always verify current IPs against `memory/reference_arcana_www_server.md` before use.
 
+## Post-Provision Checklist — Public IP
+
+Any server inventory record (this table, a project's `space.yml`, or equivalent) for a host with a routable public address MUST have that address recorded before the provisioning task is closed. Do not leave the field `null`/blank "for later" once a routable address exists.
+
+**Why.** A server bootstrapped without its public IP recorded reads as unreachable/dark to anyone consulting the inventory later — the address exists and is reachable, but the record gives no evidence of that, so an operator has no way to distinguish "not yet provisioned" from "provisioned, IP not written down". The gap surfaces only when someone happens to `ssh root@<ip>` from a stale note elsewhere and is surprised the host answers.
+
+**Rule.** As the last step of provisioning (or first step of onboarding an existing host into the inventory), confirm the host has a routable public interface (`ip -4 addr show` on the host, or the cloud provider's dashboard) and write the address into the inventory record in the same commit/change as the rest of the provisioning artefacts.
+
+**Optional lint.** A pre-commit or CI check MAY flag an inventory record where a public-interface field is `null`/empty while the host is reachable at a known address — treat this as a checklist reminder, not a hard gate, since some hosts are intentionally NAT-only.
+
+
 ## SSH Batch Execute
 
 > **Bootstrap once** (Datarim § Security Mandate S1, host-key verification):

--- a/tests/tune-0393-provision-public-ip-checklist.bats
+++ b/tests/tune-0393-provision-public-ip-checklist.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+# tune-0393-provision-public-ip-checklist.bats — reflection-SPACE-0029 EV-4.
+#
+# Covers: skills/infra-automation/SKILL.md carries a post-provision checklist
+# rule requiring a routable public IP to be recorded in the server inventory
+# before a provisioning task closes (root cause: arcana-prod had a null
+# public_ip from bootstrap, so an operator SSHing to a known address did not
+# recognize the host from the inventory record — SPACE-0029 "dark server"
+# false perception).
+
+SKILL="$BATS_TEST_DIRNAME/../skills/infra-automation/SKILL.md"
+
+@test "Q1 infra-automation SKILL.md has the Post-Provision Checklist heading" {
+    grep -qE '^## Post-Provision Checklist — Public IP' "$SKILL"
+}
+
+@test "Q2 rule says the public IP must not be left null/blank" {
+    awk '/^## Post-Provision Checklist/{flag=1; next} /^## /{flag=0} flag' "$SKILL" \
+        | grep -qi 'null'
+}
+
+@test "Q3 rule ties the check to provisioning task closure" {
+    awk '/^## Post-Provision Checklist/{flag=1; next} /^## /{flag=0} flag' "$SKILL" \
+        | grep -qi 'before the provisioning task is closed'
+}
+
+@test "Q4 rule mentions an optional lint check as non-blocking" {
+    awk '/^## Post-Provision Checklist/{flag=1; next} /^## /{flag=0} flag' "$SKILL" \
+        | grep -qi 'Optional lint'
+}


### PR DESCRIPTION
spawned-by SPACE-0029 reflection EV-4 (Class A).

Root cause: arcana-prod had a null public_ip since bootstrap (ARCA-0020) → operator SSHing to its known address had no inventory record confirming the host → false 'dark server' perception.

Fix: adds a post-provision checklist rule to `skills/infra-automation/SKILL.md` + bats gate `tests/tune-0393-provision-public-ip-checklist.bats`.