### PR TITLE
TUNE-0394: infra migration checklist — Phase-0 entrypoint probe

### DIFF
--- a/templates/infra-artifact-checklist.md
+++ b/templates/infra-artifact-checklist.md
@@ -8,6 +8,7 @@
 
 ## Phase A: Local Artifacts (agent-safe)
 
+- [ ] **Phase-0 (migration steps only):** for any step that runs a database/data migration inside a container, verify the *actual* entrypoint of that container's image before writing the step — `docker inspect <image> --format '{{.Config.Entrypoint}}'` — rather than assuming which service/container runs migrations from its name or role. A plan that assumes the wrong entrypoint (e.g. a worker image when the web image is what actually runs migrations) fails only when executed, not when reviewed.
 - [ ] All configs created (Docker Compose, HCL, YAML, JSON, etc.)
 - [ ] All scripts created and `chmod +x` (provision, bootstrap, migrate)
 - [ ] All scripts pass `bash -n` syntax check

--- a/tests/tune-0394-migration-entrypoint-probe.bats
+++ b/tests/tune-0394-migration-entrypoint-probe.bats
@@ -1,0 +1,27 @@
+#!/usr/bin/env bats
+# tune-0394-migration-entrypoint-probe.bats — reflection-SPACE-0029 EV-3.
+#
+# Covers: templates/infra-artifact-checklist.md Phase A carries a mandatory
+# Phase-0 step requiring a live `docker inspect ... Entrypoint` probe before
+# a migration step is authored (root cause: SPACE-0029's plan assumed
+# `lf-worker` ran Langfuse ClickHouse migrations; the actual entrypoint was
+# on `lf-web`, caught only on /dr-do execution).
+
+CHECKLIST="$BATS_TEST_DIRNAME/../templates/infra-artifact-checklist.md"
+
+@test "E1 checklist Phase A has a Phase-0 migration entrypoint-probe item" {
+    grep -qi 'Phase-0' "$CHECKLIST"
+}
+
+@test "E2 Phase-0 item names the exact docker inspect probe command" {
+    grep -oE '\- \[ \] .*Phase-0.*' "$CHECKLIST" | grep -qF '.Config.Entrypoint'
+}
+
+@test "E3 Phase-0 item is listed under Phase A, before the general artifact items" {
+    awk '/^## Phase A:/{flag=1} flag && /^## Phase B:/{exit} flag' "$CHECKLIST" \
+        | grep -qi 'Phase-0'
+}
+
+@test "E4 Phase-0 item warns against assuming the entrypoint from name/role" {
+    grep -oE '\- \[ \] .*Phase-0.*' "$CHECKLIST" | grep -qi 'rather than assuming'
+}


### PR DESCRIPTION
spawned-by SPACE-0029 reflection EV-3 (Class A).

Root cause: SPACE-0029 plan assumed lf-worker ran Langfuse ClickHouse migrations; actual entrypoint was on lf-web, caught only at /dr-do execution (Gap 2).

Fix: adds a mandatory Phase-0 item to `templates/infra-artifact-checklist.md` requiring a live `docker inspect <image> --format '{{.Config.Entrypoint}}'` probe before authoring a migration step, plus bats gate `tests/tune-0394-migration-entrypoint-probe.bats`.