### PR TITLE
TUNE-0410: document additive-nullable-field schema-extension pattern

### DIFF
--- a/plugins/dr-orchestrate/scripts/audit_sink.sh
+++ b/plugins/dr-orchestrate/scripts/audit_sink.sh
@@ -1,6 +1,18 @@
 #!/usr/bin/env bash
 # audit_sink.sh — JSONL audit backend.
 # V-AC: 10 (emit), 11 (required fields), 12 (hash-only credentials), 18 (schema v2).
+#
+# Additive-nullable-field schema-extension pattern (TUNE-0410): to add a new
+# field to an existing schema-version event WITHOUT a schema_version bump,
+# make it optional and default it to JSON null when the producer/env var
+# supplying it is unset. Old consumers that predate the field simply see
+# null and treat it as "not set" — no schema_version gate, no consumer
+# migration required. Precedent: `expected_outcome` in make_event_v2 below,
+# sourced from the (optional) DR_ORCH_EXPECTED_OUTCOME env var — unset
+# yields `expected_outcome: null`, which the measure script excludes from
+# the refined metric rather than erroring. Reuse this pattern for future
+# additive fields; reserve a schema_version bump for changes that alter or
+# remove an existing field's meaning/shape.
 set -euo pipefail
 
 now_iso() { date -u +%FT%TZ; }

--- a/plugins/dr-orchestrate/tests/test_audit_sink_additive_field_pattern.bats
+++ b/plugins/dr-orchestrate/tests/test_audit_sink_additive_field_pattern.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+# TUNE-0410 — additive-nullable-field schema-extension pattern documentation
+# regression guard. Source: reflection-TUNE-0225 L2/B2 (spawned Class B).
+
+setup() {
+    PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    AUDIT_SINK="$PLUGIN_ROOT/scripts/audit_sink.sh"
+}
+
+@test "audit_sink.sh header documents the additive-nullable-field pattern" {
+    run grep -ci 'additive-nullable-field' "$AUDIT_SINK"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+}
+
+@test "pattern doc cites the expected_outcome precedent and no schema_version bump" {
+    run grep -c 'expected_outcome' "$AUDIT_SINK"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+    run grep -ci 'without a schema_version bump\|no schema_version gate' "$AUDIT_SINK"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+}
+
+@test "make_event_v2 expected_outcome still yields null when unset (behaviour unchanged)" {
+    export DR_ORCH_DIR="$PLUGIN_ROOT"
+    unset DR_ORCH_EXPECTED_OUTCOME
+    # shellcheck disable=SC1090
+    source "$AUDIT_SINK"
+    run make_event_v2 "matched" "cmd" 0 10 "pane1" 0.9 "" "" "" "" ""
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"expected_outcome":null'* ]]
+}


### PR DESCRIPTION
Generalizes the `expected_outcome` precedent (optional field, defaults to JSON null, no schema_version bump) into an explicit header-level documented pattern in `audit_sink.sh`, for reuse on future additive audit-schema fields.

Source: reflection-TUNE-0225 L2/B2 (spawned Class B). TDD: `plugins/dr-orchestrate/tests/test_audit_sink_additive_field_pattern.bats` (3/3 passing).