### PR TITLE
TUNE-0339: dr-orchestrate-server supervision units (systemd + launchd)

### DIFF
--- a/cli/tests/e2e-live-tmux.md
+++ b/cli/tests/e2e-live-tmux.md
@@ -92,6 +92,19 @@ tmux kill-session -t smoketest-2 2>/dev/null || true
 redis-cli shutdown
 ```
 
+## Production supervision (beyond one-off smoke)
+
+Step 3 above (`... start &`) is correct for this one-off smoke session — the
+server dies with the shell and there is no crash recovery, which is fine for
+a bounded manual verification run. For any long-running deployment, use the
+supervised units in `plugins/dr-orchestrate/deploy/` instead:
+`dr-orchestrate-server.service` (systemd, Linux) and
+`com.arcanada.dr-orchestrate-server.plist` (launchd, macOS) — both add
+graceful shutdown and an automatic restart-with-backoff on crash. See that
+directory's `README.md` for install steps and the backoff policy. Neither
+unit is installed or enabled by shipping these templates; installing one on
+a real host is a separate operator action.
+
 ## V-AC-7 acceptance
 
 The smoke is acceptable when:

--- a/plugins/dr-orchestrate/deploy/README.md
+++ b/plugins/dr-orchestrate/deploy/README.md
@@ -1,0 +1,64 @@
+# dr-orchestrate-server supervision units
+
+Ship-with templates that replace the foreground `dr_orchestrate_server.sh
+start &` invocation documented in `cli/tests/e2e-live-tmux.md` § Smoke
+procedure (Phase G) with a supervised, restart-with-backoff service — for
+production/long-running use, not for one-off local smoke runs (the runbook's
+`&` form remains correct for that).
+
+Neither file is installed or enabled by this change — both are authored
+tooling. Installing/enabling a supervision unit on a real host is an
+operator action.
+
+## Linux — systemd
+
+```bash
+cp dr-orchestrate-server.service /etc/systemd/system/
+# edit WorkingDirectory + ExecStart to the actual plugin install path
+systemctl daemon-reload && systemctl enable --now dr-orchestrate-server
+```
+
+- `Restart=on-failure` + `RestartSec=5`: a crash relaunches after a fixed
+  5s delay; a clean `systemctl stop` does NOT relaunch.
+- `StartLimitIntervalSec=300` + `StartLimitBurst=5`: caps retries at 5 within
+  a rolling 5-minute window — a persistently-crashing process stops
+  restart-looping and the unit is marked `failed` (`systemctl reset-failed`
+  + `start` to retry manually after investigating).
+- systemd ≥ 254 additionally supports true exponential backoff via
+  `RestartSteps=` / `RestartMaxDelaySec=` — add both under `[Service]` if the
+  target host's systemd is new enough (`systemctl --version`).
+
+Verify: `systemctl status dr-orchestrate-server`; a `kill -TERM` on the main
+PID should stop the process cleanly (no relaunch — `systemctl stop` marks the
+unit inactive before signalling); a `kill -KILL` crash SHOULD trigger the
+RestartSec-delayed relaunch.
+
+## macOS — launchd
+
+```bash
+cp com.arcanada.dr-orchestrate-server.plist ~/Library/LaunchAgents/
+# edit WorkingDirectory + the two ProgramArguments paths to the actual
+# plugin install path
+launchctl load -w ~/Library/LaunchAgents/com.arcanada.dr-orchestrate-server.plist
+```
+
+- `KeepAlive.SuccessfulExit = false`: only relaunches on a non-zero exit /
+  crash — mirrors systemd's `Restart=on-failure`. A clean `launchctl unload`
+  or a check/once-mode exit 0 is not relaunched.
+- `ThrottleInterval = 5`: launchd's fixed per-attempt restart delay — the
+  closest native equivalent to systemd's `RestartSec`. launchd has no
+  built-in total-attempt cap (no `StartLimitBurst` equivalent); monitor
+  persistent crash-looping via `log show` filtered on the process name.
+
+Verify: `launchctl list | grep dr-orchestrate-server` shows a PID; a clean
+`launchctl unload` removes it without relaunch; a `kill -9` on the PID
+SHOULD relaunch after `ThrottleInterval` seconds.
+
+## Why this exists
+
+The Phase G runbook's `... start &` invocation is fine for a one-off local
+smoke test, but has no crash recovery and dies with the parent shell. For any
+long-running deployment the process needs graceful shutdown (`SIGTERM`
+handling — both units rely on socat's default signal behaviour since the
+launcher script `exec`s directly into socat, leaving no wrapper process to
+intercept the signal) and an automatic, rate-limited restart on crash.

--- a/plugins/dr-orchestrate/deploy/com.arcanada.dr-orchestrate-server.plist
+++ b/plugins/dr-orchestrate/deploy/com.arcanada.dr-orchestrate-server.plist
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+  com.arcanada.dr-orchestrate-server.plist — launchd supervision unit for the
+  dr-orchestrate socat/HTTP bridge (macOS equivalent of
+  dr-orchestrate-server.service). See that file's header for full rationale;
+  this is the launchd translation of the same restart-with-backoff contract.
+
+  Host-agnostic template — authored tooling, NOT installed or loaded on any
+  host by this change. Install (operator action):
+
+    cp com.arcanada.dr-orchestrate-server.plist ~/Library/LaunchAgents/
+    # edit WorkingDirectory + the two ProgramArguments paths below to the
+    # actual plugin install path
+    launchctl load -w ~/Library/LaunchAgents/com.arcanada.dr-orchestrate-server.plist
+
+  Verify: `launchctl list | grep dr-orchestrate-server` shows a PID; a clean
+  `launchctl unload` removes it without a relaunch (KeepAlive.SuccessfulExit
+  only triggers a restart on a NON-zero exit, matching the systemd
+  `Restart=on-failure` semantics); a `kill -9 <pid>` crash SHOULD relaunch
+  after ThrottleInterval seconds (launchd's fixed per-attempt delay — the
+  closest native equivalent to systemd RestartSec; launchd has no built-in
+  StartLimitBurst-style total-attempt cap, so persistent-crash-loop detection
+  here is operator-observed via macOS `log show` filtered on the process
+  name, not automatically fenced like the systemd unit).
+-->
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.arcanada.dr-orchestrate-server</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <!-- Edit to the actual plugin install path before loading. -->
+        <string>/Users/YOUR_USER/.claude/plugins/dr-orchestrate/scripts/dr_orchestrate_server.sh</string>
+        <string>start</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/YOUR_USER/.claude/plugins/dr-orchestrate</string>
+
+    <!-- Restart only on non-zero exit / crash — mirrors systemd Restart=on-failure.
+         A clean `launchctl unload` or a check/once-mode exit 0 is NOT relaunched. -->
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <!-- Fixed per-attempt restart delay (seconds) — launchd's closest native
+         equivalent to systemd RestartSec. launchd has no StartLimitBurst-style
+         total-attempt cap; monitor via `log show` per the header note above. -->
+    <key>ThrottleInterval</key>
+    <integer>5</integer>
+
+    <key>StandardOutPath</key>
+    <string>/tmp/dr-orchestrate-server.log</string>
+    <key>StandardErrorPath</key>
+    <string>/tmp/dr-orchestrate-server.log</string>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/plugins/dr-orchestrate/deploy/dr-orchestrate-server.service
+++ b/plugins/dr-orchestrate/deploy/dr-orchestrate-server.service
@@ -1,0 +1,55 @@
+# dr-orchestrate-server.service — supervised unit for the dr-orchestrate
+# socat/HTTP bridge (plugins/dr-orchestrate/scripts/dr_orchestrate_server.sh).
+#
+# Replaces the foreground `... start &` invocation documented in
+# cli/tests/e2e-live-tmux.md § Smoke procedure (Phase G) for PROD reliability:
+# graceful shutdown on `systemctl stop` (SIGTERM to the exec'd socat process —
+# the launcher script itself `exec`s into socat, so no wrapper process lingers),
+# and an automatic restart-with-backoff on unexpected exit / crash.
+#
+# Host-agnostic template — this is authored tooling, NOT installed or enabled
+# on any host by this change. Install (operator action):
+#
+#   cp dr-orchestrate-server.service /etc/systemd/system/
+#   # edit WorkingDirectory + ExecStart below to the actual plugin install path
+#   systemctl daemon-reload && systemctl enable --now dr-orchestrate-server
+#
+# Verify: `systemctl status dr-orchestrate-server`; `kill -TERM $(systemctl show
+# -p MainPID --value dr-orchestrate-server)` should stop cleanly (no auto-restart —
+# `systemctl stop` marks the unit inactive first); a raw crash (`kill -KILL`) SHOULD
+# trigger the RestartSec-delayed restart below.
+#
+# Backoff: RestartSec is the fixed per-attempt delay; StartLimitIntervalSec +
+# StartLimitBurst cap retries at 5 within a rolling 5-minute window so a
+# persistently-crashing process does not restart-loop forever (systemd marks
+# the unit `failed` once the burst is exhausted — operator must investigate
+# and `systemctl reset-failed` + `start` manually). systemd >= 254 additionally
+# supports true exponential backoff via `RestartSteps=`/`RestartMaxDelaySec=`;
+# add those two keys under [Service] if the target host's systemd is new enough
+# (`systemctl --version`) and a smoother ramp than the fixed RestartSec is
+# desired.
+
+[Unit]
+Description=Datarim dr-orchestrate socat/HTTP bridge (tmux + orchestrator webhook router)
+Documentation=https://github.com/Arcanada-one/datarim
+After=network.target redis.service
+Wants=redis.service
+StartLimitIntervalSec=300
+StartLimitBurst=5
+
+[Service]
+Type=simple
+# Edit to the actual plugin install path before enabling.
+WorkingDirectory=%h/.claude/plugins/dr-orchestrate
+ExecStart=%h/.claude/plugins/dr-orchestrate/scripts/dr_orchestrate_server.sh start
+Restart=on-failure
+RestartSec=5
+TimeoutStopSec=10
+# Hardening floor (mirrors dev-tools/deploy/drift-sweep.service).
+NoNewPrivileges=true
+PrivateTmp=true
+ProtectSystem=strict
+ProtectHome=read-only
+
+[Install]
+WantedBy=multi-user.target

--- a/tests/dr-orchestrate-server-deploy.bats
+++ b/tests/dr-orchestrate-server-deploy.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+# dr-orchestrate-server-deploy.bats — invariants for the dr-orchestrate-server
+# supervision-unit templates (TUNE-0339: replaces the foreground `start &`
+# invocation in the Phase G runbook with systemd + launchd restart-with-backoff
+# templates). Static-file assertions only — neither unit is installed/enabled
+# by these tests or by the change itself.
+
+DEPLOY="${BATS_TEST_DIRNAME}/../plugins/dr-orchestrate/deploy"
+SERVICE="$DEPLOY/dr-orchestrate-server.service"
+PLIST="$DEPLOY/com.arcanada.dr-orchestrate-server.plist"
+
+@test "systemd unit file exists" {
+    [ -f "$SERVICE" ]
+}
+
+@test "launchd plist file exists" {
+    [ -f "$PLIST" ]
+}
+
+@test "deploy README documents both platforms" {
+    grep -qi 'systemd' "$DEPLOY/README.md"
+    grep -qi 'launchd' "$DEPLOY/README.md"
+}
+
+# --- systemd -----------------------------------------------------------
+
+@test "systemd unit points ExecStart at dr_orchestrate_server.sh start" {
+    grep -q '^ExecStart=.*dr_orchestrate_server\.sh start$' "$SERVICE"
+}
+
+@test "systemd unit declares Restart=on-failure with a RestartSec delay" {
+    grep -q '^Restart=on-failure$' "$SERVICE"
+    grep -q '^RestartSec=' "$SERVICE"
+}
+
+@test "systemd unit caps restart attempts (StartLimitIntervalSec + StartLimitBurst)" {
+    grep -q '^StartLimitIntervalSec=' "$SERVICE"
+    grep -q '^StartLimitBurst=' "$SERVICE"
+}
+
+@test "systemd unit is enableable (WantedBy in [Install])" {
+    grep -q '^WantedBy=' "$SERVICE"
+}
+
+@test "systemd unit applies the hardening floor (matches drift-sweep.service precedent)" {
+    grep -q '^NoNewPrivileges=true$' "$SERVICE"
+    grep -q '^ProtectSystem=strict$' "$SERVICE"
+}
+
+# --- launchd -------------------------------------------------------------
+
+@test "launchd plist is well-formed XML" {
+    run python3 -c "import xml.dom.minidom as m; m.parse('$PLIST')"
+    [ "$status" -eq 0 ]
+}
+
+@test "launchd plist ProgramArguments invokes dr_orchestrate_server.sh start" {
+    grep -q 'dr_orchestrate_server.sh' "$PLIST"
+    grep -q '<string>start</string>' "$PLIST"
+}
+
+@test "launchd plist restarts only on non-zero exit (KeepAlive.SuccessfulExit=false)" {
+    run python3 - "$PLIST" <<'PY'
+import plistlib, sys
+with open(sys.argv[1], "rb") as f:
+    data = plistlib.load(f)
+keepalive = data.get("KeepAlive")
+assert isinstance(keepalive, dict), f"KeepAlive must be a dict, got {keepalive!r}"
+assert keepalive.get("SuccessfulExit") is False
+PY
+    [ "$status" -eq 0 ]
+}
+
+@test "launchd plist declares a ThrottleInterval restart delay" {
+    grep -q '<key>ThrottleInterval</key>' "$PLIST"
+}
+
+@test "launchd plist Label matches the systemd unit name (cross-platform parity)" {
+    grep -q '<string>com.arcanada.dr-orchestrate-server</string>' "$PLIST"
+}


### PR DESCRIPTION
**TUNE-0339** (P3, KB-Scrutator backlog sweep chunk 9).

The Phase G runbook (`cli/tests/e2e-live-tmux.md`) starts `dr_orchestrate_server.sh` in the foreground via `... start &` — correct for a bounded manual smoke session, but no crash recovery / no graceful-shutdown contract for a real deployment.

Adds `plugins/dr-orchestrate/deploy/`:
- `dr-orchestrate-server.service` (systemd, Linux) — `Restart=on-failure` + `RestartSec=5`, `StartLimitIntervalSec`/`StartLimitBurst` caps the retry storm, hardening floor mirrors `dev-tools/deploy/drift-sweep.service`.
- `com.arcanada.dr-orchestrate-server.plist` (launchd, macOS) — `KeepAlive.SuccessfulExit=false` (restart only on crash) + `ThrottleInterval` as the closest native `RestartSec` equivalent.
- `README.md` — install steps + backoff policy on both platforms.

Runbook gets a short "Production supervision" pointer to the new templates; the existing one-off smoke procedure is untouched.

**Authored tooling only** — no unit was installed, loaded, or enabled on any host by this change, per the item's explicit scope.

**Tests run locally (not just authored):** new `tests/dr-orchestrate-server-deploy.bats` (13 cases) — all green. Also ran `systemd-analyze verify` against the `.service` (parses clean; only reported issue is the script path not existing in this sandbox, expected), validated the `.plist` as well-formed XML + `plistlib.load` structure check, and re-ran `scripts/check-doc-refs.sh --root . --quiet` (exit 0) after the runbook edit.
