### PR TITLE
TUNE-0343: auto-derive --extra-repo in /dr-qa Layer 3b for dual-repo topologies

### DIFF
--- a/commands/dr-qa.md
+++ b/commands/dr-qa.md
@@ -141,10 +141,12 @@ description: Multi-layer quality verification — checks PRD alignment, design c
   - Exit 0 + stdout marker `CONDITIONAL_PASS` ⇒ Layer 3b verdict **PASS_WITH_NOTES** (every partial/missed item carries an operator override ≥10 chars);
   - Exit 1 + stdout marker `BLOCKED` ⇒ Layer 3b verdict **FAIL**. Capture the validator's `Focus items:` and `Next step:` lines verbatim into the QA report.
 
-- **Anti-deferral prose scan (ADVISORY at QA).** After the routing validator, scan the QA report just written for self-deferral language — the failure mode where the agent labels its own incomplete work "out of scope / informational / not a blocker / will fix later" instead of finishing it:
+- **Anti-deferral prose scan (ADVISORY at QA).** After the routing validator, scan the QA report just written for self-deferral language — the failure mode where the agent labels its own incomplete work "out of scope / informational / not a blocker / will fix later" instead of finishing it.
+  - **Auto-derive `--extra-repo` for dual-repo topologies** (convenience — the flag itself already works when passed explicitly, per `/dr-compliance` Step 5c): before invoking the scanner, run `find <repo-root> -maxdepth 6 -name .git -type d` — the same nested-repo discovery `/dr-archive` Step 0.1 already performs — and, for every match other than `<repo-root>/.git` itself, pass its parent directory as one repeatable `--extra-repo <path>` flag. This keeps the QA-time advisory self-scan covering the same touched-set as the compliance-time hard gate without the agent having to notice the dual-repo topology by hand.
   ```bash
   "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-deferral-prose.sh" \
-      --file datarim/qa/qa-report-{TASK-ID}.md --root <repo-root>
+      --file datarim/qa/qa-report-{TASK-ID}.md --root <repo-root> \
+      [--extra-repo <nested-repo-path>]...
   ```
   - Exit 0 ⇒ no self-inflicted deferral; no action.
   - Exit 1 ⇒ deferral on a touched file without a verifiable follow-up/blocked_by artefact. At QA this is **advisory**: keep the Layer 3b verdict at most **PASS_WITH_NOTES**, record the findings in the QA report, and warn the operator that `/dr-compliance` will treat the same finding as a hard block. (This mirrors the evidence-type advisory-at-QA / hard-at-compliance escalation.) The scanner is fail-open: a git-probe failure warns and passes, never false-blocks.

--- a/tests/tune-0343-dr-qa-extra-repo-auto-derive.bats
+++ b/tests/tune-0343-dr-qa-extra-repo-auto-derive.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# TUNE-0343 — Auto-derive `--extra-repo` in /dr-qa Layer 3b for dual-repo
+# topologies. Convenience-only: the `--extra-repo` flag on
+# check-deferral-prose.sh already works when passed explicitly (per
+# /dr-compliance Step 5c); this closes the gap where /dr-qa's advisory
+# self-scan silently covered a smaller touched-set than the compliance-time
+# hard gate because nothing derived the flag automatically.
+
+DR_QA="$BATS_TEST_DIRNAME/../commands/dr-qa.md"
+
+# Fixed-window extraction of the Anti-deferral prose scan bullet: header +
+# next 6 lines covers the prose, the check-deferral-prose.sh invocation, and
+# the exit-code bullets, without needing a fragile end-of-block boundary
+# match (the enclosing markdown has no clean sibling-bullet delimiter here).
+bullet_block() {
+    grep -A 6 '\*\*Anti-deferral prose scan' "$DR_QA"
+}
+
+@test "Anti-deferral prose scan bullet exists in Layer 3b" {
+    run grep -c 'Anti-deferral prose scan' "$DR_QA"
+    [ "$status" -eq 0 ]
+    [ "$output" -ge 1 ]
+}
+
+@test "bullet auto-derives --extra-repo (no longer relies on the agent noticing)" {
+    local block; block=$(bullet_block)
+    [ -n "$block" ]
+    [[ "$block" == *"--extra-repo"* ]]
+    [[ "$block" == *"uto-deriv"* ]] || [[ "$block" == *"uto derive"* ]]
+}
+
+@test "bullet reuses the nested-.git discovery mechanism from /dr-archive Step 0.1" {
+    local block; block=$(bullet_block)
+    [ -n "$block" ]
+    [[ "$block" == *"find"* ]]
+    [[ "$block" == *".git"* ]]
+}
+
+@test "bullet cites /dr-compliance Step 5c as the topology this mirrors" {
+    local block; block=$(bullet_block)
+    [ -n "$block" ]
+    [[ "$block" == *"/dr-compliance"* ]]
+}
+
+@test "the check-deferral-prose.sh invocation shows a repeatable --extra-repo slot" {
+    local block; block=$(bullet_block)
+    [ -n "$block" ]
+    [[ "$block" == *"--extra-repo"* ]]
+}


### PR DESCRIPTION
**TUNE-0343** (P3, KB-Scrutator backlog sweep chunk 9). Convenience-only — `--extra-repo` on `check-deferral-prose.sh` already works when passed explicitly (per `/dr-compliance` Step 5c); this closes the gap where `/dr-qa` Layer 3b's advisory self-scan never passed it at all, so it could silently cover a smaller touched-set than the compliance-time hard gate for dual-repo framework tasks.

Before invoking `check-deferral-prose.sh`, Layer 3b's Anti-deferral prose scan bullet now runs `find <repo-root> -maxdepth 6 -name .git -type d` (same nested-repo discovery `/dr-archive` Step 0.1 already performs) and passes each discovered nested repo as a repeatable `--extra-repo` flag automatically.

**Tests run locally (not just authored):** new `tests/tune-0343-dr-qa-extra-repo-auto-derive.bats` (5 cases) — all green. Re-ran `scripts/stack-agnostic-gate.sh --diff-only` + `scripts/task-id-gate.sh` on `commands/dr-qa.md` (both PASS: clean) and `scripts/check-doc-refs.sh --root . --quiet` (exit 0).

Note: this branch is independent of the also-open TUNE-0338 PR (#195), which touches a different section of the same file (`commands/dr-qa.md`) — both are cut from a clean `main`, no stacking.
