### PR TITLE
docs(TUNE-0480): README templates count 22->24

### DIFF
--- a/README.md
+++ b/README.md
@@ -1002,7 +1002,7 @@ datarim/
   agents/            # Agent personas (19 agents)
   skills/            # Knowledge modules (64 skills)
   commands/          # Slash commands (27 commands)
-  templates/         # Task and document templates (22 templates)
+  templates/         # Task and document templates (24 templates)
   documentation/              # Extended documentation and use cases
   CLAUDE.md          # Framework rules (copy to your project)
   install.sh         # Automated installer


### PR DESCRIPTION
Counts-drift fix surfaced by check-version-consistency.sh (TUNE-0174): README structure comment claimed 22 templates while disk has 24. Verified-signed. README not in task-id-gate scope; check-body-english PASS.