### PR TITLE
SEC-0015: scrub Arcana infra topology from public shipped surface + CI gate

### DIFF
--- a/dev-tools/personal-id-forbidden.regex
+++ b/dev-tools/personal-id-forbidden.regex
@@ -35,3 +35,18 @@ ASANA_[A-Z_]*PAT
 
 # 16-digit numeric IDs (Asana workspace/user GIDs)
 \b[0-9]{16}\b
+
+# Arcana production infrastructure — real public IPs (SEC-0015: never in shipped surface)
+\b49\.13\.52\.208\b
+\b65\.108\.236\.39\b
+\b135\.181\.222\.38\b
+\b37\.27\.107\.227\b
+
+# Arcana production infrastructure — Tailscale mesh IPs (SEC-0015)
+\b100\.78\.174\.28\b
+\b100\.121\.155\.54\b
+\b100\.70\.137\.104\b
+\b100\.90\.7\.20\b
+
+# ssh root@ to a literal IPv4 (entry-point leak — use ssh root@<host> placeholder instead)
+ssh root@[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}

--- a/skills/infra-automation/SKILL.md
+++ b/skills/infra-automation/SKILL.md
@@ -14,12 +14,12 @@ Reusable patterns for SSH-based operations across Arcana servers.
 
 | Name | Public IP | Tailscale IP | SSH |
 |------|-----------|-------------|-----|
-| Arcana WWW | 49.13.52.208 | 100.78.174.28 | `ssh root@49.13.52.208` |
-| Arcana PROD | 65.108.236.39 | 100.121.155.54 | `ssh root@65.108.236.39` |
-| Arcana DB | 135.181.222.38 | 100.70.137.104 | `ssh root@135.181.222.38` |
-| Arcana Trading | 37.27.107.227 | 100.90.7.20 | `ssh root@37.27.107.227` |
+| www | <www-public-ip> | <www-tailscale-ip> | `ssh root@<www-host>` |
+| prod | <prod-public-ip> | <prod-tailscale-ip> | `ssh root@<prod-host>` |
+| db | <db-public-ip> | <db-tailscale-ip> | `ssh root@<db-host>` |
+| trading | <trading-public-ip> | <trading-tailscale-ip> | `ssh root@<trading-host>` |
 
-> Always verify current IPs against `memory/reference_arcana_www_server.md` before use.
+> Always verify current IPs against your own private infrastructure inventory (never hardcode real addresses in this shipped skill) before use.
 
 ## Post-Provision Checklist — Public IP
 
@@ -89,8 +89,8 @@ ssh -o StrictHostKeyChecking=no -o BatchMode=yes "$host" "<COMMAND>"
 Test NxN connectivity across all devices in mesh:
 
 ```bash
-declare -A TSIP=([www]=100.78.174.28 [prod]=100.121.155.54 [db]=100.70.137.104 [trading]=100.90.7.20)
-declare -A PUBIP=([www]=49.13.52.208 [prod]=65.108.236.39 [db]=135.181.222.38 [trading]=37.27.107.227)
+declare -A TSIP=([www]="$WWW_TS_IP" [prod]="$PROD_TS_IP" [db]="$DB_TS_IP" [trading]="$TRADING_TS_IP")
+declare -A PUBIP=([www]="$WWW_PUB_IP" [prod]="$PROD_PUB_IP" [db]="$DB_PUB_IP" [trading]="$TRADING_PUB_IP")
 
 for SRC in www prod db trading; do
   printf "%-10s" "$SRC"
@@ -142,7 +142,7 @@ Check all PROD services:
 for svc in "3400 support" "3500 muneral" "3600 opsbot"; do
   port=$(echo $svc | cut -d' ' -f1)
   name=$(echo $svc | cut -d' ' -f2)
-  STATUS=$(ssh root@65.108.236.39 "curl -sf -o /dev/null -w '%{http_code}' http://localhost:$port/health" 2>/dev/null)
+  STATUS=$(ssh root@"$PROD_PUB_IP" "curl -sf -o /dev/null -w '%{http_code}' http://localhost:$port/health" 2>/dev/null)
   echo "$name (:$port): ${STATUS:-UNREACHABLE}"
 done
 ```
@@ -151,21 +151,21 @@ done
 
 ```bash
 # Docker service status on PROD
-ssh root@65.108.236.39 "docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'"
+ssh root@"$PROD_PUB_IP" "docker ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'"
 
 # Tailscale status on all servers
-for host in 49.13.52.208 65.108.236.39 135.181.222.38 37.27.107.227; do
+for host in "${PUBIP[@]}"; do
   echo "=== $host ==="; ssh root@$host "tailscale status" 2>&1 | head -8
 done
 
 # Disk usage on all servers
-for host in 49.13.52.208 65.108.236.39 135.181.222.38 37.27.107.227; do
+for host in "${PUBIP[@]}"; do
   echo "=== $host ==="; ssh root@$host "df -h / | tail -1"
 done
 
 # Check nginx configs
-ssh root@49.13.52.208 "nginx -t" 2>&1
-ssh root@65.108.236.39 "nginx -t" 2>&1
+ssh root@"$WWW_PUB_IP" "nginx -t" 2>&1
+ssh root@"$PROD_PUB_IP" "nginx -t" 2>&1
 ```
 
 ## Safety Rules

--- a/tests/security/finding-1-cloudflare-nginx-injection.bats
+++ b/tests/security/finding-1-cloudflare-nginx-injection.bats
@@ -49,48 +49,48 @@ assert_blocked_before_calls() {
 # metacharacters at the validation gate.
 
 @test "Finding 1: rejects domain with command substitution \$()" {
-  run bash "$TEMPLATE" 'foo.com$(touch /tmp/pwned-fnd1)' 49.13.52.208 foo
+  run bash "$TEMPLATE" 'foo.com$(touch /tmp/pwned-fnd1)' 203.0.113.10 foo
   assert_blocked_before_calls
   [ ! -f /tmp/pwned-fnd1 ]
 }
 
 @test "Finding 1: rejects domain with semicolon" {
-  run bash "$TEMPLATE" 'foo.com;rm -rf /' 49.13.52.208 foo
+  run bash "$TEMPLATE" 'foo.com;rm -rf /' 203.0.113.10 foo
   assert_blocked_before_calls
 }
 
 @test "Finding 1: rejects domain with backticks" {
-  run bash "$TEMPLATE" 'foo.com`whoami`' 49.13.52.208 foo
+  run bash "$TEMPLATE" 'foo.com`whoami`' 203.0.113.10 foo
   assert_blocked_before_calls
 }
 
 @test "Finding 1: rejects domain with pipe" {
-  run bash "$TEMPLATE" 'foo.com|cat /etc/passwd' 49.13.52.208 foo
+  run bash "$TEMPLATE" 'foo.com|cat /etc/passwd' 203.0.113.10 foo
   assert_blocked_before_calls
 }
 
 @test "Finding 1: rejects domain with space" {
-  run bash "$TEMPLATE" 'foo.com bar' 49.13.52.208 foo
+  run bash "$TEMPLATE" 'foo.com bar' 203.0.113.10 foo
   assert_blocked_before_calls
 }
 
 @test "Finding 1: rejects server_ip with shell metacharacters" {
-  run bash "$TEMPLATE" foo.example.com '49.13.52.208;rm -rf /' foo
+  run bash "$TEMPLATE" foo.example.com '203.0.113.10;rm -rf /' foo
   assert_blocked_before_calls
 }
 
 @test "Finding 1: rejects webroot_name with path traversal" {
-  run bash "$TEMPLATE" foo.example.com 49.13.52.208 '../../etc'
+  run bash "$TEMPLATE" foo.example.com 203.0.113.10 '../../etc'
   assert_blocked_before_calls
 }
 
 @test "Finding 1: rejects webroot_name with shell metacharacters" {
-  run bash "$TEMPLATE" foo.example.com 49.13.52.208 'foo;rm -rf /'
+  run bash "$TEMPLATE" foo.example.com 203.0.113.10 'foo;rm -rf /'
   assert_blocked_before_calls
 }
 
 @test "Finding 1: accepts valid domain + ip + webroot_name (passes validation gate)" {
-  run bash "$TEMPLATE" foo.example.com 49.13.52.208 foo
+  run bash "$TEMPLATE" foo.example.com 203.0.113.10 foo
   [ -f "$TMPDIR_TEST/calls.log" ]
   grep -q '^MOCK_' "$TMPDIR_TEST/calls.log"
 }


### PR DESCRIPTION
**Security (P1).** Removes the live Arcana infrastructure topology leak from the public OSS repo (Finding 1, audit DEV-1575).

- `skills/infra-automation/SKILL.md`: real server IPs (4 public + 4 Tailscale), `ssh root@<ip>` commands, and a personal memory-path ref replaced with generic placeholders. Inventory table keeps its shape without real addresses.
- `tests/security/finding-1-cloudflare-nginx-injection.bats`: fixture IP → RFC 5737 TEST-NET-3 (`203.0.113.10`). Tests 9/9 pass.
- `dev-tools/personal-id-forbidden.regex`: +8 real IPs +`ssh root@<literal-ip>` pattern so `personal-id-gate` (CI: personal-id-lint.yml) blocks reintroduction.

Content-fix only. Full-history purge of pre-existing commits + GitHub Support + fork issue remain operator-gated (public force-push). No real tokens/secrets present — no rotation needed.