### PR TITLE
TUNE-0480 wave-16: wire dr-init-id-collision-window into dr-archive collision branch (TUNE-0484)

### DIFF
--- a/commands/dr-archive.md
+++ b/commands/dr-archive.md
@@ -500,6 +500,7 @@ Complete and archive current task.
    - Map prefix to area subdirectory using `$HOME/.claude/skills/datarim-system/SKILL.md` § Archive Area Mapping
    - If prefix not in mapping → use `general/`
    - Create `documentation/archive/{area}/` directory if it doesn't exist
+   - **Collision-detection branch (MANDATORY before Step 2 writes the archive doc):** check whether `documentation/archive/{area}/archive-{ID}.md` already exists. A pre-existing file at that exact path under a different task title means a parallel session reserved and archived the same `{TASK-ID}` first (the TOCTOU window between `/dr-init` reservation and this archive commit). Do NOT overwrite it silently. Run the detection probe and apply the retroactive-rename procedure from `$HOME/.claude/skills/dr-init-id-collision-window/SKILL.md` § Detection and § Resolution — retroactive rename before proceeding to Step 2.
 2. Create archive document with:
    - **Frontmatter from canonical template** `${DATARIM_RUNTIME:-$HOME/.claude}/templates/archive-template.md` — copy YAML schema (`id`, `title`, `status`, `completed_date`, `complexity`, `type`, `project`, `related`, `archive_doc`, `verification_outcome`). Schema is closed; do not add custom keys.
    - **`verification_outcome` block — MANDATORY at archive time.** Triage the audit log under `datarim/qa/verify-{TASK-ID}-*.md` (if `/dr-verify` ran) and fill the four counters + `dogfood_window` per template comment block:

--- a/tests/dr-init-id-collision.bats
+++ b/tests/dr-init-id-collision.bats
@@ -27,6 +27,7 @@
 CMDS_DIR="${BATS_TEST_DIRNAME}/../commands"
 HELPER="${BATS_TEST_DIRNAME}/../dev-tools/next-free-id.sh"
 DR_INIT="${CMDS_DIR}/dr-init.md"
+DR_ARCHIVE="${CMDS_DIR}/dr-archive.md"
 
 # ── Group A — markdown-contract assertions (commands/dr-init.md Step 4) ──────
 
@@ -64,6 +65,10 @@ DR_INIT="${CMDS_DIR}/dr-init.md"
 
 @test "A09: dr-init.md wires the dr-init-id-collision-window skill into the option-(a) reassign branch" {
     grep -F "skills/dr-init-id-collision-window/SKILL.md" "$DR_INIT"
+}
+
+@test "A10: dr-archive.md wires the dr-init-id-collision-window skill into the collision-detection branch" {
+    grep -F "skills/dr-init-id-collision-window/SKILL.md" "$DR_ARCHIVE"
 }
 
 # ── Group B — functional grep-probe harness ──────────────────────────────────


### PR DESCRIPTION
Wave-16 of TUNE-0480. One framework fix (site + coworker candidates verified already-done).

- **TUNE-0484** (L1): symmetric half of merged TUNE-0483. The `dr-init-id-collision-window` skill's `loaded_by` frontmatter declares `commands/dr-archive.md (collision-detection branch)` but dr-archive.md had zero refs. Wired the detection + retroactive-rename procedure into Step 1 (archive-area determination), before Step 2 writes the archive doc — guards against silently overwriting a parallel session's `archive-{ID}.md` in the TOCTOU window. `tests/dr-init-id-collision.bats` +A10 (mirrors A09).

Local gates green: bats 19/19, check-skill-sibling-refs PASS, task-id-gate clean, personal-id-gate PASS. English-only. Signed commit, verified email.

Also closed verified-done this wave (no delta): TUNE-0352 (about.php already fully localized, live dual-render confirmed), TUNE-0349 (coworker CHANGELOG already swept, merged via coworker#8).