### PR TITLE
TUNE-0480 wave-17: infra-gated test-skip pattern + deploy-deferred AC labelling (TUNE-0386/0387)

### DIFF
--- a/commands/dr-prd.md
+++ b/commands/dr-prd.md
@@ -61,6 +61,7 @@ This command generates a structured Product Requirements Document (PRD) followin
 5.  **Generate PRD**:
     -   Use the structure from `${DATARIM_RUNTIME:-$HOME/.claude}/templates/prd-template.md`.
     -   Include: Problem Statement, Scope, Context Analysis, Technical Approach (Selected + Alternatives), Success Criteria, Risks.
+    -   For infra/fleet PRDs, apply the `templates/prd-template.md` § Deploy-Phase Verification Items labelling — mark any AC whose e2e verification requires a live broker, deployed host, or external webhook as `deploy-deferred` so `/dr-qa` expects partial + operator-override instead of flagging a coverage gap.
     -   If insights document was created in Phase 1.3, add a reference in the PRD header: `**Research:** [INSIGHTS-{task-id}](../insights/INSIGHTS-{task-id}.md)`
     -   **Pre-save validation gates (MANDATORY before write):**
         - **`ships_in:` derivation.** If the PRD ships a framework / library release, read the canonical version source (e.g. `code/datarim/VERSION` or project equivalent) and pre-fill `ships_in: <next-minor-or-patch>`. Operator-supplied override requires an inline justification comment in the PRD body. Do not echo the value from memory or from the parent PRD verbatim — version drift between PRD draft and release is a recurring defect class.

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -137,6 +137,35 @@ An integration test that spawns a real service process (daemon, server, worker) 
 
 ---
 
+## Infrastructure-Gated Test Skips
+
+An integration test that needs a live broker, database, or external service is legitimate to skip when that dependency is absent — but a bare `skip` (no probe, no message) is indistinguishable from a bug swallowed behind an unconditional skip. A reviewer scanning a green suite with skips has to hand-audit every guard to tell the two apart, which is slow and erodes trust in the suite.
+
+**Rule.** Any test that needs a live broker/service MUST probe for it in `setup()` (or the framework's equivalent pre-test hook) and `skip` with an **explicit message naming the missing dependency** when the probe fails — never a bare skip, never a fail:
+
+- Redis / broker: `redis-cli -h "$HOST" ping` (expect `PONG`).
+- Postgres: `pg_isready -h "$HOST" -p "$PORT"`.
+- HTTP service: `curl -fsS "$HEALTH_URL"` (or the project's health-check convention).
+
+```bash
+setup() {
+    if ! redis-cli -h "${REDIS_HOST:-127.0.0.1}" ping >/dev/null 2>&1; then
+        skip "no live Redis at ${REDIS_HOST:-127.0.0.1} — start the broker to run this test"
+    fi
+}
+
+@test "queue consumer processes a job end-to-end" {
+    # exercises the real broker; only reached when setup() probed it live
+    ...
+}
+```
+
+**Why this matters.** An explicit probed skip is self-evidencing — the message names the exact dependency the reviewer would need to stand up to turn the skip green, so the skip reads as intentional environment-gating on sight. A bare or unconditional skip carries no such evidence; it looks identical whether the author deliberately gated on infrastructure or accidentally short-circuited a broken test, forcing the reviewer to read the guard logic line by line to tell the two apart.
+
+**When to apply.** Any test whose assertions require a live broker, database, or external service that may not be running in the current environment (local dev, CI runner, sandboxed agent host). Skip this pattern when the dependency is always available in every environment the suite runs in (e.g. an in-process fake or an embedded engine started by the test harness itself) — in that case there is nothing to probe and a missing-dependency skip would never legitimately fire.
+
+---
+
 ## Self-Validating UI Assertions
 
 Existence assertions ("element renders any text", "counter is non-empty") pass even when the system under test is broken — they only catch the «nothing rendered at all» case. Prefer **self-validating** assertions that poll the *flipped* target state after the triggering interaction. Self-validation catches three failure modes in one shape:

--- a/templates/prd-template.md
+++ b/templates/prd-template.md
@@ -47,6 +47,14 @@ id — `D-REQ` is an addressing layer on top, not a replacement.
 #### D-REQ-02: {requirement description}
 
 ## Success Criteria
+
+### Deploy-Phase Verification Items
+
+For infra/fleet PRDs, label any AC whose e2e verification structurally requires a live broker, a deployed host, or an external webhook as `deploy-deferred` at authoring time. This tells `/dr-qa` to expect a `partial` verdict plus an operator override for that AC, rather than flagging it as a coverage gap — the verification was never going to be possible on the authoring/dev host, by design, not by omission.
+
+Example:
+- [ ] `deploy-deferred` — consumer receives the queued event within 5s of publish, verified against the live Redis instance on the deployed host.
+
 - [ ] (Measurable outcomes)
 
 > **V-AC `Covers:` binding (spec‑traceability).** On L3+ tasks each V-AC item

--- a/tests/tune-0386-infra-gate-doc.bats
+++ b/tests/tune-0386-infra-gate-doc.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+#
+# Infra-gated test skip doc + deploy-deferred PRD labelling regression guard.
+#
+# Stage-rule contract:
+#   - skills/testing/SKILL.md MUST keep the "Infrastructure-Gated Test Skips"
+#     section (probe-then-skip pattern: setup() probe, explicit-message skip,
+#     "When to apply" clause distinguishing legit env-gating from masked bugs).
+#   - templates/prd-template.md MUST keep the "Deploy-Phase Verification
+#     Items" subsection carrying the deploy-deferred label token.
+#   - commands/dr-prd.md Step 5 MUST reference the deploy-deferred labelling.
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+TESTING_SKILL="$REPO_ROOT/skills/testing/SKILL.md"
+PRD_TEMPLATE="$REPO_ROOT/templates/prd-template.md"
+DR_PRD="$REPO_ROOT/commands/dr-prd.md"
+
+@test "T1: testing SKILL.md contains the Infrastructure-Gated Test Skips section" {
+    [ -f "$TESTING_SKILL" ]
+    run grep -q "Infrastructure-Gated Test Skips" "$TESTING_SKILL"
+    [ "$status" -eq 0 ]
+}
+
+@test "T2: testing skill section contains a setup() probe example" {
+    run grep -F "setup() {" "$TESTING_SKILL"
+    [ "$status" -eq 0 ]
+    run grep -F "redis-cli -h" "$TESTING_SKILL"
+    [ "$status" -eq 0 ]
+}
+
+@test "T3: testing skill section requires an explicit-message skip" {
+    run grep -F 'skip "no live Redis at' "$TESTING_SKILL"
+    [ "$status" -eq 0 ]
+}
+
+@test "T4: testing skill section carries a When to apply clause for the infra-gate pattern" {
+    run grep -F "**When to apply.** Any test whose assertions require a live broker" "$TESTING_SKILL"
+    [ "$status" -eq 0 ]
+}
+
+@test "T5: prd-template.md carries a Deploy-Phase Verification heading" {
+    [ -f "$PRD_TEMPLATE" ]
+    run grep -q "Deploy-Phase Verification Items" "$PRD_TEMPLATE"
+    [ "$status" -eq 0 ]
+}
+
+@test "T6: prd-template.md deploy-deferred token appears under the Deploy-Phase heading" {
+    run grep -qi "deploy-deferred" "$PRD_TEMPLATE"
+    [ "$status" -eq 0 ]
+    # confirm the token appears within a few lines of the heading, not elsewhere
+    run awk '/Deploy-Phase Verification Items/,/^## /' "$PRD_TEMPLATE"
+    [ "$status" -eq 0 ]
+    echo "$output" | grep -qi "deploy-deferred"
+}
+
+@test "T7: dr-prd.md Step 5 references the deploy-deferred labelling" {
+    [ -f "$DR_PRD" ]
+    run grep -qi "deploy-deferred" "$DR_PRD"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
First autonomous PRD cycle of the TUNE-0480 remainder (operator authorised PRD cycles 2026-07-12). PRD: `datarim/prd/PRD-TUNE-0386-0387.md` (KB). Both L1 tasks derive from reflection-TUNE-0379 EP-1/EP-2.

- **TUNE-0386**: new `skills/testing/SKILL.md` § Infrastructure-Gated Test Skips — probe-then-skip pattern (`redis-cli ping`/`pg_isready`/`curl` health) with explicit dependency-naming skip message. A reviewer trusts an env-gated skip on sight instead of hand-auditing every guard. Matches the skill's Rule/Why/When shape.
- **TUNE-0387**: `prd-template.md` § Deploy-Phase Verification Items (label e2e AC needing live broker/deployed-host/webhook as `deploy-deferred` upfront → `/dr-qa` expects partial+override, not a gap) + one `dr-prd` Step 5 guidance line. Guidance-only, no /dr-qa logic change.
- `tests/tune-0386-infra-gate-doc.bats` (7 tests, triple revert-proof-verified — each assertion group bites only its target doc).

Gates: bats 7/7, task-id-gate clean ×3, personal-id-gate clean, English-only (touched files clean; sole check-body-english FAIL is pre-existing expectations-checklist:122, unrelated). Signed commit, verified email.