### PR TITLE
TUNE-0480 wave-18: spec-graph-gate expectations.md V-AC accept + PRD-waiver skip (TUNE-0473)

### DIFF
--- a/dev-tools/dr-spec-lint.sh
+++ b/dev-tools/dr-spec-lint.sh
@@ -295,7 +295,18 @@ if { [ "$LEVEL" = "L3" ] || [ "$LEVEL" = "L4" ]; } && [ -f "$EXP_FILE" ]; then
     PLAN_BOUND="$(collect_verifies "$PLAN_FILE" | awk -F'\t' '{print $2}' | sort -u)"
     EVIDENCE_BOUND="$(collect_evidence "$TASK_FILE" "$QA_FILE" "$COMPLIANCE_FILE" \
         | awk -F'\t' '{print $2}' | sort -u)"
-    while IFS=$'\t' read -r wish vac status valid_operator_override; do
+    # Split the tab-separated record with parameter expansion, NOT
+    # `IFS=$'\t' read`: tab is IFS-whitespace, so a `read` collapses an empty
+    # middle field and shifts the columns. A wish with a deliberate no-link
+    # dash (empty vac) would then read `status` into `vac` and mis-route to the
+    # `undeclared` branch with a garbage id. Explicit `%%`/`##` trimming keeps
+    # the empty vac empty so it hits the correct `no linked V-AC` branch.
+    # Source: TUNE-0473.
+    while IFS= read -r _rec; do
+        wish="${_rec%%$'\t'*}"; _rest="${_rec#*$'\t'}"
+        vac="${_rest%%$'\t'*}"; _rest="${_rest#*$'\t'}"
+        status="${_rest%%$'\t'*}"
+        valid_operator_override="${_rest##*$'\t'}"
         [ -n "$wish" ] || continue
         case "$status" in deleted|n-a) continue ;; esac
         [ "$valid_operator_override" = "yes" ] && continue

--- a/dev-tools/spec-graph-gate.sh
+++ b/dev-tools/spec-graph-gate.sh
@@ -100,6 +100,49 @@ if [ ! -f "$PRD" ]; then
         fi
         exit 0
     fi
+    # ---- Class B: documented PRD-waiver skip (TUNE-0473) ---------------------
+    # A follow-up L3/L4 task may legitimately run WITHOUT its own PRD when the
+    # operator records the canonical waiver line `**PRD waived:**` (mandated by
+    # the datarim-system task-identity contract: one scoped track from a parent
+    # PRD/archive, parent approved <30 days ago, no new requirements). Before
+    # emitting the hard usage-error, look for that marker on the task's
+    # authoritative surfaces (tasks.md is the mandated home; plan/task-description
+    # carry it in practice). When present, SKIP with an explicit reason instead
+    # of a usage-error -- this is the documented waiver path, NOT a silent bypass.
+    # Guard: the <30d age is only *asserted* in the reason when a parent PRD id
+    # in the marker resolves to a file whose mtime is within 30 days; otherwise
+    # the reason states the waiver is documented but the parent age is
+    # unverifiable (honest, non-fabricated). No invented marker: keyed strictly
+    # off the canonical `**PRD waived:**` token.
+    waiver_line=""
+    for _src in "$DATARIM_ROOT/tasks.md" "$PLAN" "$TASK_DESC" "$EXPECTATIONS"; do
+        [ -f "$_src" ] || continue
+        waiver_line="$(grep -m1 -F '**PRD waived:**' "$_src" 2>/dev/null || true)"
+        [ -n "$waiver_line" ] && break
+    done
+    if [ -n "$waiver_line" ]; then
+        # Best-effort parent-PRD age check: pull the first PRD id token from the
+        # marker line and, if the corresponding PRD file exists and is <=30 days
+        # old, assert the <30d claim; else fall back to an unverified reason.
+        waiver_reason="documented PRD-waiver (parent age unverified)"
+        _parent_id="$(printf '%s' "$waiver_line" | grep -oE 'PRD-[A-Z]+-[0-9]+' | head -1 | sed -E 's/^PRD-//')"
+        if [ -n "$_parent_id" ]; then
+            for _pprd in "$DATARIM_ROOT/prd/PRD-${_parent_id}.md" "$DATARIM_ROOT/prd/${_parent_id}-prd.md"; do
+                [ -f "$_pprd" ] || continue
+                if find "$_pprd" -mtime -30 2>/dev/null | grep -q .; then
+                    waiver_reason="documented PRD-waiver (parent <30d)"
+                fi
+                break
+            done
+        fi
+        if [ "$FORMAT" = "json" ]; then
+            printf '{"task":"%s","stage":"%s","complexity":"%s","mode":"%s","decision":"skip","reason":"%s","evaluated_artifacts":[],"excluded_artifacts":[{"path":"%s","reason":"%s"}],"findings":[]}\n' \
+                "$TASK" "$STAGE" "$LEVEL" "$MODE" "$waiver_reason" "$PRD" "$waiver_reason"
+        else
+            printf 'spec-graph: SKIP %s %s (%s, %s)\n' "$TASK" "$STAGE" "$LEVEL" "$waiver_reason"
+        fi
+        exit 0
+    fi
     usage_die "required PRD missing for $TASK"
 fi
 

--- a/dev-tools/tests/dr-spec-lint.bats
+++ b/dev-tools/tests/dr-spec-lint.bats
@@ -193,3 +193,74 @@ EOF
       | grep -F '"check_name": "graph-complete-l3"' \
       | grep -qF 'V-AC-2'
 }
+
+# ===========================================================================
+# TUNE-0473 (A): completeness scan must accept a letter-prefixed axis V-AC id
+# (V-AC-A1) cited via `Связанный AC из PRD:` in expectations.md on equal footing
+# with the numeric form — regression against a false `no linked V-AC` grade-F
+# when coverage is real (TUNE-0471: 7 false errors at 11/11 D-REQ covered).
+# ===========================================================================
+
+# Clean L3 fixture whose PRD declares LETTER-PREFIXED axis V-AC ids and whose
+# expectations.md links wishes to them. Pre-fix this graded F falsely.
+write_axis_fixture() {
+    cat >"$WORK/datarim/prd/PRD-EX-0002.md" <<'EOF'
+# PRD: Axis Example
+**Complexity:** Level 3
+
+## Requirements (D-REQ)
+
+#### D-REQ-01: the validator builds a graph
+
+#### D-REQ-02: the validator emits json
+
+## Success Criteria
+
+- V-AC-A1: graph is built
+  Covers: D-REQ-01
+- V-AC-A2: json is emitted
+  Covers: D-REQ-02
+EOF
+    cat >"$WORK/datarim/plans/EX-0002-plan.md" <<'EOF'
+# Plan: Axis Example
+- Step 1: build the graph
+  Verifies: V-AC-A1
+- Step 2: emit json
+  Verifies: V-AC-A2
+EOF
+    cat >"$WORK/datarim/tasks/EX-0002-task-description.md" <<'EOF'
+# Implementation Notes
+
+- Evidence: V-AC-A1 — bats dev-tools/tests/dr-spec-lint.bats
+- Evidence: V-AC-A2 — bats dev-tools/tests/dr-spec-lint.bats
+EOF
+    cat >"$WORK/datarim/tasks/EX-0002-expectations.md" <<'EOF'
+- **1. Build graph.**
+  - wish_id: build-graph
+  - Связанный AC из PRD: V-AC-A1
+  - #### Текущий статус
+    - pending
+- **2. Emit json.**
+  - wish_id: emit-json
+  - Связанный AC из PRD: V-AC-A2
+  - #### Текущий статус
+    - pending
+EOF
+}
+
+@test "TUNE-0473-A: axis-id V-AC (V-AC-A1) cited in expectations.md is NOT a false 'no linked V-AC'" {
+    write_axis_fixture
+    run "$SCRIPT" --task EX-0002 --root "$WORK" --format json
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"no linked V-AC"* ]]
+    [[ "$output" != *"undeclared"* ]]
+}
+
+@test "TUNE-0473-A-neg: a genuinely unlinked wish (dash cite) still flags 'no linked V-AC'" {
+    write_axis_fixture
+    # Break wish 1's link: replace the cite value with the deliberate no-link dash.
+    perl -0pi -e 's/Связанный AC из PRD: V-AC-A1/Связанный AC из PRD: —/' "$WORK/datarim/tasks/EX-0002-expectations.md"
+    run "$SCRIPT" --task EX-0002 --root "$WORK" --format json
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"no linked V-AC"* ]]
+}

--- a/dev-tools/tests/spec-graph-gate.bats
+++ b/dev-tools/tests/spec-graph-gate.bats
@@ -128,3 +128,44 @@ EOF
     [ "$status" -eq 0 ] \
       && printf '%s\n' "$output" | grep -qF '"decision":"clean"'
 }
+
+# ===========================================================================
+# TUNE-0473 (B): documented PRD-waiver skip. An L3/L4 follow-up task running
+# WITHOUT its own PRD but carrying the canonical `**PRD waived:**` marker must
+# SKIP with an explicit reason, not die with a usage-error (TUNE-0472
+# compliance got a usage-error instead of a graph verdict). No marker + no PRD
+# still dies (the waiver is documented, never a silent bypass).
+# ===========================================================================
+
+# L3 task with NO PRD file. Whether it skips or dies depends solely on the marker.
+write_noprd_fixture() {
+    mkdir -p "$WORK/datarim/prd" "$WORK/datarim/plans" "$WORK/datarim/tasks"
+    cat >"$WORK/datarim/plans/GT-0009-plan.md" <<'EOF'
+# Plan
+- Step 1: implement the follow-up
+  Verifies: V-AC-1
+EOF
+    cat >"$WORK/datarim/tasks/GT-0009-task-description.md" <<'EOF'
+## Implementation Notes
+- Evidence: V-AC-1 — bats
+EOF
+}
+
+@test "TUNE-0473-B: L3 follow-up with **PRD waived:** marker SKIPs with reason (not usage-error)" {
+    write_noprd_fixture
+    # Record the canonical waiver marker on the mandated surface (tasks.md).
+    printf '## GT-0009\n**PRD waived:** scoped follow-up of parent PRD-EX-0001, approved <30d, no new requirements.\n' \
+        >"$WORK/datarim/tasks.md"
+    run "$SCRIPT" --task GT-0009 --stage compliance --root "$WORK" --format json
+    [ "$status" -eq 0 ]
+    [[ "$output" == *'"decision":"skip"'* ]]
+    [[ "$output" == *"documented PRD-waiver"* ]]
+}
+
+@test "TUNE-0473-B-neg: L3 task with NO PRD and NO waiver marker still usage-dies (exit 2)" {
+    write_noprd_fixture
+    # No tasks.md waiver marker anywhere.
+    run "$SCRIPT" --task GT-0009 --stage compliance --root "$WORK" --format json
+    [ "$status" -eq 2 ]
+    [[ "$output" == *"required PRD missing"* ]] || [[ "$output" == *"PRD"* ]]
+}

--- a/scripts/lib/schema-regex.sh
+++ b/scripts/lib/schema-regex.sh
@@ -57,6 +57,13 @@ SCHEMA_BACKLOG_RE='^- [A-Z]{2,10}-[0-9]{4}(-[A-Za-z0-9]+)* · (pending|blocked-p
 D_REQ_ID_RE='(^#### D-REQ-[0-9]{2}: .+$)|(^[[:space:]]*[-*][[:space:]]+\*\*D-REQ-[0-9]{2}\*\*)'
 COVERS_LINE_RE='Covers:[[:space:]]*D-REQ-[0-9]{2}([[:space:]]*,[[:space:]]*D-REQ-[0-9]{2})*[[:space:]]*$'
 D_REQ_REF_RE='D-REQ-[0-9]{2}'
-VERIFIES_LINE_RE='Verifies:[[:space:]]*\**[[:space:]]*V-AC-[0-9]+(\.[0-9]+)?([[:space:]]*,[[:space:]]*V-AC-[0-9]+(\.[0-9]+)?)*'
-EVIDENCE_LINE_RE='^[[:space:]]*(-[[:space:]]*)?Evidence:[[:space:]]*V-AC-[0-9]+(\.[0-9]+)?[[:space:]]+.+$'
-V_AC_REF_RE='V-AC-[0-9]+(\.[0-9]+)?'
+VERIFIES_LINE_RE='Verifies:[[:space:]]*\**[[:space:]]*V-AC-[A-Z]?[0-9]+(\.[0-9]+)?([[:space:]]*,[[:space:]]*V-AC-[A-Z]?[0-9]+(\.[0-9]+)?)*'
+EVIDENCE_LINE_RE='^[[:space:]]*(-[[:space:]]*)?Evidence:[[:space:]]*V-AC-[A-Z]?[0-9]+(\.[0-9]+)?[[:space:]]+.+$'
+# V_AC_REF_RE — a bare V-AC reference token. Tolerates an OPTIONAL single
+# uppercase-letter axis prefix on the numeric core (V-AC-A1), the form the
+# v-ac-axis-split pattern emits when an L4 V-AC group is split across a
+# deterministic/statistical axis. Remains a strict superset of the historical
+# numeric-only id (V-AC-1, V-AC-12, V-AC-1.2), so every previously-matching
+# token still matches. Source: TUNE-0473 (letter-prefixed V-AC in an
+# expectations wish->V-AC cite was silently dropped, yielding a false grade-F).
+V_AC_REF_RE='V-AC-[A-Z]?[0-9]+(\.[0-9]+)?'

--- a/scripts/lib/spec-graph.sh
+++ b/scripts/lib/spec-graph.sh
@@ -365,9 +365,12 @@ collect_covers() {
 collect_vac() {
     local file="$1"
     [ -f "$file" ] || return 0
-    grep -nE '\bV-AC-[0-9]+' "$file" 2>/dev/null \
-        | grep -oE '^[0-9]+:.*V-AC-[0-9]+(\.[0-9]+)?' \
-        | sed -E 's/^([0-9]+):.*(V-AC-[0-9]+(\.[0-9]+)?).*$/\1\t\2/' \
+    # Route the id grammar through the shared V_AC_REF_RE so a letter-prefixed
+    # axis id (V-AC-A1) declared in the PRD is collected on equal footing with
+    # the historical numeric id. Source: TUNE-0473.
+    grep -nE "\\b${V_AC_REF_RE}" "$file" 2>/dev/null \
+        | grep -oE "^[0-9]+:.*${V_AC_REF_RE}" \
+        | sed -E "s/^([0-9]+):.*(${V_AC_REF_RE}).*\$/\\1\t\\2/" \
         | sort -u
 }
 
@@ -444,8 +447,14 @@ with open(path, encoding="utf-8") as fh:
             continue
         if not cur:
             continue
+        # Wish->V-AC link on the schema-defined cite line. Accept a plain
+        # `V-AC-N`, a letter-prefixed axis id `V-AC-A1` (v-ac-axis-split, L4),
+        # or the deliberate no-link dash form (empty link). Widened to mirror
+        # the shared V_AC_REF_RE grammar so an axis id is no longer silently
+        # dropped into a false `no linked V-AC` / `undeclared` grade-F.
+        # Source: TUNE-0473.
         if "Связанный AC из PRD:" in line:
-            vm = re.search(r"V-AC-\d+(?:\.\d+)?", line)
+            vm = re.search(r"V-AC-[A-Z]?\d+(?:\.\d+)?", line)
             cur["vac"] = vm.group(0) if vm else ""
         elif re.match(r"\s*-\s*override:\s*", line):
             cur["override"] = line.split("override:", 1)[1].strip()


### PR DESCRIPTION
Follow-up of operator's TUNE-0471/0472.

- **(A) Class A**: L3/L4 completeness scan now accepts a wish→V-AC link cited as `Связанный AC из PRD: V-AC-N` (and axis id `V-AC-A1`) in expectations.md, equal footing with task-description.md. Fixes false `no linked V-AC`/`undeclared` errors that graded **F** despite real coverage (TUNE-0471: 7 false errors at 11/11 D-REQ covered).
- **(B) Class B (guarded)**: an L3/L4 follow-up without its own PRD but carrying the canonical `**PRD waived:**` marker now SKIPs with an explicit reason instead of a usage-error. Keyed strictly off the documented marker (no invented token); honest parent-age reason.
- +4 regression tests (A / A-neg dash / B waiver-skip / B-neg still-dies), all bite-verified. 51 spec-graph bats green, shellcheck clean.