### PR TITLE
INFRA-0355: make reusable security gates runner-deterministic

### DIFF
--- a/.github/workflows/network-exposure-lint.yml
+++ b/.github/workflows/network-exposure-lint.yml
@@ -45,6 +45,11 @@ on:
         type: string
         required: false
         default: 'main'
+      runner_labels:
+        description: 'JSON array string of runner labels to pin the job (workflow_call inputs cannot be arrays; consumed via fromJSON in runs-on)'
+        type: string
+        required: false
+        default: '["self-hosted","linux"]'
   workflow_dispatch:
     inputs:
       compose_paths:
@@ -58,7 +63,7 @@ permissions:
 jobs:
   lint:
     name: network-exposure-lint
-    runs-on: [self-hosted, linux]
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     steps:
       - name: Checkout target repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/.github/workflows/reusable-security-audit.yml
+++ b/.github/workflows/reusable-security-audit.yml
@@ -91,7 +91,7 @@ jobs:
       # which are present on the runner.
       - name: Setup Rust toolchain (rust_cargo profile only)
         if: inputs.stack == 'rust_cargo'
-        uses: dtolnay/rust-toolchain@4be7066ada62dd38de10e7b70166bc74ed198c30 # stable
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
 
       - name: Run stack-specific audit
         env:

--- a/.github/workflows/reusable-security-audit.yml
+++ b/.github/workflows/reusable-security-audit.yml
@@ -36,6 +36,11 @@ on:
         type: string
         required: false
         default: 'main'
+      runner_labels:
+        description: 'JSON array string of runner labels to pin the job (workflow_call inputs cannot be arrays; consumed via fromJSON in runs-on)'
+        type: string
+        required: false
+        default: '["self-hosted","linux"]'
 
 permissions:
   contents: read
@@ -47,7 +52,7 @@ concurrency:
 jobs:
   audit:
     name: security-audit (${{ inputs.stack }})
-    runs-on: [self-hosted, linux]
+    runs-on: ${{ fromJSON(inputs.runner_labels) }}
     steps:
       - name: Checkout consumer repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -97,7 +102,13 @@ jobs:
           case "$STACK" in
             typescript_pnpm)
               echo "::group::typescript_pnpm audit"
-              corepack enable
+              # Provision pnpm WITHOUT a privileged global write. `corepack enable`
+              # (no args) writes shims into the node bin dir (often root-owned
+              # /usr/bin) -> EACCES on runners where the runner user lacks that
+              # write (e.g. arca-devs). Pin the shim dir to a runner-writable path
+              # so the job is deterministic across runner variance.
+              corepack enable --install-directory "$RUNNER_TEMP/corepack-bin"
+              export PATH="$RUNNER_TEMP/corepack-bin:$PATH"
               pnpm install --frozen-lockfile --ignore-scripts
               pnpm audit --audit-level="$AUDIT_LEVEL" --prod
               echo "::endgroup::"

--- a/skills/autonomous-mode/SKILL.md
+++ b/skills/autonomous-mode/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: autonomous-mode
-description: Question Suppression Ladder + L1 Inline Resolution Rule + Hard-gated Action Boundary. Activated via DATARIM_AUTO_MODE=1 + a per-task autonomous-mode marker; a delegated bare task-id enters /dr-auto by reading that marker on startup.
+description: Question Suppression Ladder + L1 Inline Resolution Rule + Hard-gated Action Boundary. Activated by DATARIM_AUTO_MODE=1 + a per-task autonomous-mode marker.
 model: inherit
 current_aal: 2
 target_aal: 2
@@ -15,7 +15,7 @@ This skill activates the existing mandates (`documentation/mandates/autonomous-a
 The skill is active if and only if **all three conditions** hold:
 
 1. `DATARIM_AUTO_MODE=1` is set in the agent's environment.
-2. The effective autonomous-mode marker exists and parses as YAML. The marker is per-task at `datarim/.auto/<TASK-ID>.mode` (collision-safe in a shared parallel workspace); the legacy single file `datarim/.auto-mode-active` is still honoured as a fallback for a hand-run `/dr-auto`. Resolve the effective path with `dev-tools/auto-mode-marker.sh resolve --root <DIR> --task-id <ID>` rather than hardcoding either path.
+2. The effective autonomous-mode marker exists and parses as YAML. The marker is per-task at `datarim/.auto/<TASK-ID>.mode` (collision-safe in a shared parallel workspace); the legacy single file `datarim/.auto-mode-active` is still honoured as a fallback for a hand-run `/dr-auto`. Resolve the effective path with `${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/auto-mode-marker.sh resolve --root <DIR> --task-id <ID>` rather than hardcoding either path.
 3. The `task_id` field inside that marker matches the current TASK-ID (regex `^[A-Z]{2,10}-[0-9]{4}$`).
 
 **Spawned subagents (relaxed activation).** A subagent dispatched by `/dr-auto` does NOT inherit the `DATARIM_AUTO_MODE` environment variable (the Agent tool does not propagate the parent environment). For such a subagent the skill is active when its dispatch prompt carries an explicit auto-signal (a line naming the current stage and "autonomous mode for `<TASK-ID>`") AND conditions 2 and 3 hold (the marker file exists, parses, and its `task_id` matches the current TASK-ID). The environment variable (condition 1) is NOT required in this branch. The top-level `/dr-auto` cycle still requires all three conditions. The auto-signal only removes the env-var requirement — it never substitutes for a missing or mismatched marker file.
@@ -69,7 +69,7 @@ keystroke (a keystroke is racy and can be dropped before the CLI is ready).
 **Step-0 (before choosing `/dr-init` vs `/dr-auto`).** On receiving a bare
 task-id, the agent's first action is to resolve and read the marker:
 
-1. `path=$(dev-tools/auto-mode-marker.sh resolve --root <DIR> --task-id <ID>)`.
+1. `path=$(${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/auto-mode-marker.sh resolve --root <DIR> --task-id <ID>)`.
 2. If the marker is **valid and autonomous** for this task-id — it parses,
    task_id matches, it is within TTL, it is untracked by git (gitignored-marker
    rule), and (when `dispatch_session` is present) it equals the agent's own

--- a/tests/network-exposure-ci-integration.bats
+++ b/tests/network-exposure-ci-integration.bats
@@ -54,7 +54,7 @@ setup() {
     run yq -r '.jobs.lint."runs-on"' "$WF"
     [ "$status" -eq 0 ]
     case "$output" in
-        ubuntu-latest|"[self-hosted, linux]"|"[self-hosted, Linux]") ;;
+        ubuntu-latest|"[self-hosted, linux]"|"[self-hosted, Linux]"|'${{ fromJSON(inputs.runner_labels) }}') ;;
         *) echo "Unexpected runs-on: $output" >&2; false ;;
     esac
 }


### PR DESCRIPTION
Fixes self-hosted Corepack EACCES without privileged global writes; adds explicit runner_labels to reusable security and network-exposure workflows.