### PR TITLE
INFRA-0355: create Corepack shim directory on self-hosted runners

### DIFF
--- a/.github/workflows/reusable-security-audit.yml
+++ b/.github/workflows/reusable-security-audit.yml
@@ -107,6 +107,7 @@ jobs:
               # /usr/bin) -> EACCES on runners where the runner user lacks that
               # write (e.g. arca-devs). Pin the shim dir to a runner-writable path
               # so the job is deterministic across runner variance.
+              mkdir -p "$RUNNER_TEMP/corepack-bin"
               corepack enable --install-directory "$RUNNER_TEMP/corepack-bin"
               export PATH="$RUNNER_TEMP/corepack-bin:$PATH"
               pnpm install --frozen-lockfile --ignore-scripts


### PR DESCRIPTION
Fixes the confirmed ENOENT in the Legal Arcana security-audit job: create the runner-local Corepack shim directory before `corepack enable --install-directory`. This keeps the security gate unprivileged and deterministic across self-hosted runners.