### PR TITLE
docs(soak): TUNE-0212 cite PRD-canonical traffic-mix as weight source of truth

### DIFF
--- a/dev-tools/dr-orchestrate-soak.sh
+++ b/dev-tools/dr-orchestrate-soak.sh
@@ -13,6 +13,13 @@
 #   noop       — invoke cmd_run.sh with no args (legacy pane-capture path)
 #
 # Defaults: 70/20/10 resolved/escalated/noop, 5s cycle sleep, 48h deadline.
+# The 70/20/10 mode weights and the RESOLVED_PROMPTS / ESCALATED_PROMPTS
+# corpora below are PRD-canonical: their source of truth is
+# PRD-TUNE-0165 § Amendment A (V-AC-22 Traffic-Mix Specification, TUNE-0212).
+# The verdict gate (measure-orchestrator-soak.sh) computes the false-escalation
+# rate as escalated/(resolved+escalated) over the expected_outcome=="resolved"
+# slice only, excluding blocked_decision_cooldown from both sides — so the 0.15
+# threshold is invariant to these volume weights (Amendment A.3/A.4).
 # Tune via env knobs:
 #   DR_SOAK_DURATION_HOURS  — soak deadline in hours (default 48; integer)
 #   DR_SOAK_DURATION_SECONDS — soak deadline in seconds (overrides HOURS; for smoke runs)


### PR DESCRIPTION
## TUNE-0212 — PRD-TUNE-0165 amendment: V-AC-22 traffic-mix specification (framework part)

Class B reflection-TUNE-0209 Proposal 3: V-AC-22's 0.15 false-escalation threshold shipped without an explicit traffic-mix spec. This PR is the **framework half** — the PRD amendment itself lives in the workspace `datarim/prd/` tree (gitignored, local artifact, not part of this repo).

### Change
`dev-tools/dr-orchestrate-soak.sh` already ships the canonical **70/20/10** resolved/escalated/noop defaults. This PR makes the header comment name **PRD-TUNE-0165 § Amendment A** as their source of truth and documents why the 0.15 threshold is invariant to these volume weights:

- the verdict gate (`measure-orchestrator-soak.sh`) computes `escalated / (resolved + escalated)` over the `expected_outcome=="resolved"` slice only;
- `blocked_decision_cooldown` outcomes are excluded from both numerator and denominator (cooldown-attribution decision);
- so the metric measures parser+subagent false-escalation on legitimate slash-commands and is invariant to the resolved/escalated/noop volume weights.

### Acceptance criteria
- **V-AC-4** (this PR): soak driver reflects PRD-canonical weights as defaults — 70/20/10 retained, header cites the PRD amendment.
- **V-AC-1/2/3** delivered in the workspace PRD amendment (§ Amendment A: corpora + weights, observed-rate formula + cooldown attribution, threshold retained at 0.15 with rationale).

### Verification
- `shellcheck dev-tools/dr-orchestrate-soak.sh` clean
- runtime smoke (3-cycle mock): `weights=70/20/10`, all three modes exercised, exit 0
- comment-only change; no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)