### PR TITLE
feat(dr-qa,dr-compliance): provenance / tip-freshness Step-0 gate (TUNE-0510)

### DIFF
--- a/commands/dr-compliance.md
+++ b/commands/dr-compliance.md
@@ -11,6 +11,13 @@ description: Adaptive post-QA hardening. Detects task type and applies matching 
 ## Instructions
 
 **Stage Header (mandatory)**: Emit `**{TASK-ID} · {title}**` as the first line of your response, before any tool-call narration. The title is the verbatim one-liner field from `tasks.md` (between `L{N} · ` and ` → tasks/`). Skip this header only for `/dr-help`, `/dr-status`, `/dr-doctor`, and `/dr-init` Steps 1-3 (which emit it immediately after Step 4). See `$HOME/.claude/skills/cta-format/SKILL.md` § Stage Header.
+0.  **PROVENANCE GATE (mandatory, runs first)**: Before any other logic, verify the tip being certified is still the current branch tip and the working tree is clean — i.e. nothing was rebased, amended, or committed since `/dr-qa` signed off (a known false-green class: a COMPLIANT sign-off recorded against a commit that had been rebased away). Resolve the repo root as in Step 2 (the git top-level of the touched code), then:
+    ```bash
+    "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/provenance-gate.sh" \
+        --root <repo-root> --task {TASK-ID} --stage compliance
+    ```
+    This asserts `git rev-parse HEAD` equals the SHA `/dr-qa` recorded in `datarim/provenance/{TASK-ID}.sha` and that the working tree is clean. If the QA evidence record is absent (QA predates this gate), fall back to `--expected-sha <SHA cited by the QA report>`; if neither is available, record the current clean tip with `--record` now and note the missing QA baseline in the report.
+    -   A non-zero exit (dirty tree, drifted tip, or an evidence SHA that no longer resolves) makes the verdict **NON-COMPLIANT**: emit the gate's error verbatim and route via the FAIL-Routing CTA back to `/dr-qa {TASK-ID}` to re-certify the current tip. Exit `0` proceeds.
 1.  **LOAD**: Read `$HOME/.claude/agents/compliance.md` and adopt that persona.
 2.  **RESOLVE PATH**: Find `datarim/` using standard path resolution (see `$HOME/.claude/skills/datarim-system/SKILL.md` § Path Resolution Rule). **For a task whose code lives under `Projects/<name>/code/`, NEVER probe `Projects/<name>/code/datarim/` for workflow artefacts — that path exists only for the Datarim framework's own repo (§ Path Resolution Rule point 5). Resolve `--root` to the project's git-toplevel `datarim/`.**
 

--- a/commands/dr-qa.md
+++ b/commands/dr-qa.md
@@ -12,6 +12,18 @@ description: Multi-layer quality verification — checks PRD alignment, design c
 
 
 **Stage Header (mandatory)**: Emit `**{TASK-ID} · {title}**` as the first line of your response, before any tool-call narration. The title is the verbatim one-liner field from `tasks.md` (between `L{N} · ` and ` → tasks/`). Skip this header only for `/dr-help`, `/dr-status`, `/dr-doctor`, and `/dr-init` Steps 1-3 (which emit it immediately after Step 4). See `$HOME/.claude/skills/cta-format/SKILL.md` § Stage Header.
+0.  **PROVENANCE GATE (mandatory, runs first)**: Before any other logic, assert that the tip being certified **is** the current branch tip and the working tree is clean, so a QA sign-off can never be recorded against a stale or rebased-away commit (a known false-green class: a sign-off recorded on a commit that is later rebased away, leaving the certification pinned to a tree that is no longer the branch state). Resolve the repo root first — the git top-level of the touched code (for a task whose code lives under `Projects/<name>/code/`, that nested repo, NOT the workspace root).
+    -   **Pin what will be certified** (records the current HEAD to `datarim/provenance/{TASK-ID}.sha` and blocks on a dirty tree):
+        ```bash
+        "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/provenance-gate.sh" \
+            --root <repo-root> --record --task {TASK-ID} --stage qa
+        ```
+    -   **Re-verify immediately before writing the QA report (Step 7)** that nothing rebased, amended, or committed over the tip mid-review:
+        ```bash
+        "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/provenance-gate.sh" \
+            --root <repo-root> --task {TASK-ID} --stage qa
+        ```
+    -   A non-zero exit (dirty tree, drifted tip, or an evidence SHA that no longer resolves) STOPS the command: emit the gate's error verbatim and route back to `/dr-do {TASK-ID}` to re-run against the current tip. Exit `0` proceeds. The recorded SHA is the tip the QA report certifies — cite it in the report.
 1.  **LOAD**: Read `$HOME/.claude/agents/reviewer.md` and adopt that persona.
 2.  **RESOLVE PATH**: Before any read/write to `datarim/`, find the correct path by walking up directories from cwd. If `datarim/` is not found anywhere, STOP and tell user to run `/dr-init`. Do NOT create it — only `/dr-init` may create `datarim/`. See `$HOME/.claude/skills/datarim-system/SKILL.md` § Path Resolution Rule. **For a task whose code lives under `Projects/<name>/code/`, NEVER probe `Projects/<name>/code/datarim/` for workflow artefacts — that path exists only for the Datarim framework's own repo (see § Path Resolution Rule point 5). Resolve `--root` to the project's git-toplevel `datarim/`.**
 

--- a/dev-tools/provenance-gate.sh
+++ b/dev-tools/provenance-gate.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# provenance-gate.sh — Step-0 provenance / tip-freshness gate for /dr-qa and
+# /dr-compliance.
+#
+# Prevents false-green certification of a tree that is no longer the branch
+# state (the ARAS-0033 failure: a COMPLIANT sign-off recorded against a commit
+# that was later rebased away). At certification time the gate asserts:
+#
+#   1. The working tree is clean (`git status --porcelain` is empty).
+#   2. The current tip (`git rev-parse HEAD`) equals the evidence SHA the
+#      QA/compliance evidence was gathered on — supplied as an argument or read
+#      from a well-known evidence-record file. A rebase, amend, or new commit
+#      moves HEAD away from the recorded SHA and is therefore caught here; an
+#      evidence SHA that no longer resolves (history rewritten / commit gc'd) is
+#      caught too.
+#
+# Two modes:
+#   --record   Assert a clean tree, then persist the current HEAD as the
+#              evidence SHA (call at the START of a stage to pin what will be
+#              certified).
+#   (default)  Verify: assert a clean tree AND HEAD == the expected SHA (call
+#              before writing the sign-off, and as Step 0 of a later stage that
+#              must certify the same tip).
+#
+# Usage:
+#   provenance-gate.sh --root <dir> --record (--evidence-file <path> | --task <ID>) [--stage <name>]
+#   provenance-gate.sh --root <dir>          (--expected-sha <sha> | --evidence-file <path> | --task <ID>) [--stage <name>] [--allow-dirty]
+#
+# Evidence-file default when --task <ID> is given:
+#   <root>/datarim/provenance/<TASK-ID>.sha
+# (the datarim/ subtree is gitignored in Datarim-managed repos, so the record
+# file never dirties the working tree).
+#
+# Exit codes:
+#   0  gate passed
+#   1  gate violation (dirty tree, tip drifted, or evidence SHA gone)
+#   2  usage / environment error
+#
+# Security: S1 strict mode, all expansions quoted, no eval, argv validated.
+
+set -euo pipefail
+
+ROOT="$PWD"
+MODE="verify"
+EVIDENCE_FILE=""
+EXPECTED_SHA=""
+TASK=""
+STAGE=""
+ALLOW_DIRTY=0
+
+usage_die() {
+    printf 'provenance-gate: %s\n' "$*" >&2
+    exit 2
+}
+
+block() {
+    printf 'provenance-gate: BLOCKED — %s\n' "$*" >&2
+    exit 1
+}
+
+print_usage() {
+    sed -n '2,44p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --root) shift; [[ $# -gt 0 ]] || usage_die "--root requires a path"; ROOT="$1"; shift ;;
+        --record) MODE="record"; shift ;;
+        --evidence-file) shift; [[ $# -gt 0 ]] || usage_die "--evidence-file requires a path"; EVIDENCE_FILE="$1"; shift ;;
+        --expected-sha) shift; [[ $# -gt 0 ]] || usage_die "--expected-sha requires a value"; EXPECTED_SHA="$1"; shift ;;
+        --task) shift; [[ $# -gt 0 ]] || usage_die "--task requires an id"; TASK="$1"; shift ;;
+        --stage) shift; [[ $# -gt 0 ]] || usage_die "--stage requires a value"; STAGE="$1"; shift ;;
+        --allow-dirty) ALLOW_DIRTY=1; shift ;;
+        --help|-h) print_usage; exit 0 ;;
+        *) usage_die "unknown flag: $1" ;;
+    esac
+done
+
+[[ -d "$ROOT" ]] || usage_die "root not found: $ROOT"
+
+if [[ -n "$TASK" ]]; then
+    [[ "$TASK" =~ ^[A-Z]+-[0-9]+(-[A-Za-z0-9]+)*$ ]] || usage_die "invalid task id: $TASK"
+    [[ -n "$EVIDENCE_FILE" ]] || EVIDENCE_FILE="$ROOT/datarim/provenance/${TASK}.sha"
+fi
+
+git -C "$ROOT" rev-parse --is-inside-work-tree >/dev/null 2>&1 \
+    || usage_die "not a git work tree: $ROOT"
+
+HEAD_SHA="$(git -C "$ROOT" rev-parse HEAD 2>/dev/null)" \
+    || usage_die "cannot resolve HEAD in $ROOT (no commits yet?)"
+
+# ── Clean-tree assertion (shared by both modes) ──────────────────────────────
+if [[ "$ALLOW_DIRTY" -eq 0 ]]; then
+    dirty="$(git -C "$ROOT" status --porcelain)"
+    if [[ -n "$dirty" ]]; then
+        block "working tree is not clean; commit or stash before certification:
+${dirty}"
+    fi
+fi
+
+stage_note=""
+[[ -n "$STAGE" ]] && stage_note=" (stage ${STAGE})"
+
+# ── Record mode ──────────────────────────────────────────────────────────────
+if [[ "$MODE" == "record" ]]; then
+    [[ -n "$EVIDENCE_FILE" ]] || usage_die "--record requires --evidence-file or --task"
+    mkdir -p "$(dirname "$EVIDENCE_FILE")"
+    printf '%s\n' "$HEAD_SHA" >"$EVIDENCE_FILE"
+    printf 'provenance-gate: recorded evidence SHA %s%s -> %s\n' \
+        "$HEAD_SHA" "$stage_note" "$EVIDENCE_FILE"
+    exit 0
+fi
+
+# ── Verify mode ──────────────────────────────────────────────────────────────
+expected=""
+if [[ -n "$EXPECTED_SHA" ]]; then
+    expected="$EXPECTED_SHA"
+elif [[ -n "$EVIDENCE_FILE" ]]; then
+    [[ -f "$EVIDENCE_FILE" ]] \
+        || usage_die "evidence record not found: $EVIDENCE_FILE (run --record at stage start)"
+    expected="$(head -n1 "$EVIDENCE_FILE" | tr -d '[:space:]')"
+    [[ -n "$expected" ]] || usage_die "evidence record is empty: $EVIDENCE_FILE"
+else
+    usage_die "verify mode requires --expected-sha, --evidence-file, or --task"
+fi
+
+expected_full="$(git -C "$ROOT" rev-parse --verify --quiet "${expected}^{commit}" 2>/dev/null)" \
+    || block "evidence SHA ${expected} no longer resolves in ${ROOT} — history was rewritten (rebase/amend) or the commit was garbage-collected"
+
+if [[ "$HEAD_SHA" != "$expected_full" ]]; then
+    block "branch tip moved since evidence was gathered${stage_note}:
+  evidence SHA : ${expected_full}
+  current HEAD : ${HEAD_SHA}
+a rebase, amend, or new commit changed the tip; re-run the stage against the current tip"
+fi
+
+printf 'provenance-gate: OK — tip %s matches evidence%s, working tree clean\n' \
+    "$HEAD_SHA" "$stage_note"
+exit 0

--- a/tests/provenance-gate.bats
+++ b/tests/provenance-gate.bats
@@ -1,0 +1,128 @@
+#!/usr/bin/env bats
+# TUNE-0510 — provenance / tip-freshness Step-0 gate for /dr-qa and /dr-compliance.
+# Red: a drifted tip or dirty working tree blocks. Green: a clean matching tip passes.
+
+setup() {
+    SCRIPT="${BATS_TEST_DIRNAME}/../dev-tools/provenance-gate.sh"
+    REPO="$BATS_TEST_TMPDIR/repo"
+    mkdir -p "$REPO"
+    git -C "$REPO" init -q
+    git -C "$REPO" config user.email "t@example.com"
+    git -C "$REPO" config user.name "Test"
+    git -C "$REPO" config commit.gpgsign false
+    # datarim/ is gitignored in Datarim-managed repos, so the evidence-record
+    # file (written under datarim/provenance/) never dirties the tree.
+    printf 'datarim/\n' >"$REPO/.gitignore"
+    printf 'one\n' >"$REPO/a.txt"
+    git -C "$REPO" add .gitignore a.txt
+    git -C "$REPO" commit -q -m "c1"
+}
+
+# ── Green cases ──────────────────────────────────────────────────────────────
+
+@test "green: verify passes on a clean matching tip (--expected-sha)" {
+    head="$(git -C "$REPO" rev-parse HEAD)"
+    run bash "$SCRIPT" --root "$REPO" --expected-sha "$head" --stage qa
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"OK"* ]]
+}
+
+@test "green: record then verify via evidence file passes" {
+    ef="$REPO/datarim/prov.sha"
+    run bash "$SCRIPT" --root "$REPO" --record --evidence-file "$ef" --stage qa
+    [ "$status" -eq 0 ]
+    [ -f "$ef" ]
+    run bash "$SCRIPT" --root "$REPO" --evidence-file "$ef" --stage compliance
+    [ "$status" -eq 0 ]
+}
+
+@test "green: --task derives default evidence file under datarim/provenance" {
+    run bash "$SCRIPT" --root "$REPO" --record --task TUNE-0510 --stage qa
+    [ "$status" -eq 0 ]
+    [ -f "$REPO/datarim/provenance/TUNE-0510.sha" ]
+    run bash "$SCRIPT" --root "$REPO" --task TUNE-0510 --stage compliance
+    [ "$status" -eq 0 ]
+}
+
+@test "green: --allow-dirty bypasses the clean-tree assertion" {
+    head="$(git -C "$REPO" rev-parse HEAD)"
+    printf 'dirty\n' >>"$REPO/a.txt"
+    run bash "$SCRIPT" --root "$REPO" --expected-sha "$head" --allow-dirty
+    [ "$status" -eq 0 ]
+}
+
+# ── Red cases (gate violation, exit 1) ───────────────────────────────────────
+
+@test "red: dirty tracked file blocks (exit 1)" {
+    head="$(git -C "$REPO" rev-parse HEAD)"
+    printf 'dirty\n' >>"$REPO/a.txt"
+    run bash "$SCRIPT" --root "$REPO" --expected-sha "$head"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not clean"* ]]
+}
+
+@test "red: untracked file blocks (exit 1)" {
+    head="$(git -C "$REPO" rev-parse HEAD)"
+    printf 'x\n' >"$REPO/untracked.txt"
+    run bash "$SCRIPT" --root "$REPO" --expected-sha "$head"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"not clean"* ]]
+}
+
+@test "red: amended tip after record blocks (exit 1)" {
+    ef="$REPO/datarim/prov.sha"
+    run bash "$SCRIPT" --root "$REPO" --record --evidence-file "$ef"
+    [ "$status" -eq 0 ]
+    # A message change guarantees a distinct SHA (a no-edit amend within the same
+    # second can reproduce a byte-identical commit object).
+    git -C "$REPO" commit -q --amend -m "c1-amended"
+    run bash "$SCRIPT" --root "$REPO" --evidence-file "$ef"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"tip moved"* ]]
+}
+
+@test "red: new commit after record blocks (exit 1)" {
+    ef="$REPO/datarim/prov.sha"
+    bash "$SCRIPT" --root "$REPO" --record --evidence-file "$ef"
+    printf 'two\n' >"$REPO/b.txt"
+    git -C "$REPO" add b.txt
+    git -C "$REPO" commit -q -m "c2"
+    run bash "$SCRIPT" --root "$REPO" --evidence-file "$ef"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"tip moved"* ]]
+}
+
+@test "red: unresolvable evidence SHA blocks (exit 1)" {
+    run bash "$SCRIPT" --root "$REPO" \
+        --expected-sha "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"no longer resolves"* ]]
+}
+
+# ── Usage / environment errors (exit 2) ──────────────────────────────────────
+
+@test "usage: verify without any expected source errors (exit 2)" {
+    run bash "$SCRIPT" --root "$REPO"
+    [ "$status" -eq 2 ]
+}
+
+@test "usage: verify with a missing evidence file errors (exit 2)" {
+    run bash "$SCRIPT" --root "$REPO" --evidence-file "$REPO/datarim/absent.sha"
+    [ "$status" -eq 2 ]
+}
+
+@test "usage: non-git root errors (exit 2)" {
+    mkdir -p "$BATS_TEST_TMPDIR/plain"
+    run bash "$SCRIPT" --root "$BATS_TEST_TMPDIR/plain" --expected-sha abc123
+    [ "$status" -eq 2 ]
+}
+
+@test "usage: unknown flag errors (exit 2)" {
+    run bash "$SCRIPT" --root "$REPO" --bogus
+    [ "$status" -eq 2 ]
+}
+
+@test "usage: --record without a file target errors (exit 2)" {
+    run bash "$SCRIPT" --root "$REPO" --record
+    [ "$status" -eq 2 ]
+}


### PR DESCRIPTION
## TUNE-0510 — Provenance / tip-freshness Step-0 gate for /dr-qa and /dr-compliance

**Class B · L2 · P2.** Adds a mandatory Step-0 provenance assertion so a QA/compliance sign-off can only be recorded against the exact tip the branch currently points to, with a clean working tree.

### Motivation
ARAS-0033 verify iter-1 returned BLOCKED: a `COMPLIANT_WITH_NOTES` sign-off was recorded against `83c7b2a`, which was later rebased away (became `18373b6`). Both QA and compliance certified a tree that was no longer the branch state — a false-green the "assert end state / no false-green" discipline is meant to catch. This gate makes stale-commit certification impossible by construction.

### What's here
- **`dev-tools/provenance-gate.sh`** — two modes over one repo (`--root`):
  - `--record`: assert clean tree, persist current `HEAD` as the evidence SHA (well-known file or `--task` default `datarim/provenance/<ID>.sha`).
  - default (verify): assert clean tree **and** `git rev-parse HEAD` == expected evidence SHA (from `--expected-sha`, evidence file, or `--task`). Rebase/amend/new-commit drift and a rewritten/gc'd evidence SHA are all caught.
  - Exit `0` pass · `1` gate violation · `2` usage/env error. `set -euo pipefail`, quoted, no `eval` — clean at `shellcheck --severity=warning`.
- **`commands/dr-qa.md`** Step 0 — record the tip; re-verify before writing the report.
- **`commands/dr-compliance.md`** Step 0 — verify HEAD == the SHA QA recorded, clean tree; a violation is NON-COMPLIANT.
- **`tests/provenance-gate.bats`** — 14 cases: clean-match green; dirty tree / untracked / amended tip / new commit / unresolvable SHA red; usage errors. All green locally.

### Scope
English-only shipped surface. No Rust/arcana changes; no commands beyond `/dr-qa` and `/dr-compliance`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)