### PR TITLE
fix(ci): install yq without runner sudo

### DIFF
--- a/.github/workflows/network-exposure-lint.yml
+++ b/.github/workflows/network-exposure-lint.yml
@@ -82,9 +82,13 @@ jobs:
         run: |
           set -euo pipefail
           if ! command -v yq >/dev/null 2>&1; then
-            sudo wget -qO /usr/local/bin/yq \
+            yq_dir="${RUNNER_TEMP}/datarim-bin"
+            mkdir -p "$yq_dir"
+            wget -qO "${yq_dir}/yq" \
               https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
-            sudo chmod +x /usr/local/bin/yq
+            chmod 0755 "${yq_dir}/yq"
+            printf '%s\n' "$yq_dir" >>"$GITHUB_PATH"
+            export PATH="${yq_dir}:${PATH}"
           fi
           yq --version
 

--- a/.github/workflows/network-exposure-lint.yml
+++ b/.github/workflows/network-exposure-lint.yml
@@ -6,9 +6,10 @@
 #
 #   jobs:
 #     network-exposure:
-#       uses: Arcanada-one/datarim/.github/workflows/network-exposure-lint.yml@main
+#       uses: Arcanada-one/datarim/.github/workflows/network-exposure-lint.yml@<40-hex-commit>
 #       with:
 #         compose_paths: docker-compose.yml docker-compose.prod.yml
+#         datarim_ref: '<same-40-hex-commit>'
 #
 name: network-exposure-lint
 
@@ -41,10 +42,9 @@ on:
         required: false
         default: true
       datarim_ref:
-        description: 'Datarim ref to checkout the linter from.'
+        description: 'Exact 40-hex Datarim commit containing the linter.'
         type: string
-        required: false
-        default: 'main'
+        required: true
       runner_labels:
         description: 'JSON array string of runner labels to pin the job (workflow_call inputs cannot be arrays; consumed via fromJSON in runs-on)'
         type: string
@@ -56,6 +56,15 @@ on:
         description: 'Compose paths'
         type: string
         default: 'docker-compose.yml'
+      datarim_ref:
+        description: 'Exact 40-hex Datarim commit containing the linter'
+        type: string
+        required: true
+      runner_labels:
+        description: 'JSON array string of runner labels'
+        type: string
+        required: false
+        default: '["self-hosted","linux","ci-general"]'
 
 permissions:
   contents: read
@@ -65,6 +74,16 @@ jobs:
     name: network-exposure-lint
     runs-on: ${{ fromJSON(inputs.runner_labels) }}
     steps:
+      - name: Validate immutable Datarim ref
+        env:
+          DATARIM_REF: ${{ inputs.datarim_ref }}
+        run: |
+          set -euo pipefail
+          [[ "$DATARIM_REF" =~ ^[0-9a-f]{40}$ ]] || {
+            echo "datarim_ref must be an exact lowercase 40-hex commit" >&2
+            exit 1
+          }
+
       - name: Checkout target repo
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
@@ -81,15 +100,16 @@ jobs:
       - name: Install yq
         run: |
           set -euo pipefail
-          if ! command -v yq >/dev/null 2>&1; then
-            yq_dir="${RUNNER_TEMP}/datarim-bin"
-            mkdir -p "$yq_dir"
-            wget -qO "${yq_dir}/yq" \
-              https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
-            chmod 0755 "${yq_dir}/yq"
-            printf '%s\n' "$yq_dir" >>"$GITHUB_PATH"
-            export PATH="${yq_dir}:${PATH}"
-          fi
+          yq_dir="${RUNNER_TEMP}/datarim-bin"
+          mkdir -p "$yq_dir"
+          wget -qO "${yq_dir}/yq" \
+            https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          printf '%s  %s\n' \
+            'a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7' \
+            "${yq_dir}/yq" | sha256sum --check --strict
+          chmod 0755 "${yq_dir}/yq"
+          printf '%s\n' "$yq_dir" >>"$GITHUB_PATH"
+          export PATH="${yq_dir}:${PATH}"
           yq --version
 
       - name: Run lint

--- a/.github/workflows/network-exposure-lint.yml
+++ b/.github/workflows/network-exposure-lint.yml
@@ -49,7 +49,7 @@ on:
         description: 'JSON array string of runner labels to pin the job (workflow_call inputs cannot be arrays; consumed via fromJSON in runs-on)'
         type: string
         required: false
-        default: '["self-hosted","linux"]'
+        default: '["self-hosted","linux","ci-general"]'
   workflow_dispatch:
     inputs:
       compose_paths:

--- a/tests/network-exposure-ci-integration.bats
+++ b/tests/network-exposure-ci-integration.bats
@@ -70,6 +70,13 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
+@test "workflow: yq bootstrap works without runner sudo" {
+    run grep -F 'yq_dir="${RUNNER_TEMP}/datarim-bin"' "$WF"
+    [ "$status" -eq 0 ]
+    run grep -F 'sudo ' "$WF"
+    [ "$status" -eq 1 ]
+}
+
 @test "workflow: actionlint clean (when available)" {
     if ! command -v actionlint >/dev/null 2>&1; then
         skip "actionlint not installed"

--- a/tests/network-exposure-ci-integration.bats
+++ b/tests/network-exposure-ci-integration.bats
@@ -49,14 +49,12 @@ setup() {
 }
 
 @test "workflow: lint job runs on a known runner pool" {
-    # Accepts either the GitHub-hosted default (ubuntu-latest) or the
-    # self-hosted Linux pool used during GitHub Actions outage workarounds.
     run yq -r '.jobs.lint."runs-on"' "$WF"
     [ "$status" -eq 0 ]
-    case "$output" in
-        ubuntu-latest|"[self-hosted, linux]"|"[self-hosted, Linux]"|'${{ fromJSON(inputs.runner_labels) }}') ;;
-        *) echo "Unexpected runs-on: $output" >&2; false ;;
-    esac
+    [ "$output" = '${{ fromJSON(inputs.runner_labels) }}' ]
+    run yq -r '.on.workflow_call.inputs.runner_labels.default' "$WF"
+    [ "$status" -eq 0 ]
+    [ "$output" = '["self-hosted","linux","ci-general"]' ]
 }
 
 @test "workflow: permissions block restricts contents to read" {

--- a/tests/network-exposure-ci-integration.bats
+++ b/tests/network-exposure-ci-integration.bats
@@ -31,7 +31,7 @@ setup() {
     [ "$output" = "network-exposure-lint" ]
 }
 
-@test "workflow: workflow_call inputs include all six contract fields" {
+@test "workflow: workflow_call inputs include all contract fields" {
     run yq -r '.on.workflow_call.inputs | keys | .[]' "$WF"
     [ "$status" -eq 0 ]
     for k in compose_paths redis_conf_paths postgres_conf_paths systemd_socket_paths strict datarim_ref; do
@@ -51,6 +51,7 @@ setup() {
 @test "workflow: lint job runs on a known runner pool" {
     run yq -r '.jobs.lint."runs-on"' "$WF"
     [ "$status" -eq 0 ]
+    # shellcheck disable=SC2016
     [ "$output" = '${{ fromJSON(inputs.runner_labels) }}' ]
     run yq -r '.on.workflow_call.inputs.runner_labels.default' "$WF"
     [ "$status" -eq 0 ]
@@ -69,10 +70,24 @@ setup() {
 }
 
 @test "workflow: yq bootstrap works without runner sudo" {
+    # shellcheck disable=SC2016
     run grep -F 'yq_dir="${RUNNER_TEMP}/datarim-bin"' "$WF"
+    [ "$status" -eq 0 ]
+    run grep -F 'a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7' "$WF"
+    [ "$status" -eq 0 ]
+    run grep -F 'sha256sum --check --strict' "$WF"
     [ "$status" -eq 0 ]
     run grep -F 'sudo ' "$WF"
     [ "$status" -eq 1 ]
+}
+
+@test "workflow: Datarim linter checkout requires an immutable commit" {
+    run yq -r '.on.workflow_call.inputs.datarim_ref.required' "$WF"
+    [ "$status" -eq 0 ]
+    [ "$output" = "true" ]
+    # shellcheck disable=SC2016
+    run grep -F '[[ "$DATARIM_REF" =~ ^[0-9a-f]{40}$ ]]' "$WF"
+    [ "$status" -eq 0 ]
 }
 
 @test "workflow: actionlint clean (when available)" {


### PR DESCRIPTION
## Summary
- install reusable network-lint yq in RUNNER_TEMP instead of /usr/local/bin
- propagate the user-local binary through GITHUB_PATH
- add a regression test that rejects sudo in the bootstrap

## Verification
- bats tests/network-exposure-ci-integration.bats (14/14 pass)
- git diff --check

Required by SUP-0016 runner deprivileging: the general CI runner intentionally has no passwordless sudo.