### PR TITLE
fix(INFRA-0365): make the security-audit gate correct on any runner, not just equipped ones

### DIFF
--- a/.github/workflows/reusable-security-audit.yml
+++ b/.github/workflows/reusable-security-audit.yml
@@ -84,14 +84,91 @@ jobs:
             echo "accepted-risk.yml not present at $ACCEPTED_RISK_PATH — skipping schema validation"
           fi
 
-      # Self-hosted runners do not ship a Rust toolchain the way GitHub-hosted
-      # images did, so the rust_cargo branch below would fail with
-      # "cargo: command not found" (exit 127). Provision the toolchain in-workflow
-      # for the rust_cargo profile only — other profiles rely on node/pnpm/python,
-      # which are present on the runner.
+      # INFRA-0365: this gate must be correct on ANY runner in the fleet, because
+      # `runs-on: [self-hosted, linux]` matches nearly all of them and they are
+      # NOT interchangeable. Measured 2026-07-29 across the seven runner hosts:
+      #
+      #   host             node corepack pnpm python python3 shellcheck cargo
+      #   arcana-devs       y     y       y     N      y       y          y
+      #   arcana-prod       y     y       y     N      y       y          N
+      #   arcana-dbs        y     y       y     N      y       N          N
+      #   arcana-kb         y     y       y     N      y       y          N
+      #   arcana-www        N     N       N     N      y       N          N
+      #   arcana-trading    y     y       N     N      y       N          N
+      #   arcana-agents     y     y       y     N      y       N          y
+      #
+      # Consequences that were live before this change:
+      #   - typescript_pnpm exited 127 on arcana-www (cubrim-api PR #21) while
+      #     passing on arcana-prod-ci (PR #16) — identical code, different verdict.
+      #   - `python` is absent on EVERY host, so the python profile could never
+      #     have run at all.
+      #   - `framework` silently SKIPPED its only check on the 4 hosts without
+      #     shellcheck, reporting success having audited nothing — a false green.
+      #
+      # The fix is to provision what each profile needs rather than to pin the job
+      # to whichever hosts happen to be equipped today. Pinning would also shrink
+      # the eligible pool and worsen the single-slot contention tracked in
+      # INFRA-0364.
       - name: Setup Rust toolchain (rust_cargo profile only)
         if: inputs.stack == 'rust_cargo'
         uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable
+
+      # Brings node AND corepack into the runner tool cache, so the corepack
+      # shim trick below works on a host that ships neither.
+      - name: Setup Node toolchain (typescript_pnpm profile only)
+        if: inputs.stack == 'typescript_pnpm'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          # Node 24, not 20. Corepack resolves the current pnpm (11.x), which
+          # requires the `node:sqlite` builtin; on Node 20 it dies with
+          # ERR_UNKNOWN_BUILTIN_MODULE. Found empirically on arcana-www-arcanada
+          # — setup-node itself succeeded and the pnpm shim then crashed.
+          node-version: '24'
+
+      # shellcheck has no setup-action; fetch the upstream static binary the same
+      # way other Arcanada workflows do. Without this the framework profile
+      # silently audits nothing wherever shellcheck is absent.
+      - name: Provision shellcheck (framework profile only)
+        if: inputs.stack == 'framework'
+        run: |
+          set -euo pipefail
+          if command -v shellcheck >/dev/null 2>&1; then
+            echo "shellcheck already present: $(command -v shellcheck)"
+            exit 0
+          fi
+          ver="v0.10.0"
+          curl -sSfL "https://github.com/koalaman/shellcheck/releases/download/${ver}/shellcheck-${ver}.linux.x86_64.tar.xz" \
+            | tar -xJ -C "$RUNNER_TEMP" "shellcheck-${ver}/shellcheck" --strip-components=1
+          chmod +x "$RUNNER_TEMP/shellcheck"
+          echo "$RUNNER_TEMP" >> "$GITHUB_PATH"
+          echo "shellcheck ${ver} provisioned to RUNNER_TEMP"
+
+      # Fail with a diagnosable message naming the runner and the missing tool,
+      # instead of a bare exit 127 from the middle of the audit script.
+      - name: Assert toolchain preconditions
+        env:
+          STACK: ${{ inputs.stack }}
+        run: |
+          set -euo pipefail
+          case "$STACK" in
+            typescript_pnpm) required="node corepack" ;;
+            rust_cargo)      required="cargo" ;;
+            python)          required="python3" ;;
+            framework)       required="shellcheck" ;;
+            *) echo "ERROR: unknown stack profile: $STACK" >&2; exit 1 ;;
+          esac
+          missing=""
+          for bin in $required; do
+            command -v "$bin" >/dev/null 2>&1 || missing="$missing $bin"
+          done
+          if [ -n "$missing" ]; then
+            echo "ERROR: stack '$STACK' requires:$missing" >&2
+            echo "       runner '${RUNNER_NAME:-unknown}' does not provide them, and the" >&2
+            echo "       provisioning step above did not supply them either." >&2
+            echo "       This gate must never pass without actually auditing." >&2
+            exit 1
+          fi
+          echo "toolchain OK for '$STACK' on runner '${RUNNER_NAME:-unknown}':$(for b in $required; do printf ' %s=%s' "$b" "$(command -v "$b")"; done)"
 
       - name: Run stack-specific audit
         env:
@@ -123,7 +200,9 @@ jobs:
               ;;
             python)
               echo "::group::python audit"
-              python -m pip install --upgrade pip pip-audit
+              # INFRA-0365: was `python`, which is absent on every runner host
+              # (only python3 is installed) — this profile could never have run.
+              python3 -m pip install --upgrade pip pip-audit
               pip-audit -s osv --strict
               echo "::endgroup::"
               ;;
@@ -134,10 +213,12 @@ jobs:
                 exit 1
               fi
               echo "no runtime manifests — shellcheck sweep only"
-              if command -v shellcheck >/dev/null 2>&1; then
-                find . -type f -name '*.sh' -not -path './.datarim/*' \
-                  -print0 | xargs -0 -r shellcheck -S warning
-              fi
+              # INFRA-0365: this was wrapped in `if command -v shellcheck`, so on
+              # a runner without shellcheck the gate audited NOTHING and reported
+              # success. shellcheck is now provisioned and asserted above, so the
+              # sweep always runs.
+              find . -type f -name '*.sh' -not -path './.datarim/*' \
+                -print0 | xargs -0 -r shellcheck -S warning
               ;;
             *)
               echo "ERROR: unknown stack profile: $STACK" >&2


### PR DESCRIPTION
The reusable security audit is consumed with `runs-on: [self-hosted, linux]`, which matches nearly every runner in the fleet — and the runners are **not interchangeable**. Identical code therefore passes or fails depending on which machine picks it up:

- cubrim-api PR #16 → landed on `arcana-prod-ci` → **pass**
- cubrim-api PR #21 → landed on `arcana-www-arcanada` → **fail**, exit 127 (`corepack` absent)

### Measured toolchain matrix (2026-07-29, all seven runner hosts)

| host | node | corepack | pnpm | python | python3 | shellcheck | cargo |
|---|---|---|---|---|---|---|---|
| arcana-devs | y | y | y | **N** | y | y | y |
| arcana-prod | y | y | y | **N** | y | y | N |
| arcana-dbs | y | y | y | **N** | y | **N** | N |
| arcana-kb | y | y | y | **N** | y | y | N |
| arcana-www | **N** | **N** | **N** | **N** | y | **N** | N |
| arcana-trading | y | y | **N** | **N** | y | **N** | N |
| arcana-agents | y | y | y | **N** | y | **N** | y |

This surfaced **two further defects** beyond the reported one:

1. **`python` is absent on every host** (only `python3`). The `python` profile could never have run.
2. **`framework` silently skipped its only check** wherever `shellcheck` was missing — 4 of 7 hosts. It wrapped the sweep in `if command -v shellcheck`, so it audited *nothing* and reported success. A false green, live in the current code.

### Approach — (b) self-provisioning, not (a) pinning

Pinning was rejected on three grounds. It re-couples the gate to whichever hosts happen to be equipped *today* and nothing asserts that they stay equipped. It shrinks the eligible pool, concentrating load and worsening the single-slot contention tracked in **INFRA-0364**. And it fixes neither of the two false greens above — a pinned host with a silently-missing tool still passes. Note also that pinning is already available to consumers via the existing `runner_labels` input, so it was never a missing capability, and pinning *inside* the reusable workflow would override every consumer's choice.

Changes:
- `actions/setup-node` (SHA-pinned) for `typescript_pnpm` — brings node **and** corepack.
- Static `shellcheck` provisioned for `framework`, same pattern other Arcanada workflows use.
- `python` → `python3`.
- **`framework` no longer skips**: the sweep always runs.
- **New precondition assertion** per profile: fails with a message naming the runner and the missing tool instead of a bare 127 from mid-script. `This gate must never pass without actually auditing.`

### Acceptance — verified empirically, not assumed

Pinned to `arcana-www-arcanada`, which starts with **none** of the toolchain. Run `30437795490`, both jobs green:

```
runner=arcana-www-arcanada
  node         ABSENT
  corepack     ABSENT
  pnpm         ABSENT
  shellcheck   ABSENT
...
shellcheck v0.10.0 provisioned to RUNNER_TEMP
toolchain OK for 'framework' on runner 'arcana-www-arcanada': shellcheck=/opt/actions-runner-arcanada/_work/_temp/shellcheck
```

The first attempt **failed**, which is why this had to be empirical: `setup-node` succeeded but corepack resolved pnpm 11.17.0, which needs the `node:sqlite` builtin — absent in Node 20. Pinned to Node 24; re-ran green. The temporary acceptance harness is removed in the final commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UCjANsyrFLfyxZ5w57PpQD

---
*Supersedes #260, which carried a valid signature made with the wrong committer email (`unknown_key` → `verified: false`), so `required_signatures` blocked it. Re-committed under the repo's configured signing identity; `verified: true`. No force-push was used.*