### PR TITLE
chore(tune-0530): archive — remove from index, add follow-up tasks, bump version

### DIFF
--- a/datarim/activeContext.md
+++ b/datarim/activeContext.md
@@ -1,7 +1,6 @@
 # Active Context
 
 ## Active Tasks
-- TUNE-0530 · in_progress · P1 · L3 · Rework stack selection: from prescribed stacks to justified proposals → tasks/TUNE-0530-task-description.md
 - TUNE-0499 · pending · P3 · L2 · Sync activeContext.md § Active Tasks with tasks.md (strict-mirror contract) → tasks/TUNE-0499-task-description.md
 - TUNE-0500 · pending · P3 · L1 · Resolve QCK-0010/0011 dangling archive references → tasks/TUNE-0500-task-description.md
 - TUNE-0498 · pending · P2 · L2 · Fix datarim-doctor.sh macOS bash-3.2 crash → tasks/TUNE-0498-task-description.md

--- a/datarim/backlog.md
+++ b/datarim/backlog.md
@@ -1,3 +1,5 @@
 # Backlog
 
 ## Pending
+- TUNE-0532 · pending · P2 · L2 · Add domain-specific security guidance for new tech-stack domains (CLI, Desktop, Systems, Data/ML, WASM) → tasks/TUNE-0532-task-description.md
+- TUNE-0533 · pending · P3 · L2 · Monitor toolchain reform effectiveness — if "Recommended Toolchains" proves rigid in practice, spawn lightweight toolchain-choice mechanism → tasks/TUNE-0533-task-description.md

--- a/datarim/reflection/reflection-TUNE-0530.md
+++ b/datarim/reflection/reflection-TUNE-0530.md
@@ -4,7 +4,7 @@ artifact: reflection
 captured_at: 2026-07-29
 captured_by: /dr-compliance
 status: canonical
-reflection_basis: datarim/reports/compliance-report-TUNE-0530.md
+reflection_basis: 267b5e35e9f21fc7
 ---
 
 # Reflection — TUNE-0530

--- a/datarim/tasks.md
+++ b/datarim/tasks.md
@@ -1,7 +1,6 @@
 # Tasks
 
 ## Active
-- TUNE-0530 · in_progress · P1 · L3 · Rework stack selection: from prescribed stacks to justified proposals → tasks/TUNE-0530-task-description.md
 - TUNE-0499 · pending · P3 · L2 · Sync activeContext.md § Active Tasks with tasks.md (strict-mirror contract) → tasks/TUNE-0499-task-description.md
 - TUNE-0500 · pending · P3 · L1 · Resolve QCK-0010/0011 dangling archive references → tasks/TUNE-0500-task-description.md
 - TUNE-0498 · pending · P2 · L2 · Fix datarim-doctor.sh macOS bash-3.2 --scope=all crash (UTF-8 tr + empty array) → tasks/TUNE-0498-task-description.md


### PR DESCRIPTION
## TUNE-0530 archive finalization

- Remove TUNE-0530 from tasks.md and activeContext.md
- Add follow-up tasks TUNE-0532 and TUNE-0533 to backlog
- VERSION bump to 2.59.0 (carried from tune-0530-compliance branch)
- Compliance report, QA report, reflection artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)