### PR TITLE
fix(tune-0537): fix --target/--paths/--question sed extraction in coworker-hook-guard

### DIFF
--- a/dev-tools/coworker-hook-guard.sh
+++ b/dev-tools/coworker-hook-guard.sh
@@ -487,11 +487,11 @@ case "$tool" in
         _cow_question=""
         case "$cmd" in
           *coworker\ write*)
-            _cow_target=$(printf '%s' "$cmd" | sed -n 's/.*--target[= ][[:space:]]*"\?\([^"]*\)"\?.*/\1/p' | head -1)
+            _cow_target=$(printf '%s' "$cmd" | sed -n -e 's/.*--target "\([^"]*\)".*/\1/p' -e 's/.*--target="\([^"]*\)".*/\1/p' -e 's/.*--target \([^" ]\{1,\}\).*/\1/p' -e 's/.*--target=\([^" ]\{1,\}\).*/\1/p' | head -1)
             ;;
           *coworker\ ask*)
-            _cow_target=$(printf '%s' "$cmd" | sed -n 's/.*--paths[= ][[:space:]]*"\?\([^"]*\)"\?.*/\1/p' | head -1)
-            _cow_question=$(printf '%s' "$cmd" | sed -n 's/.*--question[= ][[:space:]]*"\?\([^"]*\)"\?.*/\1/p' | head -1)
+            _cow_target=$(printf '%s' "$cmd" | sed -n -e 's/.*--paths "\([^"]*\)".*/\1/p' -e 's/.*--paths="\([^"]*\)".*/\1/p' -e 's/.*--paths \([^" ]\{1,\}\).*/\1/p' -e 's/.*--paths=\([^" ]\{1,\}\).*/\1/p' | head -1)
+            _cow_question=$(printf '%s' "$cmd" | sed -n -e 's/.*--question "\([^"]*\)".*/\1/p' -e 's/.*--question="\([^"]*\)".*/\1/p' -e 's/.*--question \([^" ]\{1,\}\).*/\1/p' -e 's/.*--question=\([^" ]\{1,\}\).*/\1/p' | head -1)
             ;;
         esac
         # Gate 1: no-coworker zone — ban ALL coworker invocations.


### PR DESCRIPTION
## Problem

The inverse gate (deny `coworker write --target <voice-bearing-path>`) added in
PR #272 never fires because the `--target` extraction sed silently returns empty
on BSD/macOS sed. The `[= ]` bracket expression is ambiguous — BSD sed
interprets `[=` as a POSIX equivalence-class opener, causing the pattern to
fail. The gates are guarded by `[ -n "$_cow_target" ]`, so an empty result
means they NEVER fire.

Same root cause affects `--paths` and `--question` extraction.

## Fix

Replace `[= ][[:space:]]*` with four explicit, portable sed patterns:
- `--flag "val"` (space then quoted — handles spaces in paths)
- `--flag="val"` (equals then quoted)
- `--flag val` (space then bare word)
- `--flag=val` (equals then bare word)

No POSIX-ambiguous bracket expressions.

## Verification

- `bats tests/test-coworker-hook-guard-voice-bearing.bats` — 13/13 pass
- `bats tests/test-coworker-hook-guard-*.bats` — 77/77 pass
- Manual: all 5 `--target` forms extract correctly on GNU sed (Linux)
- Pattern tested with explicit quoted+space paths ('Social Media/Мои посты')

🤖 Generated with [Claude Code](https://claude.com/claude-code)