### PR TITLE
fix(tune-0537): fix unquoted --target with spaces bypass in coworker-hook-guard

### DIFF
--- a/dev-tools/coworker-hook-guard.sh
+++ b/dev-tools/coworker-hook-guard.sh
@@ -487,11 +487,11 @@ case "$tool" in
         _cow_question=""
         case "$cmd" in
           *coworker\ write*)
-            _cow_target=$(printf '%s' "$cmd" | sed -n -e 's/.*--target "\([^"]*\)".*/\1/p' -e 's/.*--target="\([^"]*\)".*/\1/p' -e 's/.*--target \([^" ]\{1,\}\).*/\1/p' -e 's/.*--target=\([^" ]\{1,\}\).*/\1/p' | head -1)
+            _cow_target=$(printf '%s' "$cmd" | sed -n -e 's/.*--target "\([^"]*\)".*/\1/p' -e 's/.*--target="\([^"]*\)".*/\1/p' -e 's/.*--target \([^"].*\).*/\1/p' -e 's/.*--target=\([^"].*\).*/\1/p' | head -1)
             ;;
           *coworker\ ask*)
-            _cow_target=$(printf '%s' "$cmd" | sed -n -e 's/.*--paths "\([^"]*\)".*/\1/p' -e 's/.*--paths="\([^"]*\)".*/\1/p' -e 's/.*--paths \([^" ]\{1,\}\).*/\1/p' -e 's/.*--paths=\([^" ]\{1,\}\).*/\1/p' | head -1)
-            _cow_question=$(printf '%s' "$cmd" | sed -n -e 's/.*--question "\([^"]*\)".*/\1/p' -e 's/.*--question="\([^"]*\)".*/\1/p' -e 's/.*--question \([^" ]\{1,\}\).*/\1/p' -e 's/.*--question=\([^" ]\{1,\}\).*/\1/p' | head -1)
+            _cow_target=$(printf '%s' "$cmd" | sed -n -e 's/.*--paths "\([^"]*\)".*/\1/p' -e 's/.*--paths="\([^"]*\)".*/\1/p' -e 's/.*--paths \([^"].*\).*/\1/p' -e 's/.*--paths=\([^"].*\).*/\1/p' | head -1)
+            _cow_question=$(printf '%s' "$cmd" | sed -n -e 's/.*--question "\([^"]*\)".*/\1/p' -e 's/.*--question="\([^"]*\)".*/\1/p' -e 's/.*--question \([^"].*\).*/\1/p' -e 's/.*--question=\([^"].*\).*/\1/p' | head -1)
             ;;
         esac
         # Gate 1: no-coworker zone — ban ALL coworker invocations.

--- a/tests/test-coworker-hook-guard-voice-bearing.bats
+++ b/tests/test-coworker-hook-guard-voice-bearing.bats
@@ -197,3 +197,49 @@ run_hook_bash() {
     decision=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision')
     [ "$decision" = "deny" ]
 }
+
+# --- V-14: unquoted --target with SPACE in voice-bearing path DENIED ----------
+@test "V-14 unquoted --target with space in voice-bearing path DENIED" {
+    local fp="$TMP_DIR/Social Media/Мои посты/Telegram/test-post.md"
+    # Unquoted: shell splits the path, but coworker write sees all tokens
+    local cmd="coworker write --target $fp"
+    run run_hook_bash "$cmd"
+    [ "$status" -eq 0 ]
+    decision=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+    reason=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+    case "$reason" in
+        *"voice-bearing"*|*"Voice-bearing"*) : ;;
+        *) printf 'deny reason missing voice-bearing: %s\n' "$reason" >&2; return 1 ;;
+    esac
+}
+
+# --- V-15: --target= with space in voice-bearing path DENIED ------------------
+@test "V-15 --target= with space in voice-bearing path DENIED" {
+    local fp="$TMP_DIR/Social Media/Мои посты/Telegram/test-post.md"
+    local cmd="coworker write --target=$fp"
+    run run_hook_bash "$cmd"
+    [ "$status" -eq 0 ]
+    decision=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+    reason=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+    case "$reason" in
+        *"voice-bearing"*|*"Voice-bearing"*) : ;;
+        *) printf 'deny reason missing voice-bearing: %s\n' "$reason" >&2; return 1 ;;
+    esac
+}
+
+# --- V-16: unquoted --paths with space in voice-bearing path DENIED (coworker ask)
+@test "V-16 unquoted --paths with space in voice-bearing path DENIED (coworker ask)" {
+    local fp="$TMP_DIR/Social Media/Мои посты/Telegram/test-post.md"
+    local cmd="coworker ask --paths $fp --question \"summarize\""
+    run run_hook_bash "$cmd"
+    [ "$status" -eq 0 ]
+    decision=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision')
+    [ "$decision" = "deny" ]
+    reason=$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason')
+    case "$reason" in
+        *"voice-bearing"*|*"Voice-bearing"*) : ;;
+        *) printf 'deny reason missing voice-bearing: %s\n' "$reason" >&2; return 1 ;;
+    esac
+}


### PR DESCRIPTION
## Problem

The bare-word sed patterns used `\([^" ]\{1,\}\)` which stops at the
first space, silently truncating paths like `Social Media/posts/x.md` to
just `Social`. This means unquoted `--target` and `--target=` forms
bypass the inverse gate — the truncated prefix never matches
`is_voice_bearing_path()`.

The existing V-3 test only covers the quoted form, so the suite was green
while the hole was open.

## Fix

Replace `\([^" ]\{1,\}\)` with `\([^"]\.\*\)` for bare-word and
equals forms — captures to end-of-string, handling paths with spaces.
The leading `[^"]` guard prevents the greedy pattern from matching
quoted forms (handled by the quoted patterns that run first).

## New tests

- **V-14**: unquoted `--target` with space in voice-bearing path → DENIED
- **V-15**: `--target=` with space in voice-bearing path → DENIED
- **V-16**: unquoted `--paths` with space in voice-bearing path → DENIED

## Verification

- `bats tests/test-coworker-hook-guard-voice-bearing.bats` — 16/16 pass
- `bats tests/test-coworker-hook-guard-*.bats` — 80/80 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)