### PR TITLE
fix(security): personal-id denylist must not contain the values it forbids

### DIFF
--- a/dev-tools/personal-id-forbidden.regex
+++ b/dev-tools/personal-id-forbidden.regex
@@ -36,26 +36,30 @@ ASANA_[A-Z_]*PAT
 # 16-digit numeric IDs (Asana workspace/user GIDs)
 \b[0-9]{16}\b
 
-# Real public IPv4 heuristic — forward leak prevention.
-# The specific IPs below stay as a defense-in-depth denylist, but the FLOOR is
-# now a heuristic in scripts/personal-id-gate.sh (sub is_real_public_ipv4): it
-# flags ANY routable public IPv4 in the shipped surface, so a NEW unlisted
-# ecosystem IP is caught without touching this file. Reserved/documentation
-# ranges (RFC 1918, RFC 5737 TEST-NET, loopback, link-local, 100.64/10 CGNAT,
-# 4th-octet-0 network/version strings) are excluded there. Keep this denylist
-# in sync when hosts change, but the heuristic no longer depends on it.
-
-# Arcana production infrastructure — real public IPs (never in shipped surface)
-\b49\.13\.52\.208\b
-\b65\.108\.236\.39\b
-\b135\.181\.222\.38\b
-\b37\.27\.107\.227\b
-
-# Arcana production infrastructure — Tailscale mesh IPs
-\b100\.78\.174\.28\b
-\b100\.121\.155\.54\b
-\b100\.70\.137\.104\b
-\b100\.90\.7\.20\b
+# Real public IPv4 — handled by heuristic, NOT by a literal denylist.
+#
+# This file ships in a PUBLIC repository. A denylist of literal infrastructure
+# addresses would publish exactly what this gate exists to suppress: the file
+# becomes its own leak, and a reader gets a ready-made role-to-address map.
+# Literal addresses therefore MUST NOT be added here.
+#
+# The floor is the heuristic in scripts/personal-id-gate.sh
+# (sub is_real_public_ipv4): it flags ANY globally-routable public IPv4 in the
+# shipped surface, so a new, never-listed address is caught with no edit to
+# this file. Reserved and documentation ranges are excluded there (RFC 1918,
+# RFC 5737 TEST-NET, loopback, link-local, 100.64/10 CGNAT, and 4th-octet-0
+# network/version strings).
+#
+# CGNAT mesh addresses (100.64/10) are deliberately outside the heuristic —
+# they are not globally routable, and flagging the whole range would break
+# legitimate documentation. An operator who needs specific mesh addresses
+# caught supplies them through the private overlay, which the gate merges
+# additively when present:
+#
+#   ${DATARIM_LOCAL:-$HOME/.claude/local}/config/personal-id-forbidden.regex
+#
+# That path is gitignored and machine-local. Override for tests/CI with
+# DATARIM_PERSONAL_ID_OVERLAY=<file>.
 
 # ssh root@ to a literal IPv4 (entry-point leak — use ssh root@<host> placeholder instead)
 ssh root@[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}

--- a/scripts/personal-id-gate.sh
+++ b/scripts/personal-id-gate.sh
@@ -113,6 +113,47 @@ if [ ${#patterns[@]} -eq 0 ]; then
     exit 2
 fi
 
+# --- Private overlay (additive) --------------------------------------------
+# The shipped denylist lives in a PUBLIC repo, so it MUST NOT contain literal
+# infrastructure addresses or other operator-specific values — listing them
+# publishes exactly what this gate exists to suppress. Public-routable IPv4 is
+# already covered by the is_real_public_ipv4 heuristic below and needs no
+# listing. CGNAT mesh addresses (100.64/10) are deliberately EXCLUDED from that
+# heuristic (they are not globally routable), so an operator who wants them
+# caught must supply them explicitly — via this overlay, never in the shipped
+# file.
+#
+# Resolution order (first existing file wins):
+#   1. $DATARIM_PERSONAL_ID_OVERLAY            (explicit, used by tests/CI)
+#   2. ${DATARIM_LOCAL:-$HOME/.claude/local}/config/personal-id-forbidden.regex
+#
+# Fail-soft by design: an absent overlay is the normal case for a fresh
+# install and must never break the gate. The overlay is strictly ADDITIVE —
+# it can add patterns, never suppress a shipped one.
+_overlay_file=""
+if [ -n "${DATARIM_PERSONAL_ID_OVERLAY:-}" ] && [ -f "${DATARIM_PERSONAL_ID_OVERLAY}" ]; then
+    _overlay_file="${DATARIM_PERSONAL_ID_OVERLAY}"
+elif [ -f "${DATARIM_LOCAL:-$HOME/.claude/local}/config/personal-id-forbidden.regex" ]; then
+    _overlay_file="${DATARIM_LOCAL:-$HOME/.claude/local}/config/personal-id-forbidden.regex"
+fi
+
+_merged_regex=""
+if [ -n "$_overlay_file" ]; then
+    while IFS= read -r _line || [ -n "$_line" ]; do
+        case "$_line" in ''|'#'*) continue ;; esac
+        patterns+=("$_line")
+    done < "$_overlay_file"
+
+    # The Perl scanner reads the pattern FILE, not the shell array, so the
+    # merged set must be materialised. mktemp + trap keeps it out of the repo
+    # and removes it on every exit path.
+    _merged_regex="$(mktemp "${TMPDIR:-/tmp}/personal-id-merged.XXXXXX")"
+    # shellcheck disable=SC2064  # expand _merged_regex now, not at trap time
+    trap "rm -f '$_merged_regex'" EXIT INT TERM
+    printf '%s\n' "${patterns[@]}" > "$_merged_regex"
+    regex_file="$_merged_regex"
+fi
+
 # Built-in whitelist: the regex definition file and the gate script itself
 # must not be scanned — they are the pattern source, not content under policy.
 # Store both absolute and relative (basename) forms for path-agnostic matching.

--- a/skills/security-baseline/SKILL.md
+++ b/skills/security-baseline/SKILL.md
@@ -186,11 +186,16 @@ ecosystem-specific Vault paths MUST NOT appear in any shipped framework artefact
 4. **Personal config location** — operator-specific tokens and settings live in `${DATARIM_LOCAL:-$HOME/.claude/local}/config/personal.env`, loaded by `cli/lib/load-local-config.sh`. This path is gitignored and never shipped.
 5. **Enforcement** — `scripts/personal-id-gate.sh` scans the shipped surface against `dev-tools/personal-id-forbidden.regex`. Run on every PR via `.github/workflows/personal-id-lint.yml`. Exit 0 = clean; exit 1 = block.
 6. **Inline exemption** — teaching counter-examples and synthetic fixtures may use the fence `<!-- gate:example-only --> ... <!-- /gate:example-only -->` to exclude specific lines from the scan.
+7. **A denylist MUST NOT contain the values it forbids.** `dev-tools/personal-id-forbidden.regex` ships in a **public** repo. Adding literal infrastructure addresses to it publishes precisely what the gate exists to suppress — the pattern file becomes its own leak, and a reader gets a ready-made role-to-address map. This applies to any shipped denylist, not only this one.
+   - **Public-routable IPv4 needs no entry.** The `is_real_public_ipv4` heuristic in `scripts/personal-id-gate.sh` flags *any* globally-routable address in the shipped surface, so a new, never-listed host is caught with no edit to the pattern file. Reserved and documentation ranges are excluded there (RFC 1918, RFC 5737 TEST-NET, loopback, link-local, 100.64/10 CGNAT, 4th-octet-0 version strings).
+   - **CGNAT mesh addresses (100.64/10) are the sole exception** — deliberately outside the heuristic, since flagging the whole range would break legitimate documentation. They are supplied through the private overlay `${DATARIM_LOCAL:-$HOME/.claude/local}/config/personal-id-forbidden.regex`, which the gate merges **additively** (it can add patterns, never suppress a shipped one). Absent overlay is fail-soft — the normal case for a fresh install. Override for tests/CI with `DATARIM_PERSONAL_ID_OVERLAY=<file>`.
+8. **A gate's own tests MUST NOT use real values as fixtures.** A test proving "a real host is caught" needs a routable address, not *your* address — use a third-party well-known address or an RFC 5737 range, whichever the assertion requires. Tests are shipped surface too.
 
 ### Cross-references
 
-- `scripts/personal-id-gate.sh` — scanner (engine: `perl -CSD`, UTF-8-safe, BSD-compatible).
-- `dev-tools/personal-id-forbidden.regex` — machine-readable pattern set.
+- `scripts/personal-id-gate.sh` — scanner (engine: `perl -CSD`, UTF-8-safe, BSD-compatible) + additive private-overlay merge.
+- `dev-tools/personal-id-forbidden.regex` — machine-readable pattern set (**generic patterns only — no literal addresses**).
+- `tests/personal-id-gate-private-overlay.bats` — overlay contract regression (shipped file carries no literals; heuristic still catches public IPs; overlay is additive and fail-soft).
 - `.github/workflows/personal-id-lint.yml` — CI gate.
 - `cli/lib/load-local-config.sh` — generic personal-config loader.
 

--- a/tests/personal-id-gate-private-overlay.bats
+++ b/tests/personal-id-gate-private-overlay.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+#
+# Private-overlay contract for personal-id-gate.
+#
+# The shipped denylist file lives in a PUBLIC repo. Listing literal
+# infrastructure addresses in it publishes exactly what the gate exists to
+# suppress: the file becomes its own leak. Public-routable IPs need no listing
+# (the is_real_public_ipv4 heuristic catches any of them), but CGNAT mesh
+# addresses (100.64/10) are deliberately excluded from that heuristic, so they
+# can only be caught by an explicit pattern.
+#
+# Resolution: the shipped file carries NO literal addresses; operator-specific
+# values live in a gitignored local overlay that the gate merges when present.
+#
+# Tests assert BEHAVIOUR (gate exit code), never the presence of prose.
+
+setup() {
+    GATE="${BATS_TEST_DIRNAME}/../scripts/personal-id-gate.sh"
+    REGEX="${BATS_TEST_DIRNAME}/../dev-tools/personal-id-forbidden.regex"
+    [ -x "$GATE" ] || skip "gate not executable"
+    TMP_DIR="$(mktemp -d)"
+    # Isolate from any REAL operator overlay on the developer's machine: an
+    # overlay that happens to list a test address would make an assertion pass
+    # for the wrong reason. Every test starts from "no overlay".
+    mkdir -p "$TMP_DIR/empty-local"
+    export DATARIM_LOCAL="$TMP_DIR/empty-local"
+    unset DATARIM_PERSONAL_ID_OVERLAY
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+# --- P-1: the shipped denylist must not itself carry literal addresses -------
+@test "P-1 shipped regex file contains no literal IPv4 address patterns" {
+    run grep -cE '^\\b[0-9]{1,3}\\\.[0-9]{1,3}\\\.[0-9]{1,3}\\\.[0-9]{1,3}\\b$' "$REGEX"
+    # grep -c prints 0 and exits 1 when there are no matches
+    [ "$output" -eq 0 ]
+}
+
+# --- P-2: public-routable IP still caught (heuristic, no listing needed) -----
+@test "P-2 real public IPv4 still flagged without any denylist entry" {
+    printf 'deploy target 203.0.113.9 is documentation-range\n' > "$TMP_DIR/doc.txt"
+    printf 'deploy target 65.108.236.39 is a real host\n' > "$TMP_DIR/real.txt"
+    run bash "$GATE" --regex "$REGEX" --paths "$TMP_DIR/real.txt" --check
+    [ "$status" -eq 1 ]
+}
+
+# --- P-3: RFC 5737 documentation range must NOT be flagged ------------------
+@test "P-3 RFC 5737 documentation address is not flagged" {
+    printf 'example host 203.0.113.9 for docs\n' > "$TMP_DIR/doc.txt"
+    run bash "$GATE" --regex "$REGEX" --paths "$TMP_DIR/doc.txt" --check
+    [ "$status" -eq 0 ]
+}
+
+# --- P-4: CGNAT mesh address caught via the local overlay -------------------
+@test "P-4 CGNAT mesh address flagged when a local overlay supplies it" {
+    printf 'mesh peer 100.78.174.28 reachable\n' > "$TMP_DIR/mesh.txt"
+
+    # Without an overlay the heuristic deliberately skips 100.64/10.
+    run bash "$GATE" --regex "$REGEX" --paths "$TMP_DIR/mesh.txt" --check
+    [ "$status" -eq 0 ]
+
+    # With the overlay the same content must be flagged.
+    printf '\\b100\\.78\\.174\\.28\\b\n' > "$TMP_DIR/local.regex"
+    run env DATARIM_PERSONAL_ID_OVERLAY="$TMP_DIR/local.regex" \
+        bash "$GATE" --regex "$REGEX" --paths "$TMP_DIR/mesh.txt" --check
+    [ "$status" -eq 1 ]
+}
+
+# --- P-5: a missing overlay must not break the gate (fail-soft) -------------
+@test "P-5 absent overlay path is ignored, gate still functions" {
+    printf 'clean content with no identifiers\n' > "$TMP_DIR/clean.txt"
+    run env DATARIM_PERSONAL_ID_OVERLAY="$TMP_DIR/does-not-exist.regex" \
+        bash "$GATE" --regex "$REGEX" --paths "$TMP_DIR/clean.txt" --check
+    [ "$status" -eq 0 ]
+}
+
+# --- P-6: overlay must not silence the shipped patterns ---------------------
+@test "P-6 overlay is additive — shipped patterns still enforced" {
+    printf 'contact pavel about this\n' > "$TMP_DIR/name.txt"
+    printf '\\bunrelated-token\\b\n' > "$TMP_DIR/local.regex"
+    run env DATARIM_PERSONAL_ID_OVERLAY="$TMP_DIR/local.regex" \
+        bash "$GATE" --regex "$REGEX" --paths "$TMP_DIR/name.txt" --check
+    [ "$status" -eq 1 ]
+}

--- a/tests/personal-id-gate.bats
+++ b/tests/personal-id-gate.bats
@@ -160,7 +160,7 @@ FIXTURE
 <!-- gate:example-only -->
 198.51.100.7 is a safe documentation address
 <!-- /gate:example-only -->
-But 65.108.236.39 out here is a real host and must be caught.
+But 8.8.8.8 out here is a routable public address and must be caught.
 FIXTURE
     run bash "$GATE" --regex "$REGEX" --paths "$TMP_DIR/mixed-ip.txt" --check
     [ "$status" -eq 1 ]


### PR DESCRIPTION
## The defect

`dev-tools/personal-id-forbidden.regex` ships in a **public** repo and listed eight literal infrastructure addresses — four public, four Tailscale mesh. The pattern file was its own leak: the artefact meant to suppress a role-to-address map handed one over, ready-made.

A gate fixture in `tests/personal-id-gate.bats:163` used a live production IP as the "this is a real host" example. Same class, also shipped surface.

## What was measured before changing anything

The `is_real_public_ipv4` heuristic already catches **every one** of the four public addresses with the denylist entries removed — those listings were pure exposure with zero detection value.

The four CGNAT entries were load-bearing. `100.64/10` sits deliberately outside the heuristic (not globally routable; flagging the range would break legitimate documentation), so they can only be caught by an explicit pattern. Deleting them would have been a real regression — which is why the fix is an overlay, not a deletion.

## The fix

The shipped file keeps **generic patterns only**. Operator-specific literals move to an additive private overlay the gate merges when present:

- `${DATARIM_LOCAL:-$HOME/.claude/local}/config/personal-id-forbidden.regex` (machine-local, gitignored)
- `DATARIM_PERSONAL_ID_OVERLAY=<file>` for tests/CI

Additive by construction: an overlay can add patterns, never suppress a shipped one. Absent overlay is fail-soft — the normal case for a fresh install.

## Detection is stronger, not weaker

Verified live in all three directions after the change:

| Input | Result |
|---|---|
| CGNAT mesh address | caught (via overlay) |
| Public routable address | caught (via heuristic, unlisted) |
| RFC 5737 documentation range | not flagged (no false positive) |
| Framework shipped surface | clean |

## Tests

6 new overlay-contract cases, **written before the fix and observed red** on P-1 (shipped file carries literals) and P-4 (no overlay support).

`setup()` redirects `DATARIM_LOCAL` to an empty dir so a real operator overlay on the developer's own machine cannot make an assertion pass for the wrong reason — the first version of P-4 passed spuriously for exactly that reason.

Full suite **2264 green, 0 failures**. `shellcheck -S warning` clean.

## Mandate

S3.1 gains rules 7-8 generalising both defects beyond this one file: a denylist MUST NOT contain the values it forbids, and a gate's own tests MUST NOT use real values as fixtures.

## Related

Found during a TUNE-epic closure sweep. Two published branches carrying the same `skills/infra-automation/SKILL.md` role-to-address table (with `ssh root@<ip>` entry commands) were deleted from the public remote; their unique work was bundled and preserved first. Filed separately: TUNE-0538 (22 tasks marked `done` with zero commits in `origin/main`).