### PR TITLE
feat(tune-0541): closure gate — a task cannot be `done` while its work is absent from origin/main

### DIFF
--- a/commands/dr-archive.md
+++ b/commands/dr-archive.md
@@ -159,6 +159,48 @@ The framework ships the PreToolUse guard (`dev-tools/datarim-exec-guard.sh`) tha
    is permitted.
 
 
+0.13. **CLOSURE REACHABILITY GATE** (MANDATORY for every git repository touched by the task):
+
+   Step 0.12 asserts that local commits reached **the remote**. It does not assert that the
+   work reached the repository's **canonical default branch**. A pushed feature branch whose
+   pull request was never opened satisfies 0.12 completely while leaving the framework without
+   the work — which is precisely how 22 backlog entries came to read `done` with zero of their
+   content in `origin/main`, each recording `await ... signed-push+PR` as its evidence. Closure
+   is reachability from `main`, not a branch existing somewhere.
+
+   **0.13.1 Detection per repo.** For each git repository classified in Step 0.1.1:
+
+   ```bash
+   "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/closure-gate.sh" \
+       --root <repo-path> --branch <task-branch> --task <TASK-ID>
+   ```
+
+   Exit `0` = every file and line the branch contributes is present in `origin/main`;
+   exit `1` = work is absent, and the task MUST NOT be marked `done`;
+   exit `2` = usage or environment error, including an unresolvable base ref. Unlike 0.12,
+   this gate fails **closed**: a base that cannot be resolved is never read as "everything
+   landed", because that reading is what produced the defect.
+
+   **0.13.2 What it asserts, and why not the obvious alternatives.**
+   - **Not ancestry of the evidence commit.** `main` merges by squash, so a branch's own
+     commits are never ancestors of `main`. `git merge-base --is-ancestor <evidence> origin/main`
+     is false for every *correctly* merged task, so a gate built on it would block everything
+     while catching nothing — an acceptance check no correct task can satisfy.
+   - **Not commit-message matching.** `git log --grep=<TASK-ID>` is unsound in both directions:
+     it misses work that landed without naming its id, and it reports work as landed when an
+     unrelated commit merely mentions the id.
+   - **Not added-file counts.** `git diff --diff-filter=A` counts only *additions*, so a branch
+     that solely modifies existing files reports zero while its work is unmerged.
+   - **Content reachability**, which squash-merge preserves: every added file must be present in
+     `origin/main` by blob or basename, and every substantive line added to a pre-existing file
+     must be findable in the `origin/main` tree.
+
+   **0.13.3 Routing on exit 1.** Halt the archive. The work is real and unmerged, so the
+   resolution is to land it — open the pull request, merge it, then re-run the gate. If the work
+   is deliberately being abandoned, that is a **cancellation**, not an archive: record it per
+   § Cancellation Mode. Marking `done` with the work outside `main` is not an available outcome,
+   and no attestation substitutes for the gate passing.
+
 0.15. **DRIFT SITE-UPDATE GATE** (MANDATORY when the task's commits touched a path under a registered product's `repo_local` in `documentation/ecosystem-sync/registry.yml`):
 
    When an archived task changed a registered product's repository, the deployed

--- a/dev-tools/closure-gate.sh
+++ b/dev-tools/closure-gate.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# closure-gate.sh — assert that the work a task claims is actually present in
+# canonical `origin/main` before that task may be marked `done`.
+#
+# Motivation. A sweep on 2026-07-30 found 22 backlog entries reading `done`
+# whose work had never left a worktree. Each carried evidence of the form
+# "focused bats N/N green @<sha> (worktree ...)" — true statements about a tree
+# that no consumer of the framework could reach. A gate written, tested green
+# and left on a branch is indistinguishable in effect from a gate never written.
+#
+# Why this does NOT assert ancestry of the evidence commit. Datarim's `main`
+# requires signed commits and merges pull requests by SQUASH. A squash merge
+# rewrites the contribution into one new commit, so the branch's own commits are
+# never ancestors of `main`. `git merge-base --is-ancestor <evidence> origin/main`
+# is therefore false for every CORRECTLY merged task, and a gate built on it
+# would fail everything while passing nothing — an acceptance check no correct
+# task can satisfy. The same reasoning rules out `git rev-list --count`.
+#
+# Why this does NOT match commit messages. `git log --grep=<TASK-ID>` is unsound
+# in both directions: it misses work that landed without naming its id, and it
+# reports work as landed when an unrelated commit merely mentions the id (an
+# observed case: `main` carried "... (tracked as TUNE-0321)" while the TUNE-0321
+# work was absent).
+#
+# What it asserts instead — CONTENT reachability, which squash-merge preserves:
+#
+#   1. Every file the branch ADDS is present in `origin/main`, matched by blob
+#      content or by basename (so a landing under a renamed path still passes).
+#   2. Every substantive line the branch ADDS to a file that already existed is
+#      findable in the `origin/main` tree. This is what catches a branch whose
+#      `--diff-filter=A` count is zero because it only modified files — a shape
+#      that added-file counting reports as clean while the work is unmerged.
+#
+# Usage:
+#   closure-gate.sh --root <dir> --branch <name> [--task <ID>] [--base <ref>]
+#                   [--max-lines <n>] [--quiet]
+#
+# Exit codes:
+#   0  work is present in the base ref — closure may proceed
+#   1  work is absent — the task must not be marked `done`
+#   2  usage / environment error (also the fail-closed path when the base ref
+#      cannot be resolved: an unresolvable base is never treated as "clean")
+#
+# Security: S1 strict mode, all expansions quoted, no eval, argv validated.
+
+set -euo pipefail
+
+ROOT="$PWD"
+BRANCH=""
+TASK=""
+BASE="origin/main"
+MAX_LINES=400
+QUIET=0
+
+die_usage() { printf 'closure-gate: %s\n' "$1" >&2; exit 2; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --root)      ROOT="${2:-}";      shift 2 || die_usage "--root needs a value" ;;
+    --branch)    BRANCH="${2:-}";    shift 2 || die_usage "--branch needs a value" ;;
+    --task)      TASK="${2:-}";      shift 2 || die_usage "--task needs a value" ;;
+    --base)      BASE="${2:-}";      shift 2 || die_usage "--base needs a value" ;;
+    --max-lines) MAX_LINES="${2:-}"; shift 2 || die_usage "--max-lines needs a value" ;;
+    --quiet)     QUIET=1; shift ;;
+    -h|--help)   sed -n '2,45p' "$0"; exit 0 ;;
+    *)           die_usage "unknown argument: $1" ;;
+  esac
+done
+
+[ -n "$BRANCH" ] || die_usage "--branch is required"
+[ -d "$ROOT" ]   || die_usage "--root is not a directory: $ROOT"
+case "$MAX_LINES" in (*[!0-9]*|'') die_usage "--max-lines must be a positive integer" ;; esac
+
+git -C "$ROOT" rev-parse --git-dir >/dev/null 2>&1 || die_usage "not a git repository: $ROOT"
+
+# Fail CLOSED: an unresolvable base ref must never read as "everything landed".
+git -C "$ROOT" rev-parse --verify --quiet "$BASE" >/dev/null \
+  || die_usage "cannot resolve base ref '$BASE' — refusing to certify closure against an unknown base"
+git -C "$ROOT" rev-parse --verify --quiet "$BRANCH" >/dev/null \
+  || die_usage "cannot resolve branch '$BRANCH'"
+
+MB="$(git -C "$ROOT" merge-base "$BASE" "$BRANCH" 2>/dev/null || true)"
+[ -n "$MB" ] || die_usage "no merge base between '$BASE' and '$BRANCH'"
+
+say() { [ "$QUIET" -eq 1 ] || printf '%s\n' "$*"; }
+
+MISSING_FILES=()
+MISSING_LINES=()
+
+# ---------------------------------------------------------------------------
+# 1. Files the branch ADDS must exist in the base, by blob or by basename.
+#
+# The base tree is materialised into two lookup files rather than piped into
+# `grep -q`. In a pipeline, `grep -q` exits at the first match and closes the
+# pipe; when the upstream producer still has more than a pipe buffer left to
+# write it dies with SIGPIPE, and `set -o pipefail` then reports a SUCCESSFUL
+# match as a failure. That defect reported two genuinely-landed gates as absent
+# and is covered by the large-base-tree regression test.
+# ---------------------------------------------------------------------------
+BASE_BLOBS="$(mktemp)"; BASE_NAMES="$(mktemp)"
+trap 'rm -f "$BASE_BLOBS" "$BASE_NAMES" "${CANDIDATES:-}"' EXIT
+
+git -C "$ROOT" ls-tree -r --format='%(objectname)' "$BASE" | sort -u > "$BASE_BLOBS"
+git -C "$ROOT" ls-tree -r --name-only "$BASE" > "$BASE_NAMES"
+
+# basename index, so a landing under a renamed directory still matches
+BASE_BASENAMES="$(mktemp)"
+trap 'rm -f "$BASE_BLOBS" "$BASE_NAMES" "$BASE_BASENAMES" "${CANDIDATES:-}"' EXIT
+sed 's|.*/||' "$BASE_NAMES" | sort -u > "$BASE_BASENAMES"
+
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+  blob="$(git -C "$ROOT" rev-parse "$BRANCH:$path" 2>/dev/null || true)"
+  if [ -n "$blob" ] && grep -qxF -- "$blob" "$BASE_BLOBS"; then
+    continue                                   # identical content is in the base
+  fi
+  if grep -qxF -- "${path##*/}" "$BASE_BASENAMES"; then
+    continue                                   # landed under a renamed directory
+  fi
+  MISSING_FILES+=("$path")
+done < <(git -C "$ROOT" diff --diff-filter=A --name-only "$MB..$BRANCH" 2>/dev/null || true)
+
+# ---------------------------------------------------------------------------
+# 2. Substantive lines the branch ADDS to pre-existing files must be findable.
+# ---------------------------------------------------------------------------
+CANDIDATES="$(mktemp)"
+trap 'rm -f "$BASE_BLOBS" "$BASE_NAMES" "$BASE_BASENAMES" "$CANDIDATES"' EXIT
+
+while IFS= read -r path; do
+  [ -n "$path" ] || continue
+  git -C "$ROOT" diff --diff-filter=M -U0 "$MB..$BRANCH" -- "$path" 2>/dev/null \
+    | grep '^+' | grep -v '^+++' | sed 's/^+//' \
+    | sed 's/^[[:space:]]*//; s/[[:space:]]*$//' \
+    | awk -v p="$path" 'length($0) >= 12 && $0 !~ /^[[:punct:][:space:]]*$/ { print p "\t" $0 }'
+done < <(git -C "$ROOT" diff --diff-filter=M --name-only "$MB..$BRANCH" 2>/dev/null || true) \
+  | sort -u -t$'\t' -k2 > "$CANDIDATES"
+
+TOTAL_CAND="$(wc -l < "$CANDIDATES" | tr -d ' ')"
+CHECKED=0
+while IFS=$'\t' read -r path line; do
+  [ -n "$line" ] || continue
+  if [ "$CHECKED" -ge "$MAX_LINES" ]; then break; fi
+  CHECKED=$((CHECKED + 1))
+  if ! git -C "$ROOT" grep -qF -- "$line" "$BASE" 2>/dev/null; then
+    MISSING_LINES+=("$path	$line")
+  fi
+done < "$CANDIDATES"
+
+# ---------------------------------------------------------------------------
+# Verdict
+# ---------------------------------------------------------------------------
+label="${TASK:-$BRANCH}"
+
+if [ "${#MISSING_FILES[@]}" -eq 0 ] && [ "${#MISSING_LINES[@]}" -eq 0 ]; then
+  say "closure-gate: PASS — all content from '$BRANCH' is present in '$BASE' ($label)"
+  [ "$TOTAL_CAND" -gt "$CHECKED" ] && \
+    say "closure-gate: note — checked $CHECKED of $TOTAL_CAND candidate lines (--max-lines $MAX_LINES)"
+  exit 0
+fi
+
+say "closure-gate: FAIL — work claimed by $label is NOT present in '$BASE'."
+say "closure-gate: this task must not be marked \`done\`."
+say ""
+
+if [ "${#MISSING_FILES[@]}" -gt 0 ]; then
+  say "Files added on '$BRANCH' and absent from '$BASE' (${#MISSING_FILES[@]}):"
+  for f in "${MISSING_FILES[@]}"; do say "  $f"; done
+  say ""
+fi
+
+if [ "${#MISSING_LINES[@]}" -gt 0 ]; then
+  say "Lines added to pre-existing files and absent from '$BASE' (${#MISSING_LINES[@]}):"
+  n=0
+  for entry in "${MISSING_LINES[@]}"; do
+    n=$((n + 1)); [ "$n" -gt 20 ] && { say "  ... and $(( ${#MISSING_LINES[@]} - 20 )) more"; break; }
+    say "  ${entry%%	*}: $(printf '%s' "${entry#*	}" | cut -c1-100)"
+  done
+  say ""
+fi
+
+if [ "$TOTAL_CAND" -gt "$CHECKED" ]; then
+  say "closure-gate: note — checked $CHECKED of $TOTAL_CAND candidate lines (--max-lines $MAX_LINES);"
+  say "              the reported set is therefore a lower bound, not the full residue."
+fi
+
+exit 1

--- a/dev-tools/tests/closure-gate.bats
+++ b/dev-tools/tests/closure-gate.bats
@@ -1,0 +1,195 @@
+#!/usr/bin/env bats
+# closure-gate.bats — a task must not be markable `done` while the work it
+# claims is absent from canonical `origin/main`.
+#
+# Derived from the TUNE-0541 sweep, in which 22 backlog entries read `done`
+# while every one of them had unmerged content. Each scenario below is a shape
+# actually observed in that sweep.
+
+setup() {
+  GATE="${BATS_TEST_DIRNAME}/../closure-gate.sh"
+  TMP="$(mktemp -d)"
+  export GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null
+  REPO="$TMP/repo"
+  mkdir -p "$REPO"
+  git -C "$REPO" init -q -b main
+  git -C "$REPO" config user.email t@example.invalid
+  git -C "$REPO" config user.name tester
+  git -C "$REPO" config commit.gpgsign false
+
+  mkdir -p "$REPO/dev-tools"
+  printf 'base\n' > "$REPO/base.txt"
+  printf '#!/bin/sh\necho existing\n' > "$REPO/dev-tools/existing.sh"
+  git -C "$REPO" add -A
+  git -C "$REPO" commit -qm "base"
+
+  # a stand-in for origin/main that the gate can resolve without a network
+  git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+}
+
+teardown() { rm -rf "$TMP"; }
+
+# advance origin/main by one commit, so the branch is never simply "main"
+advance_main() {
+  git -C "$REPO" checkout -q main
+  printf 'unrelated\n' >> "$REPO/base.txt"
+  git -C "$REPO" commit -qam "unrelated main advance"
+  git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+}
+
+# ---------------------------------------------------------------------------
+# FAIL shapes — work is genuinely absent from main
+# ---------------------------------------------------------------------------
+
+@test "fails when the branch adds a file main lacks (TUNE-0191 shape)" {
+  git -C "$REPO" checkout -qb feat
+  printf '#!/bin/sh\necho gate\n' > "$REPO/dev-tools/check-frontmatter-mirror.sh"
+  git -C "$REPO" add -A
+  git -C "$REPO" commit -qm "feat: add mirror gate"
+  advance_main
+
+  run "$GATE" --root "$REPO" --branch feat
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"check-frontmatter-mirror.sh"* ]]
+}
+
+@test "fails when the branch only MODIFIES a file and that content is absent (TUNE-0153/0367/0385 shape)" {
+  # the shape the brief misread as landed: --diff-filter=A yields zero
+  git -C "$REPO" checkout -qb feat
+  printf 'BRAND_HYGIENE_POLICY_MARKER\n' >> "$REPO/dev-tools/existing.sh"
+  git -C "$REPO" commit -qam "feat: brand-hygiene policy"
+  advance_main
+
+  run "$GATE" --root "$REPO" --branch feat
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"BRAND_HYGIENE_POLICY_MARKER"* ]]
+}
+
+@test "added-file count alone would pass the modify-only shape — the gate must not rely on it" {
+  git -C "$REPO" checkout -qb feat
+  printf 'BRAND_HYGIENE_POLICY_MARKER\n' >> "$REPO/dev-tools/existing.sh"
+  git -C "$REPO" commit -qam "feat: brand-hygiene policy"
+  advance_main
+
+  # the naive signal the brief used, asserted red so the fixture stays honest
+  added="$(git -C "$REPO" diff --diff-filter=A --name-only origin/main..feat | wc -l)"
+  [ "$added" -eq 0 ]
+
+  run "$GATE" --root "$REPO" --branch feat
+  [ "$status" -eq 1 ]
+}
+
+@test "fails when main merely MENTIONS the task id without carrying the work (TUNE-0321 shape)" {
+  git -C "$REPO" checkout -qb feat
+  printf 'ECONOMICS_RESILIENCE_MARKER\n' >> "$REPO/dev-tools/existing.sh"
+  git -C "$REPO" commit -qam "feat(TUNE-0321): economics resilience"
+
+  # main gains an unrelated commit whose message forward-references the id
+  git -C "$REPO" checkout -q main
+  printf 'other\n' >> "$REPO/base.txt"
+  git -C "$REPO" commit -qam "feat: unrelated work (tracked as TUNE-0321)"
+  git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+
+  run "$GATE" --root "$REPO" --branch feat --task TUNE-0321
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"ECONOMICS_RESILIENCE_MARKER"* ]]
+}
+
+# ---------------------------------------------------------------------------
+# PASS shapes — work IS in main
+# ---------------------------------------------------------------------------
+
+@test "passes when the branch was SQUASH-merged (evidence commit unreachable by design)" {
+  # The decisive case. Datarim's main requires signed commits and merges via
+  # squash, so the branch's own commits are never ancestors of main. A gate
+  # asserting ancestry of the evidence sha fails every correctly merged task.
+  git -C "$REPO" checkout -qb feat
+  printf '#!/bin/sh\necho gate\n' > "$REPO/dev-tools/new-gate.sh"
+  printf 'MODIFIED_MARKER\n' >> "$REPO/dev-tools/existing.sh"
+  git -C "$REPO" add -A
+  git -C "$REPO" commit -qm "feat: new gate"
+  evidence="$(git -C "$REPO" rev-parse HEAD)"
+
+  git -C "$REPO" checkout -q main
+  git -C "$REPO" merge --squash feat >/dev/null 2>&1
+  git -C "$REPO" commit -qm "feat: new gate (#123)"
+  git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+
+  # the evidence commit is genuinely NOT an ancestor — the ancestry gate's premise
+  run git -C "$REPO" merge-base --is-ancestor "$evidence" origin/main
+  [ "$status" -ne 0 ]
+
+  # ...yet the content is present, so closure is legitimate
+  run "$GATE" --root "$REPO" --branch feat
+  [ "$status" -eq 0 ]
+}
+
+@test "passes on a LARGE base tree — no SIGPIPE false positive (regression)" {
+  # Regression for a pipefail + `grep -q` defect: `grep -q` exits on first match
+  # and closes the pipe, so an upstream `printf`/`awk` dies with SIGPIPE (141)
+  # and `set -o pipefail` reports the successful match as a failure. Small
+  # fixtures hide it because the whole stream fits in the pipe buffer; the bug
+  # only appears once the base tree is big enough to still be writing. Observed
+  # against the real repository, where two genuinely-landed gates
+  # (check-qa-verdict-blocked.sh, check-archive-sha-chain.sh) were reported absent.
+  # The remainder AFTER the matching path must exceed the 64 KB pipe buffer,
+  # otherwise the upstream process finishes writing before `grep -q` exits and
+  # no SIGPIPE occurs. `zzz/` sorts after `dev-tools/`, and the names are long
+  # on purpose: ~3000 paths of ~70 bytes is ~200 KB of post-match output.
+  mkdir -p "$REPO/zzz"
+  for i in $(seq 1 3000); do
+    printf 'filler\n' > "$REPO/zzz/a-rather-long-filler-path-name-component-$i.txt"
+  done
+  git -C "$REPO" add -A
+  git -C "$REPO" commit -qm "bulk"
+  git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+
+  git -C "$REPO" checkout -qb feat
+  printf 'CONTENT_V1\n' > "$REPO/dev-tools/landed-gate.sh"
+  git -C "$REPO" add -A
+  git -C "$REPO" commit -qm "feat: add gate"
+
+  # the gate lands on main under the same path but with later edits, so the
+  # blob differs and the basename branch of the check is what must succeed
+  git -C "$REPO" checkout -q main
+  printf 'CONTENT_V1\nCONTENT_V2_FOLLOWUP\n' > "$REPO/dev-tools/landed-gate.sh"
+  git -C "$REPO" add -A
+  git -C "$REPO" commit -qm "feat: add gate (#1) plus follow-up fix"
+  git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+
+  run "$GATE" --root "$REPO" --branch feat
+  [ "$status" -eq 0 ]
+}
+
+@test "passes when the work landed under a RENAMED path" {
+  git -C "$REPO" checkout -qb feat
+  printf 'RENAMED_CONTENT_MARKER\n' > "$REPO/dev-tools/old-name.sh"
+  git -C "$REPO" add -A
+  git -C "$REPO" commit -qm "feat: add tool"
+
+  git -C "$REPO" checkout -q main
+  printf 'RENAMED_CONTENT_MARKER\n' > "$REPO/dev-tools/new-name.sh"
+  git -C "$REPO" add -A
+  git -C "$REPO" commit -qm "feat: add tool under final name"
+  git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+
+  run "$GATE" --root "$REPO" --branch feat
+  [ "$status" -eq 0 ]
+}
+
+# ---------------------------------------------------------------------------
+# Contract
+# ---------------------------------------------------------------------------
+
+@test "usage error when --branch is absent" {
+  run "$GATE" --root "$REPO"
+  [ "$status" -eq 2 ]
+}
+
+@test "fails closed when origin/main cannot be resolved" {
+  git -C "$REPO" checkout -qb feat
+  git -C "$REPO" update-ref -d refs/remotes/origin/main
+  run "$GATE" --root "$REPO" --branch feat
+  [ "$status" -eq 2 ]
+  [[ "$output" == *"origin/main"* ]]
+}


### PR DESCRIPTION
Closes the mechanism gap behind TUNE-0541: 22 backlog entries read `done` while
none of their work was in `origin/main`.

## The hole

`/dr-archive` Step 0.12 asserts that local commits reached **the remote**. It does
not assert that the work reached the **canonical default branch**. A pushed feature
branch whose pull request was never opened satisfies 0.12 completely. Every one of
the 22 recorded `await ... signed-push+PR` as its evidence, so all 22 passed the
gate that existed.

## What this adds

`dev-tools/closure-gate.sh` asserts **content reachability** from `origin/main`,
plus Step 0.13 in `commands/dr-archive.md` invoking it, failing closed.

Three tempting designs are deliberately rejected, each with a test:

- **Ancestry of the evidence commit.** `main` merges by squash, so a branch's own
  commits are never ancestors of `main`. `merge-base --is-ancestor` is false for
  every *correctly* merged task — that gate would block everything and catch
  nothing.
- **Commit-message matching.** Unsound in both directions: it misses work that
  landed without naming its id, and reports work as landed when an unrelated
  commit merely mentions it. Observed: `main` carried "(tracked as TUNE-0321)"
  while the TUNE-0321 work was absent.
- **Added-file counts.** `--diff-filter=A` counts only additions, so a branch that
  only modifies files reports zero while its work is unmerged. Three of the 22 have
  exactly this shape.

## Validation on real data

- 22/22 orphaned branches → FAIL (correctly blocked)
- 5/5 branches whose work did land → PASS (no false positives)
- 9/9 bats green; shellcheck clean

## A defect the unit tests did not catch

The first implementation reported two genuinely-landed gates as absent. Cause: a
`pipefail` + `grep -q` interaction — `grep -q` exits at the first match and closes
the pipe, the upstream producer dies with SIGPIPE, and `pipefail` turns a
successful match into a failure. Small fixtures cannot reproduce it because the
whole stream fits in the pipe buffer; only the real 1000-file tree exposed it.
The regression test now sizes the post-match remainder past the buffer, and was
confirmed red against the old code before the fix.

`public-surface-lint.sh` reports 118 pre-existing failures on `origin/main`
unchanged by this branch; none are in these files.
