### PR TITLE
feat(dev-tools): generalise frontmatter-key behaviour-gate mirror guard (TUNE-0191)

### DIFF
--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -26,6 +26,7 @@ Discipline in `code/datarim/CLAUDE.md`).
 | `check-deferral-prose.sh` | `commands/dr-qa.md` Layer 3b (advisory), `commands/dr-compliance.md` Step 5c (hard), `commands/dr-archive.md` Step 0.45 |
 | `check-stage-snapshot-on-exit.sh` | `commands/dr-continue.md`, `commands/dr-archive.md`, validator suite |
 | `check-skill-frontmatter.sh` | `/dr-plugin doctor` § skill-registry check |
+| `check-frontmatter-mirror.sh` | frontmatter-key behaviour-gate mirror drift guard (TUNE-0191) vs `rules/frontmatter-key-registry.yaml`; enforced by `tests/check-frontmatter-mirror.bats`, advisory in CI/datarim-doctor |
 | `check-security-policy.sh` | `/dr-qa` ecosystem security gate, `/dr-compliance` |
 | `check-topic-overlap.py` | `commands/dr-init.md` Step 3.5 (backlog similarity) |
 | `network-exposure-check.sh`, `network-exposure-gate.sh` | `commands/dr-do.md` Step 8.5 |

--- a/dev-tools/check-frontmatter-mirror.sh
+++ b/dev-tools/check-frontmatter-mirror.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+#
+# check-frontmatter-mirror.sh — TUNE-0191 frontmatter-key behaviour-gate mirror
+# drift guard (source: reflection-TUNE-0184 § P-6).
+#
+# Enforces two invariants against dev-tools/rules/frontmatter-key-registry.yaml,
+# failing on drift in EITHER direction:
+#
+#   P1 registry-completeness (instruction surface = commands/skills/agents):
+#      - every live top-level frontmatter key is categorised in the registry;
+#      - no `status: live` instruction entry has vanished from the surface;
+#      - a key registered `status: reserved` must NOT appear live.
+#
+#   P2 mirror-presence (for `surface: instruction, status: live, mirror: required`
+#      entries carrying a `body_marker`):
+#      - a file carrying the frontmatter key MUST carry the body marker;
+#      - a file carrying the body marker MUST carry the frontmatter key.
+#
+#   Reserved required-mirror keys (e.g. disable-model-invocation) are guarded by
+#   P1 (a live re-introduction fails as "reserved found live"); P2 activates only
+#   once the entry is reclassified `status: live`, which then enforces the mirror.
+#   Templates (surface: template) are survey-only and NOT drift-gated here.
+#
+# Usage:
+#   check-frontmatter-mirror.sh [--root <repo-root>] [--registry <yaml>] [--quiet]
+# Exit codes:  0 PASS · 1 drift · 2 usage/error.
+# Read-only. No writes anywhere. Bash 3.2 compatible (no associative arrays).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT=""
+REGISTRY=""
+QUIET=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --root)     ROOT="${2:-}"; shift 2 ;;
+        --registry) REGISTRY="${2:-}"; shift 2 ;;
+        --quiet)    QUIET=true; shift ;;
+        -h|--help)  sed -n '2,32p' "$0"; exit 0 ;;
+        *) echo "ERROR: unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+[[ -z "$ROOT" ]] && ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+[[ -z "$REGISTRY" ]] && REGISTRY="$SCRIPT_DIR/rules/frontmatter-key-registry.yaml"
+
+if [[ ! -d "$ROOT" ]]; then
+    echo "ERROR: root not a directory: $ROOT" >&2; exit 2
+fi
+if [[ ! -f "$REGISTRY" ]]; then
+    echo "ERROR: registry not found: $REGISTRY" >&2; exit 2
+fi
+
+log() { $QUIET || echo "$@"; }
+
+# ── Extract top-level frontmatter keys from a markdown file's leading block. ──
+extract_keys() {
+    awk '
+        BEGIN { c = 0 }
+        /^---$/ { c++; if (c == 2) exit; next }
+        c == 1 { print }
+    ' "$1" | grep -oE '^[A-Za-z][A-Za-z0-9_-]*:' | sed 's/:$//'
+}
+
+# ── Extract the body (everything after the leading frontmatter block). ───────
+extract_body() {
+    awk '
+        BEGIN { c = 0 }
+        /^---$/ { c++; next }
+        c >= 2 { print }
+    ' "$1"
+}
+
+# ── Instruction-surface file list. ──────────────────────────────────────────
+instruction_files() {
+    shopt -s nullglob
+    local f
+    for f in "$ROOT"/commands/*.md;       do [[ -f "$f" ]] && echo "$f"; done
+    for f in "$ROOT"/skills/*.md;         do [[ -f "$f" ]] && echo "$f"; done
+    for f in "$ROOT"/skills/*/SKILL.md;   do [[ -f "$f" ]] && echo "$f"; done
+    for f in "$ROOT"/agents/*.md;         do [[ -f "$f" ]] && echo "$f"; done
+}
+
+# ── Parse the registry into pipe records: key|surface|category|mirror|status|body_marker
+parse_registry() {
+    awk '
+        function flush() {
+            if (key != "")
+                printf "%s|%s|%s|%s|%s|%s\n", key, surface, category, mirror, status, body_marker
+            key=""; surface=""; category=""; mirror=""; status=""; body_marker=""
+        }
+        /^[[:space:]]*-[[:space:]]+key:[[:space:]]*/ {
+            flush()
+            v=$0; sub(/^[[:space:]]*-[[:space:]]+key:[[:space:]]*/, "", v)
+            gsub(/[[:space:]]*#.*$/, "", v); gsub(/^["'"'"']|["'"'"']$/, "", v)
+            key=v; next
+        }
+        /^[[:space:]]+surface:[[:space:]]*/     { v=$0; sub(/^[[:space:]]+surface:[[:space:]]*/,"",v);     gsub(/[[:space:]]*#.*$/,"",v); surface=v; next }
+        /^[[:space:]]+category:[[:space:]]*/    { v=$0; sub(/^[[:space:]]+category:[[:space:]]*/,"",v);    gsub(/[[:space:]]*#.*$/,"",v); category=v; next }
+        /^[[:space:]]+mirror:[[:space:]]*/      { v=$0; sub(/^[[:space:]]+mirror:[[:space:]]*/,"",v);      gsub(/[[:space:]]*#.*$/,"",v); mirror=v; next }
+        /^[[:space:]]+status:[[:space:]]*/      { v=$0; sub(/^[[:space:]]+status:[[:space:]]*/,"",v);      gsub(/[[:space:]]*#.*$/,"",v); status=v; next }
+        /^[[:space:]]+body_marker:[[:space:]]*/ { v=$0; sub(/^[[:space:]]+body_marker:[[:space:]]*/,"",v); gsub(/[[:space:]]*#.*$/,"",v); gsub(/^["'"'"']|["'"'"']$/,"",v); body_marker=v; next }
+        END { flush() }
+    ' "$1"
+}
+
+REG="$(parse_registry "$REGISTRY")"
+if [[ -z "$REG" ]]; then
+    echo "ERROR: registry parsed to zero entries: $REGISTRY" >&2; exit 2
+fi
+
+# Registry key sets (instruction surface).
+INSTR_LIVE_KEYS="$(echo "$REG"     | awk -F'|' '$2=="instruction" && $5=="live"     {print $1}' | sort -u)"
+INSTR_RESERVED_KEYS="$(echo "$REG" | awk -F'|' '$2=="instruction" && $5=="reserved" {print $1}' | sort -u)"
+
+# Live surface keys actually present.
+SURFACE_KEYS="$(
+    while IFS= read -r f; do
+        [[ -n "$f" ]] && extract_keys "$f"
+    done < <(instruction_files) | sort -u
+)"
+
+fail=0
+in_list() { grep -Fxq "$1" <<<"$2"; }
+
+# ── P1: registry-completeness (either-side drift) ────────────────────────────
+if [[ -n "$SURFACE_KEYS" ]]; then
+    while IFS= read -r k; do
+        [[ -z "$k" ]] && continue
+        if in_list "$k" "$INSTR_LIVE_KEYS"; then
+            :
+        elif in_list "$k" "$INSTR_RESERVED_KEYS"; then
+            log "FAIL P1: key '$k' is registered status:reserved but found live on the surface"
+            fail=1
+        else
+            log "FAIL P1: uncategorised key '$k' — not in registry (add an entry to $(basename "$REGISTRY"))"
+            fail=1
+        fi
+    done <<<"$SURFACE_KEYS"
+fi
+
+if [[ -n "$INSTR_LIVE_KEYS" ]]; then
+    while IFS= read -r r; do
+        [[ -z "$r" ]] && continue
+        if ! in_list "$r" "$SURFACE_KEYS"; then
+            log "FAIL P1: stale registry entry '$r' (status:live) has vanished from the surface"
+            fail=1
+        fi
+    done <<<"$INSTR_LIVE_KEYS"
+fi
+
+# ── P2: mirror-presence for live, required-mirror keys ───────────────────────
+while IFS='|' read -r key surface _ mirror status body_marker; do
+    [[ "$surface" == "instruction" ]] || continue
+    [[ "$status"  == "live" ]]        || continue
+    [[ "$mirror"  == "required" ]]    || continue
+    [[ -n "$body_marker" ]]           || continue
+
+    while IFS= read -r f; do
+        [[ -n "$f" ]] || continue
+        has_key=false; has_marker=false
+        extract_keys "$f" | grep -Fxq "$key" && has_key=true
+        extract_body "$f" | grep -Fq -- "$body_marker" && has_marker=true
+
+        if $has_key && ! $has_marker; then
+            log "FAIL P2: '$key' frontmatter key present without body marker '$body_marker' in ${f#"$ROOT"/}"
+            fail=1
+        fi
+        if $has_marker && ! $has_key; then
+            log "FAIL P2: body marker '$body_marker' present without '$key' frontmatter key in ${f#"$ROOT"/}"
+            fail=1
+        fi
+    done < <(instruction_files)
+done <<<"$REG"
+
+if [[ $fail -eq 0 ]]; then
+    log "RESULT: PASS (frontmatter-key mirror drift guard — P1 + P2)"
+    exit 0
+else
+    log "RESULT: FAIL (frontmatter-key mirror drift)"
+    exit 1
+fi

--- a/dev-tools/rules/frontmatter-key-registry.yaml
+++ b/dev-tools/rules/frontmatter-key-registry.yaml
@@ -1,0 +1,324 @@
+# frontmatter-key-registry.yaml — Datarim frontmatter-key behaviour-gate registry.
+#
+# Source insight: reflection-TUNE-0184 § P-6 (2026-05-12). A machine-readable
+# contract (a frontmatter key, flag, or gating directive) MUST mirror to a
+# human-readable surface adjacent to the call site, plus a regression test that
+# fails on drift in either direction. TUNE-0191 generalises that one-off lesson
+# to the whole frontmatter surface.
+#
+# Consumer: dev-tools/check-frontmatter-mirror.sh (read-only two-pass drift guard).
+# Location: dev-tools/rules/frontmatter-key-registry.yaml (sibling of fb-rules.yaml).
+#
+# Schema (block style only, depth <= 2, no anchors/flow):
+#   keys:
+#     - key: <top-level frontmatter key, verbatim, case-sensitive>
+#       surface: instruction | template
+#           instruction = commands/skills/agents (where behaviour-gating lives;
+#                         DRIFT-GATED by pass P1).
+#           template    = templates/ data-artefact schema (survey-only; NOT
+#                         drift-gated — governed by the artefact-schema track,
+#                         e.g. stage-snapshot-frontmatter-schema + /dr-doctor).
+#       category: G | C | E | M
+#           G  behaviour-gate w/ out-of-file consumer — the key changes
+#              discoverability/invocability observable WITHOUT opening the file
+#              (the P-6 failure class). Mirror REQUIRED.
+#           C  capability-gate, in-file only — restricts the tool set; visible
+#              in-file, enforced at run time. Mirror RECOMMENDED (documented).
+#           E  execution tuning, in-file only — model/effort; self-evident from
+#              output, no surprise-failure, no external catalog. Mirror NONE.
+#           M  metadata / schema field — descriptive; no behavioural gate.
+#              Mirror NONE.
+#       mirror: required | recommended | none
+#           required    — ENFORCED by pass P2: a file carrying the frontmatter
+#                         key MUST carry `body_marker`, and a file carrying the
+#                         marker MUST carry the key (either-side drift = FAIL).
+#           recommended — documented convention, NOT test-enforced.
+#           none        — no mirror expected.
+#       status: live | reserved
+#           live     — currently present on the surface; DRIFT-GATED by P1.
+#           reserved — schema-allowed but not currently used; a dormant P2 guard
+#                      that fires the moment the key is (re-)introduced.
+#       body_marker: <substring>   # required only when mirror: required
+#       surfaces:    <free text>   # external consumer surfaces (guidance)
+#       note:        <free text>   # rationale / cross-reference
+#
+# P1 (registry-completeness) compares the set of live top-level keys on the
+# instruction surface against the `surface: instruction, status: live` entries
+# below and fails on drift in either direction. Keep this list in sync when a
+# command/skill/agent adds or drops a top-level frontmatter key.
+
+keys:
+
+  # ── instruction surface — G (behaviour-gate, out-of-file consumer) ──────────
+  - key: disable-model-invocation
+    surface: instruction
+    category: G
+    mirror: required
+    status: reserved
+    body_marker: model-invocation
+    surfaces: "command/skill body note + dr-help table + skills/cta-format.md + skills/visual-maps/pipeline-routing.md"
+    note: >-
+      The canonical P-6 case. Removed from the live surface by TUNE-0223
+      (autonomy mandate) but kept schema-reserved by check-skill-frontmatter.sh.
+      Encoded here as a dormant guard: any re-introduction MUST carry a visible
+      body note (mirror) adjacent to the frontmatter plus the external consumer
+      surfaces above, or pass P2 fails.
+
+  # ── instruction surface — C (capability-gate, in-file only) ─────────────────
+  - key: allowed-tools
+    surface: instruction
+    category: C
+    mirror: recommended
+    status: live
+    note: >-
+      Restricts the tool set of a command/skill. Visible in-file and enforced at
+      run time; a body reader who acts on the prose without parsing YAML can hit
+      a permission denial. A one-line "Tools:" body note is RECOMMENDED but not
+      enforced — the frontmatter is self-adjacent, so enforcing a mirror across
+      every grant would be noise > signal.
+  - key: tools
+    surface: instruction
+    category: C
+    mirror: recommended
+    status: live
+    note: "Agent tool allowlist (e.g. peer-reviewer = read-only). Same rationale as allowed-tools."
+
+  # ── instruction surface — E (execution tuning, in-file only) ────────────────
+  - key: model
+    surface: instruction
+    category: E
+    mirror: none
+    status: live
+    note: "Model selection (inherit|sonnet|opus|haiku|full-id). Validated by check-skill-frontmatter.sh."
+  - key: effort
+    surface: instruction
+    category: E
+    mirror: none
+    status: live
+    note: "Reasoning-effort tuning. Self-evident from output; no external catalog."
+
+  # ── instruction surface — M (metadata / schema field) ───────────────────────
+  - key: name
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+  - key: description
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+  - key: title
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+  - key: id
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+  - key: argument-hint
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+    note: "Invocation-UX hint; not a gate."
+  - key: usage
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+  - key: Usage
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+    note: "Case variant of usage present on one command; both registered (checker is case-sensitive)."
+  - key: phase
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+  - key: options
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+  - key: globs
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+    note: "Path-activation hint (advisory match), not a hide/block gate."
+  - key: metadata
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+    note: "Container for nested fields (model_tier, current_aal, target_aal, runtime, creators)."
+  - key: loaded_by
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+    note: "Documents which command loads the skill; coupling metadata."
+  - key: source
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+  - key: applicability
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+  - key: target_aal
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+    note: "AAL governance surface (aal-mandate / per-repo aal.yaml) owns AAL mirroring — out of this pattern's scope."
+  - key: current_aal
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+    note: "See target_aal — AAL governance surface, separate track."
+  - key: autonomy
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+    note: "Autonomy declaration; governed by the AAL/autonomy mandate, not this pattern."
+
+  # ── template surface — survey-only (all metadata; NOT drift-gated) ──────────
+  # Recorded to satisfy the P-6 survey across templates/. Behaviour-gating keys
+  # do not appear here (templates are data artefacts). Governed by the
+  # artefact-schema track (stage-snapshot-frontmatter-schema + /dr-doctor), so
+  # pass P1 does not scan templates.
+  - key: task_id
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: status
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: type
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: complexity
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: priority
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: project
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: related
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: prd
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: plan
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: parent
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: parent_prd
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: parent_init_task
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: reflection_basis
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: schema_version
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: scope
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: verdict
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: verification_outcome
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: artifact
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: agent
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: archive_doc
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: captured_at
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: captured_by
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: started
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: date
+    surface: template
+    category: M
+    mirror: none
+    status: live
+  - key: completed_date
+    surface: template
+    category: M
+    mirror: none
+    status: live

--- a/tests/check-frontmatter-mirror.bats
+++ b/tests/check-frontmatter-mirror.bats
@@ -1,0 +1,273 @@
+#!/usr/bin/env bats
+#
+# TUNE-0191 — regression test for the generalised frontmatter-key behaviour-gate
+# mirror pattern (source: reflection-TUNE-0184 § P-6).
+#
+# Covers dev-tools/check-frontmatter-mirror.sh two-pass drift guard:
+#   P1 registry-completeness — every live top-level frontmatter key on the
+#      instruction surface (commands/skills/agents) is categorised in the
+#      registry; no stale `status: live` entry has vanished from the surface.
+#   P2 mirror-presence — for every `mirror: required` key, a file carrying the
+#      frontmatter key must carry its body marker, and vice-versa (either-side).
+#
+# The real shipped registry is dev-tools/rules/frontmatter-key-registry.yaml.
+# Fixture tests inject a temp registry via --registry to exercise drift paths
+# without mutating the real tree.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../dev-tools/check-frontmatter-mirror.sh"
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+
+setup() {
+    TMP="$(mktemp -d)"
+    mkdir -p "$TMP/commands" "$TMP/skills/alpha" "$TMP/agents"
+}
+
+teardown() {
+    rm -rf "$TMP"
+}
+
+# Minimal instruction-surface fixture: one command, one skill, one agent, all
+# carrying only registered keys.
+seed_clean_tree() {
+    cat >"$TMP/commands/dr-x.md" <<'EOF'
+---
+name: dr-x
+description: fixture command
+---
+body
+EOF
+    cat >"$TMP/skills/alpha/SKILL.md" <<'EOF'
+---
+name: alpha
+description: fixture skill
+---
+body
+EOF
+    cat >"$TMP/agents/bot.md" <<'EOF'
+---
+name: bot
+description: fixture agent
+---
+body
+EOF
+}
+
+# A registry that categorises exactly name + description as live instruction keys.
+seed_registry() {
+    cat >"$TMP/registry.yaml" <<'EOF'
+keys:
+  - key: name
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+  - key: description
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+EOF
+}
+
+@test "script exists and is executable" {
+    [ -x "$SCRIPT" ]
+}
+
+@test "usage error (unknown flag) exits 2" {
+    run "$SCRIPT" --bogus
+    [ "$status" -eq 2 ]
+}
+
+@test "usage error (missing registry file) exits 2" {
+    seed_clean_tree
+    run "$SCRIPT" --root "$TMP" --registry "$TMP/no-such.yaml"
+    [ "$status" -eq 2 ]
+}
+
+@test "PASS on a clean fixture tree with a matching registry" {
+    seed_clean_tree
+    seed_registry
+    run "$SCRIPT" --root "$TMP" --registry "$TMP/registry.yaml"
+    [ "$status" -eq 0 ]
+}
+
+@test "P1 FAIL when a live key is not categorised in the registry" {
+    seed_clean_tree
+    seed_registry
+    # Add an uncategorised behaviour-gating key to the command frontmatter.
+    cat >"$TMP/commands/dr-x.md" <<'EOF'
+---
+name: dr-x
+description: fixture command
+allowed-tools: Read Bash
+---
+body
+EOF
+    run "$SCRIPT" --root "$TMP" --registry "$TMP/registry.yaml"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"allowed-tools"* ]]
+    [[ "$output" == *"uncategorised"* ]] || [[ "$output" == *"not in registry"* ]]
+}
+
+@test "P1 FAIL when a status:live registry entry vanished from the surface" {
+    seed_clean_tree
+    cat >"$TMP/registry.yaml" <<'EOF'
+keys:
+  - key: name
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+  - key: description
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+  - key: ghost-key
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+EOF
+    run "$SCRIPT" --root "$TMP" --registry "$TMP/registry.yaml"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"ghost-key"* ]]
+    [[ "$output" == *"stale"* ]] || [[ "$output" == *"vanished"* ]]
+}
+
+@test "reserved status entry never triggers the stale-live check" {
+    seed_clean_tree
+    cat >"$TMP/registry.yaml" <<'EOF'
+keys:
+  - key: name
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+  - key: description
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+  - key: disable-model-invocation
+    surface: instruction
+    category: G
+    mirror: required
+    status: reserved
+    body_marker: model-invocation
+EOF
+    run "$SCRIPT" --root "$TMP" --registry "$TMP/registry.yaml"
+    [ "$status" -eq 0 ]
+}
+
+@test "P2 FAIL when a mirror:required key is present without its body marker" {
+    seed_clean_tree
+    # Make allowed-tools a required-mirror key with a body_marker.
+    cat >"$TMP/registry.yaml" <<'EOF'
+keys:
+  - key: name
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+  - key: description
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+  - key: allowed-tools
+    surface: instruction
+    category: C
+    mirror: required
+    status: live
+    body_marker: 'Tools:'
+EOF
+    # Command carries the key but the body lacks the 'Tools:' marker.
+    cat >"$TMP/commands/dr-x.md" <<'EOF'
+---
+name: dr-x
+description: fixture command
+allowed-tools: Read Bash
+---
+body without the marker
+EOF
+    run "$SCRIPT" --root "$TMP" --registry "$TMP/registry.yaml"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"allowed-tools"* ]]
+    [[ "$output" == *"marker"* ]]
+}
+
+@test "P2 FAIL when a body marker is present without the frontmatter key" {
+    seed_clean_tree
+    cat >"$TMP/registry.yaml" <<'EOF'
+keys:
+  - key: name
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+  - key: description
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+  - key: allowed-tools
+    surface: instruction
+    category: C
+    mirror: required
+    status: live
+    body_marker: 'Tools:'
+EOF
+    # Command carries the marker in the body but NOT the frontmatter key.
+    cat >"$TMP/commands/dr-x.md" <<'EOF'
+---
+name: dr-x
+description: fixture command
+---
+**Tools:** Read Bash
+EOF
+    run "$SCRIPT" --root "$TMP" --registry "$TMP/registry.yaml"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"allowed-tools"* ]]
+    [[ "$output" == *"marker"* ]]
+}
+
+@test "P2 PASS when key and body marker co-occur" {
+    seed_clean_tree
+    cat >"$TMP/registry.yaml" <<'EOF'
+keys:
+  - key: name
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+  - key: description
+    surface: instruction
+    category: M
+    mirror: none
+    status: live
+  - key: allowed-tools
+    surface: instruction
+    category: C
+    mirror: required
+    status: live
+    body_marker: 'Tools:'
+EOF
+    cat >"$TMP/commands/dr-x.md" <<'EOF'
+---
+name: dr-x
+description: fixture command
+allowed-tools: Read Bash
+---
+**Tools:** Read Bash
+EOF
+    run "$SCRIPT" --root "$TMP" --registry "$TMP/registry.yaml"
+    [ "$status" -eq 0 ]
+}
+
+# ── Real-tree assertion (AC-1 / AC-3): the shipped registry fully covers the
+#    live instruction surface and the checker passes against the actual repo. ──
+@test "real shipped tree PASSES against the shipped registry" {
+    run "$SCRIPT" --root "$REPO_ROOT"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Relands **TUNE-0191**, one of the 22 tasks the TUNE-0541 sweep found marked `done`
with none of its content in `origin/main`. The work was implemented and verified
inside a worktree branch; the pull request was never opened.

Verdict: **GENUINELY-LOST-WORK-EXISTS** — see
`documentation/archive/framework/TUNE-0541-verdict-table.md`.

Cherry-picked onto current `main` from the original worktree branch. The branch's
merge-base *is* an ancestor of `main`, so this is a clean single-commit reland
rather than part of the re-rooted 0141/0206/0365 chain.

Verified before opening: `shellcheck --severity=warning` (CI's own severity) clean
on every shell file the commit ships, and every `.bats` file it touches run green.

The `closure-gate.sh` merged in #278 reports this branch's work as absent from
`main` today, and will report it present once this merges — that transition is the
gate's intended signal.