### PR TITLE
feat(dr-orchestrate): typed kv forward from audit consumer to obs + compliance sinks

### DIFF
--- a/plugins/dr-orchestrate/scripts/fleet_audit_consumer.sh
+++ b/plugins/dr-orchestrate/scripts/fleet_audit_consumer.sh
@@ -13,6 +13,8 @@
 #   DR_FLEET_AUDIT_GROUP    Consumer group (default obs)
 #   DR_FLEET_AUDIT_CONSUMER Consumer name (default audit-consumer-1)
 #   DR_FLEET_BLOCK_MS       XREADGROUP block timeout ms (default 5000)
+#   DR_FLEET_METRICS_DIR    Obs metrics sink dir (default <plugin>/var/metrics)
+#   DR_FLEET_COMPLIANCE_DIR Compliance sink dir (default <plugin>/var/compliance)
 
 set -uo pipefail
 
@@ -27,6 +29,7 @@ AUDIT_SINK="$PLUGIN_DIR/scripts/audit_sink.sh"
 : "${DR_FLEET_AUDIT_CONSUMER:=audit-consumer-1}"
 : "${DR_FLEET_BLOCK_MS:=5000}"
 : "${DR_FLEET_METRICS_DIR:=$PLUGIN_DIR/var/metrics}"
+: "${DR_FLEET_COMPLIANCE_DIR:=$PLUGIN_DIR/var/compliance}"
 
 MODE="loop"
 
@@ -53,25 +56,76 @@ _check() {
 }
 
 _process_entry() {
-  # Forward one audit-log entry to the obs metrics sink (JSONL).
-  # Reason fields are redacted before persistence (PRD § Security).
-  # Full structured parsing (field-by-field kv extraction) is deferred;
-  # current implementation redacts the raw blob and appends it to the daily
-  # obs sink so the obs aggregator can pick it up on the next --snapshot run.
-  # pending full sink wiring: backlog item "audit-consumer: typed kv forward to obs/compliance"
-  # (Source: discovered-during-auto)
+  # Parse one audit-log entry and forward it as a typed schema-v2 event to the
+  # obs metrics sink and the compliance sink, then acknowledge it via XACK.
+  #
+  # `raw` is the flattened XREADGROUP output from bus_subscribe: redis-cli in
+  # non-tty mode emits one token per line — the stream key, the stream entry id
+  # (\d+-\d+), then alternating field / value lines (id, ts, type, task_id,
+  # reason, …). Reason material is redacted before persistence (PRD § Security).
   local raw="$1"
-  local redacted_raw
-  redacted_raw="$(redact_reason "$raw")"
 
-  local sink_file
-  sink_file="$DR_FLEET_METRICS_DIR/audit-consumer-$(date -u +%Y-%m-%d).jsonl"
-  mkdir -p "$DR_FLEET_METRICS_DIR"
-  emit "$sink_file" \
-    "{\"ts\":\"$(date -u +%FT%TZ)\",\"group\":\"$DR_FLEET_AUDIT_GROUP\",\"raw\":\"$redacted_raw\"}"
+  # Empty read (no pending entry) or mock placeholder — nothing to forward.
+  if [[ -z "$raw" || "$raw" == "(empty)" ]]; then
+    return 0
+  fi
 
-  printf 'AUDIT [%s] group=%s entry forwarded to obs sink\n' \
-    "$(date -u +%FT%TZ)" "$DR_FLEET_AUDIT_GROUP"
+  # Field-by-field kv extraction via a small state machine (no arithmetic, so
+  # it stays correct under `set -e` inherited from audit_sink.sh).
+  local entry_id="" f_id="" f_ts="" f_type="" f_task_id="" f_reason=""
+  local state="seek" key=""
+  local line
+  while IFS= read -r line; do
+    case "$state" in
+      seek)
+        # First \d+-\d+ line is the Redis stream entry id (used for XACK).
+        if [[ "$line" =~ ^[0-9]+-[0-9]+$ ]]; then
+          entry_id="$line"; state="key"
+        fi
+        ;;
+      key)
+        # A second entry-id line marks the next entry — process one at a time.
+        if [[ "$line" =~ ^[0-9]+-[0-9]+$ ]]; then
+          break
+        fi
+        key="$line"; state="val"
+        ;;
+      val)
+        case "$key" in
+          id)      f_id="$line" ;;
+          ts)      f_ts="$line" ;;
+          type)    f_type="$line" ;;
+          task_id) f_task_id="$line" ;;
+          reason)  f_reason="$line" ;;
+        esac
+        state="key"
+        ;;
+    esac
+  done <<< "$raw"
+
+  # No stream entry id parsed — malformed or empty batch, skip.
+  if [[ -z "$entry_id" ]]; then
+    return 0
+  fi
+
+  # Build the canonical schema-v2 envelope (make_event_v2 redacts `reason`),
+  # then enrich with the source provenance so the parsed id/ts/task_id survive.
+  local event
+  event="$(make_event_v2 "" "audit-forward" 0 0 "$f_task_id" 0 "" \
+             "$DR_FLEET_AUDIT_GROUP" "" "$f_type" "forwarded" "$f_reason")"
+  event="$(printf '%s' "$event" | jq -c \
+    --arg sid "$f_id" --arg sts "$f_ts" --arg tid "$f_task_id" \
+    '. + {source_id: $sid, source_ts: $sts, task_id: $tid}')"
+
+  local day; day="$(date -u +%Y-%m-%d)"
+  emit "$DR_FLEET_METRICS_DIR/audit-consumer-$day.jsonl" "$event"
+  emit "$DR_FLEET_COMPLIANCE_DIR/audit-compliance-$day.jsonl" "$event"
+
+  # Compliance ACK — remove the message from the pending entries list.
+  bus_ack "$TOPIC" "$DR_FLEET_AUDIT_GROUP" "$entry_id" >/dev/null 2>&1 || true
+
+  printf 'AUDIT [%s] group=%s entry=%s forwarded to obs+compliance sinks\n' \
+    "$(date -u +%FT%TZ)" "$DR_FLEET_AUDIT_GROUP" "$entry_id"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/plugins/dr-orchestrate/tests/fleet/obs-aggregation.bats
+++ b/plugins/dr-orchestrate/tests/fleet/obs-aggregation.bats
@@ -11,15 +11,47 @@ REDIS_URL="${DR_ORCH_REDIS_URL:-redis://127.0.0.1:6379}"
 setup() {
   TMP="$(mktemp -d)"
   export DR_FLEET_METRICS_DIR="$TMP/metrics"
+  export DR_FLEET_COMPLIANCE_DIR="$TMP/compliance"
   export DR_ORCH_REDIS_URL="$REDIS_URL"
   export DR_FLEET_BUS_BACKEND=mock
   export DR_FLEET_MOCK_LOG="$TMP/mock.log"
   export DR_FLEET_MOCK_XADD_ID="1700000000000-0"
+  export BUS_ADAPTER_SH="$PLUGIN_ROOT/scripts/bus_adapter.sh"
+  export AUDIT_SINK_SH="$PLUGIN_ROOT/scripts/audit_sink.sh"
+  export AUDIT_CONSUMER_SH="$PLUGIN_ROOT/scripts/fleet_audit_consumer.sh"
   REDIS_AVAILABLE=0
   if command -v redis-cli >/dev/null 2>&1 \
       && redis-cli -u "$REDIS_URL" ping 2>/dev/null | grep -q PONG; then
     REDIS_AVAILABLE=1
   fi
+}
+
+# Call _process_entry in an isolated shell with the bus + sink deps sourced.
+# Passes the raw flattened XREADGROUP blob as $1 to the sourced function.
+# `set --` clears positional args before sourcing the consumer so its top-level
+# arg parser (a no-op path when sourced) does not see the harness arguments.
+_run_process_entry() {
+  run bash -c '
+    RAW="$1"
+    source "$BUS_ADAPTER_SH"
+    source "$AUDIT_SINK_SH"
+    set --
+    source "$AUDIT_CONSUMER_SH"
+    _process_entry "$RAW"
+  ' _ "$1"
+}
+
+# A canonical flattened XREADGROUP blob (redis-cli non-tty form): stream key,
+# entry id, then alternating field / value lines — mirrors fleet event shape.
+_sample_audit_blob() {
+  printf '%s\n' \
+    "stream:fleet:audit-log" \
+    "1700000000000-5" \
+    "id"      "status-evt-42" \
+    "ts"      "2026-07-21T10:00:00Z" \
+    "type"    "lifecycle" \
+    "task_id" "TUNE-0385" \
+    "reason"  "${1:-plain reason text}"
 }
 
 teardown() {
@@ -119,4 +151,69 @@ teardown() {
 @test "V-AC-6: fleet_audit_consumer.sh --check exits 0" {
   run bash "$PLUGIN_ROOT/scripts/fleet_audit_consumer.sh" --check
   [ "$status" -eq 0 ]
+}
+
+# ── audit consumer: typed kv forward to obs + compliance sinks ────────────────
+
+@test "audit-consumer: parses kv fields into a schema-v2 obs event" {
+  local blob; blob="$(_sample_audit_blob)"
+  _run_process_entry "$blob"
+  [ "$status" -eq 0 ]
+  local day; day="$(date -u +%Y-%m-%d)"
+  local obs="$DR_FLEET_METRICS_DIR/audit-consumer-$day.jsonl"
+  [ -f "$obs" ]
+  run jq -e '.schema_version == 2
+             and .task_id == "TUNE-0385"
+             and .source_id == "status-evt-42"
+             and .source_ts == "2026-07-21T10:00:00Z"
+             and .stage == "lifecycle"' "$obs"
+  [ "$status" -eq 0 ]
+}
+
+@test "audit-consumer: forwards the same event to the compliance sink" {
+  local blob; blob="$(_sample_audit_blob)"
+  _run_process_entry "$blob"
+  [ "$status" -eq 0 ]
+  local day; day="$(date -u +%Y-%m-%d)"
+  local comp="$DR_FLEET_COMPLIANCE_DIR/audit-compliance-$day.jsonl"
+  [ -f "$comp" ]
+  run jq -e '.schema_version == 2 and .task_id == "TUNE-0385"' "$comp"
+  [ "$status" -eq 0 ]
+}
+
+@test "audit-consumer: acknowledges the stream entry via XACK" {
+  local blob; blob="$(_sample_audit_blob)"
+  _run_process_entry "$blob"
+  [ "$status" -eq 0 ]
+  run grep -F 'XACK stream:fleet:audit-log obs 1700000000000-5' "$DR_FLEET_MOCK_LOG"
+  [ "$status" -eq 0 ]
+}
+
+@test "audit-consumer: redacts credential material in the reason field" {
+  local blob; blob="$(_sample_audit_blob 'blocked because token=hunter2')"
+  _run_process_entry "$blob"
+  [ "$status" -eq 0 ]
+  local day; day="$(date -u +%Y-%m-%d)"
+  local obs="$DR_FLEET_METRICS_DIR/audit-consumer-$day.jsonl"
+  run grep -F 'hunter2' "$obs"
+  [ "$status" -ne 0 ]
+  run grep -F '<REDACTED>' "$obs"
+  [ "$status" -eq 0 ]
+}
+
+@test "audit-consumer: empty subscribe result is a no-op (no sink, no ACK)" {
+  _run_process_entry ""
+  [ "$status" -eq 0 ]
+  _run_process_entry "(empty)"
+  [ "$status" -eq 0 ]
+  local day; day="$(date -u +%Y-%m-%d)"
+  [ ! -f "$DR_FLEET_METRICS_DIR/audit-consumer-$day.jsonl" ]
+  [ ! -f "$DR_FLEET_COMPLIANCE_DIR/audit-compliance-$day.jsonl" ]
+  run grep -F 'XACK' "$DR_FLEET_MOCK_LOG"
+  [ "$status" -ne 0 ]
+}
+
+@test "audit-consumer: source drops the deferred 'pending full sink wiring' marker" {
+  run grep -F 'pending full sink wiring' "$AUDIT_CONSUMER_SH"
+  [ "$status" -ne 0 ]
 }


### PR DESCRIPTION
Relands **TUNE-0385**, one of the 22 tasks the TUNE-0541 sweep found marked `done`
with none of its content in `origin/main`. The work was implemented and verified
inside a worktree branch; the pull request was never opened.

Verdict: **GENUINELY-LOST-WORK-EXISTS** — see
`documentation/archive/framework/TUNE-0541-verdict-table.md`.

Cherry-picked onto current `main` from the original worktree branch. The branch's
merge-base *is* an ancestor of `main`, so this is a clean single-commit reland
rather than part of the re-rooted 0141/0206/0365 chain.

Verified before opening: `shellcheck --severity=warning` (CI's own severity) clean
on every shell file the commit ships, and every `.bats` file it touches run green.

The `closure-gate.sh` merged in #278 reports this branch's work as absent from
`main` today, and will report it present once this merges — that transition is the
gate's intended signal.