### PR TITLE
test(tune-0141): retarget a stale co-assertion after main renamed the section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ Agents are specialized personas loaded per pipeline stage. Each agent has define
 | **reviewer** | QA & Security Lead | /dr-qa, /dr-archive (Step 0.5 reflection) |
 | **compliance** | Compliance Runner | /dr-compliance |
 | **code-simplifier** | Code Simplification | /dr-compliance |
-| **strategist** | Strategic Advisor | /dr-plan (L3-4) |
+| **strategist** | Strategic Advisor | /dr-plan (L3-4; redundancy-only or ambiguous L1-L2) |
 | **devops** | DevOps Engineer | /dr-plan, /dr-do, /dr-compliance |
 | **writer** | Content Writer | /dr-write, /dr-archive (Step 0.5 + final docs), /dr-prd |
 | **editor** | Content Editor | /dr-edit, /dr-qa (content) |
@@ -203,7 +203,7 @@ Before writing ANY file to `datarim/`:
 |---------|-------|-------------|
 | `/dr-init` | Initialize | Create task, pick from backlog, or **scaffold a new project**. Assess complexity, set up `datarim/` |
 | `/dr-prd` | Requirements | Generate PRD with discovery interview |
-| `/dr-plan` | Planning | Detailed implementation plan with strategist gate |
+| `/dr-plan` | Planning | Detailed implementation plan with strategist gate; a logged strategist decision is mandatory for redundancy-only or ambiguous scope at any complexity |
 | `/dr-design` | Design | Architecture exploration with consilium |
 | `/dr-do` | Execution | Implement the plan: TDD for code, structured iteration for other work |
 | `/dr-qa` | Quality | Multi-layer verification (PRD, design, plan, output quality) |

--- a/README.md
+++ b/README.md
@@ -194,9 +194,11 @@ Stages in `[brackets]` are conditional — included when the agent determines th
   verify claims against sources, remove AI writing artifacts, preserve the author's
   natural voice.
 
-- **Strategic advisor gate** — before committing to major work, the strategist agent
-  evaluates value, risk, and cost. Not every technically interesting idea deserves
-  implementation resources.
+- **Strategic advisor gate** — before committing to major work, the strategist
+  evaluates value, risk, and cost. `/dr-plan` also requires and logs this review
+  at any complexity when the entire scope only removes redundancy, dead code,
+  or duplicate surfaces without adding behavior. Ambiguous cleanup claims fail
+  closed; a valid `GO` unlocks only the next existing planning gate.
 
 - **Project scaffolding** — `/dr-init create project "Name"` creates a complete
   project structure: CLAUDE.md with Laws of Robotics and Datarim pipeline, documentation/
@@ -427,7 +429,7 @@ documentation, or any structured work.
 | **Reviewer** | Reviews code for quality, correctness, and adherence to plan | `qa` |
 | **Compliance** | Validates implementation against PRD, checks for regressions | `compliance` |
 | **Code Simplifier** | Reduces complexity, eliminates duplication, improves readability | `do`, `qa` |
-| **Strategist** | Evaluates value/risk/cost, advises on priorities, gates major work | `init`, `prd` |
+| **Strategist** | Evaluates value/risk/cost, advises on priorities, gates L3/L4 and redundancy-only planning | `plan` |
 | **DevOps** | Handles deployment, CI/CD, infrastructure, and environment configuration | `do`, `compliance` |
 | **Writer** | Creates content — articles, docs, research papers, posts, guides | `write`, `archive` (Step 0.5) |
 | **Editor** | Editorial review — fact-checking, AI pattern removal, style, polish | `edit`, `qa` |
@@ -484,7 +486,7 @@ specific capabilities. You can add custom skills by placing `.md` files in
 |---------|-------|-------------|
 | `/dr-init` | Initialize | Start a new task, pick from backlog, or scaffold a new project. For tasks: assigns complexity (L1-L4) and routes pipeline. For projects: `/dr-init create project "Name"`. |
 | `/dr-prd` | Requirements | Generate a Product Requirements Document. Analyzes the problem, defines scope, success criteria, and constraints. |
-| `/dr-plan` | Planning | Create a detailed implementation plan. Breaks work into phases, estimates effort, identifies risks. |
+| `/dr-plan` | Planning | Create a detailed implementation plan. Breaks work into phases, estimates effort, identifies risks; a logged strategist decision is mandatory for redundancy-only or ambiguous scope at any complexity |
 | `/dr-design` | Design | Explore architectural decisions. Evaluates alternatives, documents trade-offs, defines interfaces. |
 | `/dr-do` | Execution | Execute the plan. TDD for code, structured iteration for research, documentation, or other work. |
 | `/dr-qa` | Quality | Run quality checks. PRD alignment, design conformance, plan completeness, output quality. |

--- a/agents/strategist.md
+++ b/agents/strategist.md
@@ -18,9 +18,40 @@ Your goal is to evaluate whether a task is worth building and propose the most e
 - Flag anti-patterns: building without validation, solving unreported problems, premature scale, resume-driven development, gold-plating.
 - Output: strategic assessment with go/no-go/pivot recommendation.
 
+## Redundancy-only planning review
+
+When `/dr-plan` identifies wholly reductive or ambiguous scope, add these
+mandatory lenses to the normal Value/Risk/Cost assessment:
+
+- Identify intentional redundancy serving availability, rollback, backup,
+  defense-in-depth, separation-of-duty, or audit needs.
+- Check current direct, dynamic, plugin, and configuration-driven consumers.
+- Test whether consolidation creates a single point of failure, joins privilege
+  or data boundaries, removes rollback, or expands blast radius.
+- Propose the minimum safe scope and a cheaper alternative.
+
+### Closed redundancy-gate response
+
+Propose exactly these assessment fields for the parent to normalize:
+
+```text
+verdict=GO | NO_GO | PIVOT | INCOMPLETE
+worth_building=yes | no | conditional
+rationale=<one printable-ASCII line>
+most_efficient_path=<one printable-ASCII line>
+safety_assessment=<one printable-ASCII line>
+```
+
+These values are untrusted recommendations. The `/dr-plan` parent independently
+owns the semantic classification, predicate results, canonical evidence,
+invocation and digest bindings, complete record, gate status, and route. The
+strategist must not write the runtime or Markdown record, must not select a CTA
+or route, and must not claim that its `GO` bypasses Step 4 or any later gate.
+
 **Context Loading**:
 - READ: `datarim/tasks.md`, `datarim/activeContext.md`, `datarim/prd/*.md`
 - ALWAYS APPLY:
   - `$HOME/.claude/skills/datarim-system/SKILL.md` (Core workflow rules, file locations)
 
-**When invoked:** `/dr-plan` stage (mandatory for L3-4), optional for L2.
+**When invoked:** `/dr-plan` stage (mandatory for L3-4; also mandatory at L1-L2
+when the whole scope is redundancy-only or ambiguous).

--- a/commands/dr-plan.md
+++ b/commands/dr-plan.md
@@ -44,13 +44,81 @@ Note: the machine-local PreToolUse guard remains the hard floor; this Step-0 che
     -   Review `datarim/prd/*.md` if available.
     -   Read `datarim/insights/INSIGHTS-{task-id}.md` if exists (research context from `/dr-prd` Phase 1.3).
 
-3.  **Strategist Gate** (mandatory for L3-4, optional for L2):
-    -   Load `$HOME/.claude/agents/strategist.md`.
-    -   Evaluate:
-        -   **Value** — is this worth building?
-        -   **Risk** — what's irreversible?
-        -   **Cost** — what's the minimum viable experiment?
-    -   If strategist recommends pivot or cheaper alternative, present to user before proceeding.
+3.  **Strategist Gate** (mandatory for L3-4 and for redundancy-only or ambiguous scope at every complexity):
+    1.  **Classify the whole scope semantically.** Read the complete canonical
+        task inputs: init-task operator brief and append-log, task description,
+        and approved PRD when present. Apply both tests to every intended
+        deliverable:
+        - `positive_scope_test=pass` only when every deliverable exclusively
+          removes, retires, merges, or consolidates an existing surface.
+        - `no_new_behavior_test=pass` only when no deliverable adds a user
+          behavior, API, command, schema meaning, capability, operational
+          obligation, or unrelated fix.
+        Also check current consumers (including dynamic, plugin, and
+        configuration-driven use), intentional availability/rollback/audit
+        redundancy, and the safe survivor. Keywords such as "cleanup" or
+        "dead code" have no classification authority.
+        - Both tests `pass` -> `classification=redundancy_only`.
+        - Any explicit `fail` -> `classification=non_matching`.
+        - Otherwise -> `classification=ambiguous`; ambiguity never bypasses
+          review.
+    2.  **Freeze and bind the invocation.** Before appending any strategist
+        assessment or record, hash the canonical init-task, pre-decision task
+        description, and approved PRD in that fixed order. Serialize the
+        manifest as repeated `relative_path NUL lowercase_sha256 NUL` pairs and
+        use its SHA-256 as `scope_digest`. Evidence may reference only existing
+        same-task lines in those regular, non-symlink canonical artifacts.
+        Create `datarim/.auto/strategist-gate/{TASK-ID}/` current-user-owned at
+        mode 0700. With `umask 077`, allocate a fresh collision-resistant
+        invocation ID and its mode-0600 record using atomic no-clobber
+        creation. Never reuse a persisted Markdown record or an earlier
+        invocation as validator input.
+    3.  **Invoke exactly once when required.** Load
+        `$HOME/.claude/agents/strategist.md`.
+        - `redundancy_only` or `ambiguous`: strategist review is mandatory at
+          L1-L4 (`invocation_reason=redundancy_gate` at L1/L2; `both` at
+          L3/L4).
+        - Clearly `non_matching`: preserve existing routing. L1/L2 do not
+          invoke it; L3/L4 still perform their normal mandatory strategist
+          review (`invocation_reason=complexity_gate`).
+        - An L3/L4 redundancy review enhances the normal complexity review; it
+          is exactly one strategist invocation, never two dispatches.
+        Evaluate Value, Risk, Cost, intentional redundancy, current consumers,
+        consolidation boundaries, the minimum safe scope, and a cheaper path.
+        The strategist proposes only `verdict`, `worth_building`, `rationale`,
+        `most_efficient_path`, and `safety_assessment`. Treat every proposed
+        value as untrusted. The parent independently owns classification,
+        predicates, evidence, invocation fields, normalization, gate status,
+        and route.
+        For L3/L4 `non_matching` work, retain the general strategist assessment
+        as a separate parent-owned decision beside the specialized
+        `NOT_APPLICABLE` record. Persist and evaluate that general verdict
+        before continuing: general `NO_GO`, `PIVOT`, or `INCOMPLETE` remains
+        non-advancing even though the specialized helper returns
+        `result=normal_route`.
+    4.  **Normalize and validate the closed record.** Write exactly the 18
+        fields defined by `dev-tools/check-strategist-gate-record.sh`, then run:
+        ```bash
+        bash "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-strategist-gate-record.sh" \
+          --root <workspace-root> \
+          --record datarim/.auto/strategist-gate/{TASK-ID}/{invocation}.record \
+          --task {TASK-ID} --complexity L1|L2|L3|L4 \
+          --invocation {invocation} --scope-digest {scope_digest}
+        ```
+        Only helper exit 0 or 1 establishes a structurally valid decision. On
+        exit 2, 64, timeout, missing response, or invocation failure, leave the
+        rejected record untouched for audit, atomically allocate a fresh
+        recovery invocation, synthesize and validate a bounded `INCOMPLETE`
+        record that names the original stable failure code, and fail closed.
+    5.  **Persist, then route.** After validation, persist the exact validated
+        record under `## Decisions` in the task description before Step 4; a
+        successful L3/L4 plan mirrors the same record. A redundancy-only `GO`
+        with `worth_building=yes` unlocks Step 4 only. `NO_GO`, `PIVOT`,
+        `INCOMPLETE`, missing, or malformed results use `route=return_to_prd`
+        and planning MUST NOT proceed. A `non_matching` special record uses
+        `NOT_APPLICABLE` and preserves the normal route; it cannot override an
+        L3/L4 general strategist `NO_GO` or `PIVOT`. No result weakens or skips
+        Step 4 or any later hard gate.
 
 4.  **Detailed Design (Phase 4)**:
     -   **Architectural-superseding fallback re-check (lightweight — the primary probe now runs at `/dr-init`)**: `/dr-init` already probes any `Source:`/`Spawned from:` reference present in the operator's brief (or the selected backlog item's description) and recommends cancellation/reframing before the task-description or activeContext entry ever exists. Here, re-run only the narrow fallback case: has a NEW archive landed under `documentation/archive/*/archive-<ID>.md` addressing this same problem class SINCE `/dr-init` ran for this task? Compare against the `captured_at` timestamp in `datarim/tasks/{TASK-ID}-init-task.md` (e.g. `git log --since="<captured_at>" -- documentation/archive/`). If a new archive matches, apply the same decision procedure (cancel / scope reduction / re-framing) BEFORE proceeding to Component Breakdown, and document the answer (and archives consulted) inline in the plan's Overview / Decisions section. If no new archive landed, this fallback is a no-op — note "no new sibling archives since /dr-init" and continue. Cost: one `git log` check. Saving: catches the rare case where a sibling task archives in the window between `/dr-init` and `/dr-plan`, without re-doing the full probe every time.
@@ -368,7 +436,11 @@ When auto-mode is active (env var `DATARIM_AUTO_MODE=1` AND the matching per-tas
 
 1. Consults `${DATARIM_RUNTIME:-$HOME/.claude}/skills/autonomous-mode/SKILL.md` § Question Suppression Ladder ([definition](../skills/autonomous-mode/SKILL.md)) before any `AskUserQuestion` or equivalent operator prompt at this stage.
 2. Stage-specific suppression hooks:
-   - Step 3 Strategist Gate (L3-4 only) — pivot suggestion resolved through Ladder; suggest pivot inline, escalate to L5 only if it changes scope materially.
+   - Step 3 Strategist Gate — the normal L3/L4 review plus mandatory review for
+     `redundancy_only` or `ambiguous` scope at any complexity. Persist the
+     validated decision. Resolve a non-advancing result through the Ladder and
+     return to `/dr-prd`; escalate to L5 only if the resulting scope change is
+     materially irreversible.
    - Step 4 Architectural-superseding fallback re-check — the primary probe now runs at `/dr-init` Step 3.5; this hook applies only when a new sibling archive landed after `/dr-init` ran, resolved through Ladder L1-L2 (read the newly-landed archive).
 3. Discovered gaps → apply L1 Inline Resolution Rule ([definition](../skills/autonomous-mode/SKILL.md)) per `skills/autonomous-mode/SKILL.md`; log in `datarim/tasks/{TASK-ID}-auto-inline-log.md` if applied inline.
 4. Hard-gated actions → escalate to operator through Ladder L5; log via `"${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/append-init-task-qa.sh" --decided-by operator` per `skills/init-task-persistence/SKILL.md` § Q&A round-trip.

--- a/dev-tools/check-strategist-gate-record.sh
+++ b/dev-tools/check-strategist-gate-record.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+# Validate a parent-normalized /dr-plan strategist gate record.
+# This helper is deliberately structural: it does not classify prose, invoke
+# agents, write records, select routes, or open evidence paths.
+
+set -euo pipefail
+IFS=$' \t\n'
+
+usage() {
+    cat <<'EOF'
+Usage: check-strategist-gate-record.sh \
+  --root <workspace-root> \
+  --record datarim/.auto/strategist-gate/<task>/<invocation>.record \
+  --task <task-id> \
+  --complexity L1|L2|L3|L4 \
+  --invocation <invocation-id> \
+  --scope-digest <sha256>
+
+Exit 0: advancing or normal-route record
+Exit 1: valid non-advancing record
+Exit 2: malformed or untrusted record
+Exit 64: command-line misuse
+EOF
+}
+
+usage_error() {
+    printf 'check-strategist-gate-record: %s\n' "$1" >&2
+    exit 64
+}
+
+malformed() {
+    printf 'check-strategist-gate-record: %s\n' "$1" >&2
+    exit 2
+}
+
+stat_follow() {
+    target=$1
+    if stat -Lc '%d:%i:%u:%a:%s:%Y' "$target" >/dev/null 2>&1; then
+        stat -Lc '%d:%i:%u:%a:%s:%Y' "$target" 2>/dev/null
+        return
+    fi
+    stat -Lf '%d:%i:%u:%Lp:%z:%m' "$target" 2>/dev/null
+}
+
+emit_result() {
+    printf 'result=%s\nreason=%s\n' "$1" "$2"
+}
+
+ROOT=
+RECORD_REL=
+TASK=
+COMPLEXITY=
+INVOCATION=
+SCOPE_DIGEST=
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --help|-h)
+            usage
+            exit 0
+            ;;
+        --root|--record|--task|--complexity|--invocation|--scope-digest)
+            flag=$1
+            shift
+            [ "$#" -gt 0 ] || usage_error "$flag requires a value"
+            case "$flag" in
+                --root) ROOT=$1 ;;
+                --record) RECORD_REL=$1 ;;
+                --task) TASK=$1 ;;
+                --complexity) COMPLEXITY=$1 ;;
+                --invocation) INVOCATION=$1 ;;
+                --scope-digest) SCOPE_DIGEST=$1 ;;
+            esac
+            shift
+            ;;
+        *) usage_error 'unknown flag' ;;
+    esac
+done
+
+[ -n "$ROOT" ] || usage_error 'missing --root'
+[ -n "$RECORD_REL" ] || usage_error 'missing --record'
+[ -n "$TASK" ] || usage_error 'missing --task'
+[ -n "$COMPLEXITY" ] || usage_error 'missing --complexity'
+[ -n "$INVOCATION" ] || usage_error 'missing --invocation'
+[ -n "$SCOPE_DIGEST" ] || usage_error 'missing --scope-digest'
+
+LC_ALL=C
+export LC_ALL
+[ "${#TASK}" -le 96 ] || usage_error 'invalid task id'
+printf '%s' "$TASK" | grep -Eq '^[A-Z][A-Z0-9]{1,9}-[0-9]{4,}(-[A-Za-z0-9][A-Za-z0-9-]{0,63})?$' \
+    || usage_error 'invalid task id'
+[ "${#INVOCATION}" -le 96 ] || usage_error 'invalid invocation id'
+printf '%s' "$INVOCATION" | grep -Eq '^[a-z0-9][A-Za-z0-9._-]{0,95}$' \
+    || usage_error 'invalid invocation id'
+case "$COMPLEXITY" in L1|L2|L3|L4) ;; *) usage_error 'invalid complexity' ;; esac
+printf '%s' "$SCOPE_DIGEST" | grep -Eq '^[a-f0-9]{64}$' \
+    || usage_error 'invalid scope digest'
+case "$ROOT" in /*) ;; *) usage_error 'root must be absolute' ;; esac
+[ -d "$ROOT" ] || usage_error 'root is not a directory'
+[ ! -L "$ROOT" ] || malformed 'workspace root is a symlink'
+
+ROOT_PHYSICAL=$(cd -P "$ROOT" 2>/dev/null && pwd -P) \
+    || usage_error 'cannot resolve workspace root'
+[ "$ROOT_PHYSICAL" = "${ROOT%/}" ] || malformed 'workspace root is not canonical'
+
+EXPECTED_REL="datarim/.auto/strategist-gate/$TASK/$INVOCATION.record"
+[ "$RECORD_REL" = "$EXPECTED_REL" ] || malformed 'record path binding mismatch'
+
+DATARIM_DIR="$ROOT_PHYSICAL/datarim"
+AUTO_DIR="$DATARIM_DIR/.auto"
+GATE_DIR="$AUTO_DIR/strategist-gate"
+TASK_DIR="$GATE_DIR/$TASK"
+RECORD_ABS="$ROOT_PHYSICAL/$RECORD_REL"
+
+for component in "$DATARIM_DIR" "$AUTO_DIR" "$GATE_DIR" "$TASK_DIR"; do
+    [ -e "$component" ] || malformed 'required record parent is missing'
+    [ ! -L "$component" ] || malformed 'symlinked path component'
+    [ -d "$component" ] || malformed 'record parent is not a directory'
+done
+
+TASK_PHYSICAL=$(cd -P "$TASK_DIR" 2>/dev/null && pwd -P) \
+    || malformed 'cannot resolve task directory'
+[ "$TASK_PHYSICAL" = "$TASK_DIR" ] || malformed 'task directory escaped root'
+
+CURRENT_UID=$(id -u) || malformed 'cannot determine current uid'
+TASK_META_BEFORE=$(stat_follow "$TASK_DIR") || malformed 'cannot stat task directory'
+IFS=: read -r _ _ task_uid task_mode _ _ <<EOF
+$TASK_META_BEFORE
+EOF
+[ -n "$task_mode" ] || malformed 'invalid task directory metadata'
+[ "$task_uid" = "$CURRENT_UID" ] || malformed 'task directory owner mismatch'
+[ "$task_mode" = 700 ] || malformed 'task directory mode mismatch'
+
+[ -e "$RECORD_ABS" ] || malformed 'record is missing'
+[ ! -L "$RECORD_ABS" ] || malformed 'record is a symlink'
+[ -f "$RECORD_ABS" ] || malformed 'record is not regular'
+RECORD_META_PATH=$(stat_follow "$RECORD_ABS") || malformed 'cannot stat record'
+IFS=: read -r _ _ record_uid record_mode record_size _ <<EOF
+$RECORD_META_PATH
+EOF
+[ -n "$record_mode" ] || malformed 'invalid record metadata'
+[ "$record_uid" = "$CURRENT_UID" ] || malformed 'record owner mismatch'
+[ "$record_mode" = 600 ] || malformed 'record mode mismatch'
+
+exec 3<"$RECORD_ABS" || malformed 'cannot open record'
+FD_PATH="/proc/$$/fd/3"
+[ -e "$FD_PATH" ] || FD_PATH="/dev/fd/3"
+RECORD_META_FD_BEFORE=$(stat_follow "$FD_PATH") || malformed 'cannot stat record descriptor'
+[ "$RECORD_META_FD_BEFORE" = "$RECORD_META_PATH" ] \
+    || malformed 'record changed before descriptor open'
+TASK_META_OPEN=$(stat_follow "$TASK_DIR") || malformed 'cannot restat task directory'
+[ "$TASK_META_OPEN" = "$TASK_META_BEFORE" ] || malformed 'task directory changed before record open'
+
+schema_version=__UNSET__
+task_id=__UNSET__
+invocation_id=__UNSET__
+scope_digest=__UNSET__
+complexity=__UNSET__
+classification=__UNSET__
+positive_scope_test=__UNSET__
+no_new_behavior_test=__UNSET__
+scope_evidence=__UNSET__
+invocation_reason=__UNSET__
+strategist_invoked=__UNSET__
+verdict=__UNSET__
+worth_building=__UNSET__
+rationale=__UNSET__
+most_efficient_path=__UNSET__
+safety_assessment=__UNSET__
+gate_status=__UNSET__
+route=__UNSET__
+seen='|'
+line_count=0
+parsed_bytes=0
+last_line_had_newline=0
+
+while :; do
+    line=
+    if IFS= read -r line <&3; then
+        line_had_newline=1
+    else
+        [ -n "$line" ] || break
+        line_had_newline=0
+    fi
+    line_count=$((line_count + 1))
+    parsed_bytes=$((parsed_bytes + ${#line} + line_had_newline))
+    last_line_had_newline=$line_had_newline
+    [ "$line_count" -le 18 ] || malformed 'unexpected or duplicate key'
+    printf '%s' "$line" | grep -q '[^ -~]' && malformed 'record contains non-ascii or control bytes'
+    case "$line" in *=*) ;; *) malformed 'record line is not key=value' ;; esac
+    key=${line%%=*}
+    value=${line#*=}
+    [ -n "$key" ] || malformed 'empty record key'
+    [ "${#value}" -le 500 ] || malformed 'record value exceeds 500 bytes'
+    case "$seen" in *"|$key|"*) malformed 'duplicate record key' ;; esac
+    seen="${seen}${key}|"
+    case "$key" in
+        schema_version) schema_version=$value ;;
+        task_id) task_id=$value ;;
+        invocation_id) invocation_id=$value ;;
+        scope_digest) scope_digest=$value ;;
+        complexity) complexity=$value ;;
+        classification) classification=$value ;;
+        positive_scope_test) positive_scope_test=$value ;;
+        no_new_behavior_test) no_new_behavior_test=$value ;;
+        scope_evidence) scope_evidence=$value ;;
+        invocation_reason) invocation_reason=$value ;;
+        strategist_invoked) strategist_invoked=$value ;;
+        verdict) verdict=$value ;;
+        worth_building) worth_building=$value ;;
+        rationale) rationale=$value ;;
+        most_efficient_path) most_efficient_path=$value ;;
+        safety_assessment) safety_assessment=$value ;;
+        gate_status) gate_status=$value ;;
+        route) route=$value ;;
+        *) malformed 'unknown record key' ;;
+    esac
+done
+RECORD_META_FD_AFTER=$(stat_follow "$FD_PATH") || malformed 'cannot restat record descriptor'
+exec 3<&-
+
+[ "$line_count" -eq 18 ] || malformed 'record is missing required keys'
+[ "$parsed_bytes" -eq "$record_size" ] || malformed 'record contains NUL bytes'
+[ "$last_line_had_newline" -eq 1 ] || malformed 'record lacks a final newline'
+[ "$RECORD_META_FD_AFTER" = "$RECORD_META_FD_BEFORE" ] \
+    || malformed 'record descriptor changed during validation'
+RECORD_META_PATH_AFTER=$(stat_follow "$RECORD_ABS") || malformed 'record path disappeared during validation'
+[ ! -L "$RECORD_ABS" ] || malformed 'record path became a symlink'
+[ "$RECORD_META_PATH_AFTER" = "$RECORD_META_FD_AFTER" ] \
+    || malformed 'record path changed during validation'
+TASK_META_AFTER=$(stat_follow "$TASK_DIR") || malformed 'task directory disappeared during validation'
+[ "$TASK_META_AFTER" = "$TASK_META_BEFORE" ] || malformed 'task directory changed during validation'
+for component in "$DATARIM_DIR" "$AUTO_DIR" "$GATE_DIR" "$TASK_DIR"; do
+    [ ! -L "$component" ] || malformed 'path component changed to a symlink'
+    [ -d "$component" ] || malformed 'record parent changed type'
+done
+TASK_PHYSICAL_AFTER=$(cd -P "$TASK_DIR" 2>/dev/null && pwd -P) \
+    || malformed 'cannot re-resolve task directory'
+[ "$TASK_PHYSICAL_AFTER" = "$TASK_PHYSICAL" ] || malformed 'task directory escaped during validation'
+
+[ "$schema_version" = 1 ] || malformed 'schema version mismatch'
+[ "$task_id" = "$TASK" ] || malformed 'task binding mismatch'
+[ "$invocation_id" = "$INVOCATION" ] || malformed 'invocation binding mismatch'
+[ "$scope_digest" = "$SCOPE_DIGEST" ] || malformed 'scope digest binding mismatch'
+[ "$complexity" = "$COMPLEXITY" ] || malformed 'complexity binding mismatch'
+case "$classification" in redundancy_only|non_matching|ambiguous) ;; *) malformed 'invalid classification' ;; esac
+case "$positive_scope_test" in pass|fail|unknown) ;; *) malformed 'invalid positive scope result' ;; esac
+case "$no_new_behavior_test" in pass|fail|unknown) ;; *) malformed 'invalid no-new-behavior result' ;; esac
+case "$invocation_reason" in none|complexity_gate|redundancy_gate|both) ;; *) malformed 'invalid invocation reason' ;; esac
+case "$strategist_invoked" in yes|no) ;; *) malformed 'invalid strategist invocation marker' ;; esac
+case "$verdict" in GO|NO_GO|PIVOT|NOT_APPLICABLE|INCOMPLETE) ;; *) malformed 'invalid verdict' ;; esac
+case "$worth_building" in yes|no|conditional|not_applicable) ;; *) malformed 'invalid worth-building value' ;; esac
+case "$gate_status" in pass|block|not_applicable) ;; *) malformed 'invalid gate status' ;; esac
+case "$route" in proceed|return_to_prd) ;; *) malformed 'invalid route' ;; esac
+
+if [ -z "$scope_evidence" ] || [ "$scope_evidence" = __UNSET__ ]; then
+    malformed 'scope evidence is missing'
+fi
+case "$scope_evidence" in ,*|*,|*,,*) malformed 'invalid scope evidence list' ;; esac
+IFS=, read -r -a evidence_references <<EOF
+$scope_evidence
+EOF
+for reference in "${evidence_references[@]}"; do
+    printf '%s' "$reference" | grep -Eq "^datarim/tasks/${TASK}-(init-task|task-description)\\.md:[1-9][0-9]*$|^datarim/prd/PRD-${TASK}\\.md:[1-9][0-9]*$" \
+        || malformed 'invalid scope evidence reference'
+done
+
+for text_value in "$rationale" "$most_efficient_path" "$safety_assessment"; do
+    if [ -z "$text_value" ] || [ "$text_value" = __UNSET__ ]; then
+        malformed 'decision text is missing'
+    fi
+    printf '%s' "$text_value" | grep -Eiq \
+        '(secret|password|token|credential)[[:space:]_/-]*[:=]|authorization[[:space:]_/-]*:[[:space:]]*bearer|(^|[^A-Za-z0-9])bearer[[:space:]]+[A-Za-z0-9._-]+|eyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+|-----BEGIN [A-Z ]*PRIVATE KEY-----|api[[:space:]_/-]*key[[:space:]_/-]*[:=]|(^|[^A-Za-z0-9])route[[:space:]_/-]*[:=]|next[[:space:]_/-]*step[[:space:]_/-]*[:=]|[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}|(^|[^0-9])\+?[0-9][0-9 ()-]{7,}[0-9]' \
+        && malformed 'unsafe decision text'
+    printf '%s' "$text_value" | grep -Eq '(^|[^A-Za-z0-9_.-])\.\./|(^|[^A-Za-z0-9_.-])/[A-Za-z0-9._/-]|(^|[^A-Za-z0-9_.-])path[[:space:]_/-]*=' \
+        && malformed 'unsafe path in decision text'
+done
+
+case "$positive_scope_test/$no_new_behavior_test" in
+    pass/pass) PREDICATE_CLASS=reductive ;;
+    unknown/unknown|unknown/pass|pass/unknown) PREDICATE_CLASS=ambiguous ;;
+    fail/fail|fail/pass|fail/unknown|pass/fail|unknown/fail) PREDICATE_CLASS=non_matching ;;
+    *) malformed 'invalid predicate pair' ;;
+esac
+case "$classification/$PREDICATE_CLASS" in
+    redundancy_only/reductive|ambiguous/ambiguous|non_matching/non_matching) ;;
+    *) malformed 'classification contradicts predicate results' ;;
+esac
+
+case "$COMPLEXITY" in
+    L1|L2) REQUIRED_REASON=redundancy_gate ;;
+    L3|L4) REQUIRED_REASON=both ;;
+esac
+
+case "$classification" in
+    redundancy_only)
+        [ "$invocation_reason" = "$REQUIRED_REASON" ] || malformed 'wrong redundancy invocation reason'
+        [ "$strategist_invoked" = yes ] || malformed 'strategist was not invoked'
+        case "$verdict/$worth_building/$gate_status/$route" in
+            GO/yes/pass/proceed)
+                RESULT=advance
+                REASON=strategist_go
+                EXIT_CODE=0
+                ;;
+            NO_GO/no/block/return_to_prd)
+                RESULT=block
+                REASON=strategist_no_go
+                EXIT_CODE=1
+                ;;
+            PIVOT/conditional/block/return_to_prd)
+                RESULT=block
+                REASON=strategist_pivot
+                EXIT_CODE=1
+                ;;
+            INCOMPLETE/conditional/block/return_to_prd)
+                RESULT=block
+                REASON=strategist_incomplete
+                EXIT_CODE=1
+                ;;
+            *) malformed 'invalid redundancy decision tuple' ;;
+        esac
+        [ "$rationale" != not_applicable ] || malformed 'redundancy rationale is missing'
+        [ "$most_efficient_path" != not_applicable ] || malformed 'efficient path is missing'
+        [ "$safety_assessment" != not_applicable ] || malformed 'safety assessment is missing'
+        ;;
+    ambiguous)
+        [ "$invocation_reason" = "$REQUIRED_REASON" ] || malformed 'wrong ambiguous invocation reason'
+        [ "$strategist_invoked" = yes ] || malformed 'strategist was not invoked'
+        [ "$verdict/$worth_building/$gate_status/$route" = INCOMPLETE/conditional/block/return_to_prd ] \
+            || malformed 'invalid ambiguous decision tuple'
+        [ "$rationale" != not_applicable ] || malformed 'ambiguous rationale is missing'
+        [ "$most_efficient_path" != not_applicable ] || malformed 'ambiguous path is missing'
+        [ "$safety_assessment" != not_applicable ] || malformed 'ambiguous safety assessment is missing'
+        RESULT=block
+        REASON=scope_ambiguous
+        EXIT_CODE=1
+        ;;
+    non_matching)
+        case "$COMPLEXITY:$invocation_reason:$strategist_invoked" in
+            L1:none:no|L2:none:no|L1:redundancy_gate:yes|L2:redundancy_gate:yes|L3:complexity_gate:yes|L4:complexity_gate:yes|L3:both:yes|L4:both:yes) ;;
+            *) malformed 'invalid non-matching invocation tuple' ;;
+        esac
+        [ "$verdict/$worth_building/$gate_status/$route" = NOT_APPLICABLE/not_applicable/not_applicable/proceed ] \
+            || malformed 'invalid non-matching decision tuple'
+        [ "$rationale" = not_applicable ] || malformed 'non-matching rationale must be not_applicable'
+        [ "$most_efficient_path" = not_applicable ] || malformed 'non-matching path must be not_applicable'
+        [ "$safety_assessment" = not_applicable ] || malformed 'non-matching safety must be not_applicable'
+        RESULT=normal_route
+        REASON=not_applicable
+        EXIT_CODE=0
+        ;;
+esac
+
+emit_result "$RESULT" "$REASON"
+exit "$EXIT_CODE"

--- a/documentation/explanation/pipeline.md
+++ b/documentation/explanation/pipeline.md
@@ -53,13 +53,20 @@ init → prd → plan → design → do → qa → compliance → archive
 
 **What happens:**
 1. Analyze PRD and project context
-2. Strategist gate (L3-4 mandatory): Value/Risk/Cost assessment
-3. Component breakdown — list all modified and new files
-4. Interface design — function signatures, API contracts
-5. Security design — threat model, controls (Appendix A)
-6. Implementation steps with code examples
-7. Rollback strategy
-8. Validation checklist
+2. Whole-scope semantic screen: distinguish wholly reductive no-new-behavior
+   work, clearly non-matching work, and ambiguity without relying on keywords
+3. Strategist gate: mandatory for L3/L4 and for reductive or ambiguous scope at
+   every complexity; a matching L3/L4 task reuses one invocation
+4. Parent-normalized, task/invocation/scope-bound decision record is validated
+   and logged; a valid specialized `GO` or valid non-matching normal route may
+   reach the unchanged next gate, but an L3/L4 general strategist negative
+   remains non-advancing
+5. Architectural-superseding probe — remains mandatory and can still cancel,
+   reduce, or reframe the task
+6. Component breakdown — list all modified and new files
+7. Interface design — function signatures, API contracts
+8. Security design — threat model, controls (Appendix A)
+9. Implementation steps, rollback strategy, and validation checklist
 
 ---
 

--- a/documentation/reference/agents.md
+++ b/documentation/reference/agents.md
@@ -8,7 +8,7 @@ Datarim includes 18 specialized agents. Each agent is a persona with defined cap
 |-------|------|-------|----------------|
 | planner | Lead Project Manager | opus | /dr-init, /dr-plan, /dr-archive |
 | architect | Chief Architect | opus | /dr-prd, /dr-design |
-| strategist | Strategic Advisor | opus | /dr-plan (L3-4) |
+| strategist | Strategic Advisor | opus | /dr-plan (L3-4; redundancy-only or ambiguous L1-L2) |
 | security | Security Analyst | opus | /dr-design, /dr-qa, /dr-compliance |
 | reviewer | QA & Security Lead | opus | /dr-qa, /dr-archive (Step 0.5 reflection) |
 | skill-creator | Skill/Agent/Command Creator | opus | /dr-addskill |

--- a/documentation/reference/commands.md
+++ b/documentation/reference/commands.md
@@ -39,7 +39,7 @@ Source: TUNE-0032. Spec: `skills/cta-format/SKILL.md`. Template: `templates/cta-
 |---------|-------|-------|-------------|
 | `/dr-init` | Initialize | planner | Create task, assess complexity, set up `datarim/`. Includes Step 2.5b — non-blocking topic-overlap advisory against pending backlog (v2.7.0+). Emits CTA. |
 | `/dr-prd` | Requirements | architect | Generate PRD with discovery interview. Emits CTA. |
-| `/dr-plan` | Planning | planner | Detailed implementation plan with strategist gate. Emits CTA. |
+| `/dr-plan` | Planning | planner | Detailed implementation plan with strategist gate. Emits CTA; a logged strategist decision is mandatory for redundancy-only or ambiguous scope at any complexity |
 | `/dr-design` | Design | architect | Architecture exploration with consilium (L3-4). Emits CTA. |
 | `/dr-do` | Execution | developer | TDD development, one method at a time. Emits CTA. |
 | `/dr-qa` | Quality | reviewer | Multi-layer verification (PRD, design, plan, code). For deploy-class tasks, Layer 4g (Prod-Readiness Gate) runs a read-only test↔prod runner symmetry probe and blocks merge-proposal on FAIL/BLOCKED. Emits CTA (FAIL-Routing variant on BLOCKED). |
@@ -47,6 +47,13 @@ Source: TUNE-0032. Spec: `skills/cta-format/SKILL.md`. Template: `templates/cta-
 | `/dr-compliance` | Hardening | compliance | 7-step post-QA hardening workflow. Compliance report follows `templates/compliance-report-template.md` (v2.14.0+): four top sections in strict order — «Начальная задача», «Как решили», «Артефакты задачи», «Следующие шаги» — plus an audit addendum under `---` carrying `### Step-by-step verdicts`, `### Remaining risks`, `### Related`. Emits CTA (FAIL-Routing variant on NON-COMPLIANT). |
 | `/dr-archive` | Archive | reviewer (Step 0.5 reflection) + planner (Steps 1-7) | Reflection + evolution proposals + complete task + update backlog + reset context. For deploy-class tasks, Step 0.4 (Prod-Merge Verification Gate) blocks archive until the production merge is done AND verified. Archive doc follows `templates/archive-template.md` (v2.14.0+): four top sections in strict order — «Начальная задача», «Как решили», «Артефакты задачи», «Следующие шаги» — plus an audit addendum under `---` carrying `### verification_outcome`, `### Acceptance Criteria`, `### Lessons Learned`, `### Operator Handoff`, `### Related`. The «Как решили» section is a single-level bullet list that maps each operator-brief bullet to a quoted item + Russian status word (выполнено / частично / не выполнено / неприменимо) + one or two plain-language sentences; expectations fold into the same list with marker «(уточнение брифа)». Emits CTA. |
 | `/dr-auto` | Autonomous | orchestrator (spawns per-stage subagents) | Subagent orchestrator that drives a task from its current status to a passing `/dr-compliance` + reflection — it does NOT run the final `/dr-archive`. Spawns the matching agent per stage (planner/architect/developer/reviewer/compliance) via the Agent tool and summarises each result to decide the next stage. Activates `autonomous-mode.md` via env var `DATARIM_AUTO_MODE=1` + marker `datarim/.auto-mode-active`; the Question Suppression Ladder suppresses clarification questions; hard-gated actions still escalate to the operator. Stage-replay allowed. Two modes — Continue (`/dr-auto {TASK-ID}` resume) / Bootstrap (`/dr-auto "<free-text>"`). Emits CTA + stage snapshot `stage: auto`. |
+
+`/dr-plan` binds the specialized decision to the current task, invocation, and
+canonical-scope digest. The read-only
+`dev-tools/check-strategist-gate-record.sh` validates the closed 18-field
+record and returns advancing, normal-route, valid non-advancing, or malformed;
+it never classifies prose, invokes the strategist, writes files, or selects a
+route. Missing or malformed evidence returns the task to `/dr-prd`.
 
 ## Content Commands (3)
 

--- a/documentation/tutorials/getting-started.md
+++ b/documentation/tutorials/getting-started.md
@@ -449,6 +449,14 @@ After initialization, the pipeline depends on the task's complexity level. Datar
 /dr-archive
 ```
 
+During `/dr-plan`, Datarim checks the whole task scope before detailed planning.
+If every deliverable only removes redundancy, dead code, or duplicate surfaces
+without adding behavior—or if that claim is still ambiguous—the strategist
+review is mandatory even for L1/L2. Datarim logs one scope-bound decision; L3/L4
+reuse their normal strategist invocation. A valid `GO` reaches the existing
+architectural-superseding probe, not implementation, and every later hard gate
+still applies. Clearly non-matching work follows the normal complexity route.
+
 ### L3+ -- Feature or Major (5+ files, 200+ lines)
 
 ```

--- a/skills/visual-maps/utility-and-dependencies.md
+++ b/skills/visual-maps/utility-and-dependencies.md
@@ -77,7 +77,7 @@ graph TD
     prd --> architect
     prd -.->|"Phase 1.3"| researcher
     plan --> planner
-    plan -.->|"L3-4"| strategist
+    plan -.->|"L3-4 or reductive/ambiguous scope"| strategist
     design --> architect
     design -.->|"L3-4"| security_agent
     design -.->|"L3-4"| sre_agent

--- a/tests/dr-plan-strategist-redundancy-gate.bats
+++ b/tests/dr-plan-strategist-redundancy-gate.bats
@@ -497,7 +497,7 @@ replace_field() {
     [ "$step3_line" -lt "$step4_line" ]
     grep -qF 'unlocks Step 4 only' "$COMMAND"
     grep -qF 'AUTOMATIC SPEC-GRAPH VALIDATION' "$COMMAND"
-    grep -qF 'AUTOMATIC POST-STEP SELF-VERIFICATION' "$COMMAND"
+    grep -qF '## Post-Step Self-Verification Hook (Automatic)' "$COMMAND"
     grep -qF 'Stage Snapshot Emission' "$COMMAND"
 }
 

--- a/tests/dr-plan-strategist-redundancy-gate.bats
+++ b/tests/dr-plan-strategist-redundancy-gate.bats
@@ -1,0 +1,520 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    HELPER="$REPO_ROOT/dev-tools/check-strategist-gate-record.sh"
+    COMMAND="$REPO_ROOT/commands/dr-plan.md"
+    STRATEGIST="$REPO_ROOT/agents/strategist.md"
+    TASK_ID="TUNE-0141"
+    INVOCATION_ID="plan-20260720T011722Z"
+    DIGEST="1005d94539506a705895eb61caa2da20c53d55d75b0ae493a96ca46b633f8444"
+    TEST_ROOT="$BATS_TEST_TMPDIR/workspace-$BATS_TEST_NUMBER"
+    TASK_DIR="$TEST_ROOT/datarim/.auto/strategist-gate/$TASK_ID"
+    RECORD_REL="datarim/.auto/strategist-gate/$TASK_ID/$INVOCATION_ID.record"
+    RECORD="$TEST_ROOT/$RECORD_REL"
+    REAL_STAT_BIN="$(command -v stat)"
+    mkdir -p "$TASK_DIR"
+    chmod 700 "$TASK_DIR"
+}
+
+make_swapping_stat() {
+    swap_kind="$1"
+    wrapper_dir="$BATS_TEST_TMPDIR/stat-wrapper-$BATS_TEST_NUMBER-$swap_kind"
+    mkdir -p "$wrapper_dir"
+    printf '%s\n' 0 >"$wrapper_dir/count"
+    cat >"$wrapper_dir/stat" <<'EOF'
+#!/bin/sh
+count=$(cat "$SWAP_COUNT")
+count=$((count + 1))
+printf '%s\n' "$count" >"$SWAP_COUNT"
+if [ "$count" -eq 5 ]; then
+    case "$SWAP_KIND" in
+        record)
+            mv "$SWAP_RECORD" "$SWAP_RECORD.old"
+            cp "$SWAP_REPLACEMENT" "$SWAP_RECORD"
+            chmod 600 "$SWAP_RECORD"
+            ;;
+        directory)
+            mv "$SWAP_TASK_DIR" "$SWAP_TASK_DIR.old"
+            mkdir -p "$SWAP_TASK_DIR"
+            chmod 700 "$SWAP_TASK_DIR"
+            cp "$SWAP_REPLACEMENT" "$SWAP_RECORD"
+            chmod 600 "$SWAP_RECORD"
+            ;;
+    esac
+fi
+exec "$REAL_STAT_BIN" "$@"
+EOF
+    chmod 755 "$wrapper_dir/stat"
+    SWAP_WRAPPER_DIR="$wrapper_dir"
+    SWAP_COUNT_FILE="$wrapper_dir/count"
+}
+
+write_record() {
+    cat >"$RECORD" <<EOF
+schema_version=1
+task_id=$TASK_ID
+invocation_id=$INVOCATION_ID
+scope_digest=$DIGEST
+complexity=L3
+classification=non_matching
+positive_scope_test=fail
+no_new_behavior_test=fail
+scope_evidence=datarim/tasks/$TASK_ID-init-task.md:21,datarim/prd/PRD-$TASK_ID.md:47
+invocation_reason=complexity_gate
+strategist_invoked=yes
+verdict=NOT_APPLICABLE
+worth_building=not_applicable
+rationale=not_applicable
+most_efficient_path=not_applicable
+safety_assessment=not_applicable
+gate_status=not_applicable
+route=proceed
+EOF
+    chmod 600 "$RECORD"
+}
+
+run_helper() {
+    run "$HELPER" \
+        --root "$TEST_ROOT" \
+        --record "$RECORD_REL" \
+        --task "$TASK_ID" \
+        --complexity L3 \
+        --invocation "$INVOCATION_ID" \
+        --scope-digest "$DIGEST"
+}
+
+run_helper_at_complexity() {
+    selected_complexity="$1"
+    run "$HELPER" \
+        --root "$TEST_ROOT" \
+        --record "$RECORD_REL" \
+        --task "$TASK_ID" \
+        --complexity "$selected_complexity" \
+        --invocation "$INVOCATION_ID" \
+        --scope-digest "$DIGEST"
+}
+
+replace_field() {
+    field="$1"
+    value="$2"
+    awk -F= -v key="$field" -v replacement="$value" '
+        $1 == key { print key "=" replacement; next }
+        { print }
+    ' "$RECORD" >"$RECORD.next"
+    mv "$RECORD.next" "$RECORD"
+    chmod 600 "$RECORD"
+}
+
+@test "[validator] help is available and missing arguments use exit 64" {
+    run "$HELPER" --help
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"--scope-digest"* ]]
+
+    run "$HELPER" --task "$TASK_ID"
+    [ "$status" -eq 64 ]
+
+    run "$HELPER" $'--token=secret\033[31m\nforged'
+    [ "$status" -eq 64 ]
+    [ "$output" = "check-strategist-gate-record: unknown flag" ]
+}
+
+@test "[validator] valid L3 non-matching record preserves the normal route" {
+    write_record
+    run_helper
+    [ "$status" -eq 0 ]
+    [ "$output" = $'result=normal_route\nreason=not_applicable' ]
+}
+
+@test "[validator] valid L2 redundancy-only GO advances" {
+    write_record
+    replace_field complexity L2
+    replace_field classification redundancy_only
+    replace_field positive_scope_test pass
+    replace_field no_new_behavior_test pass
+    replace_field invocation_reason redundancy_gate
+    replace_field verdict GO
+    replace_field worth_building yes
+    replace_field rationale "removal is worth doing"
+    replace_field most_efficient_path "delete the unused survivor"
+    replace_field safety_assessment "rollback remains available"
+    replace_field gate_status pass
+    run "$HELPER" --root "$TEST_ROOT" --record "$RECORD_REL" --task "$TASK_ID" \
+        --complexity L2 --invocation "$INVOCATION_ID" --scope-digest "$DIGEST"
+    [ "$status" -eq 0 ]
+    [ "$output" = $'result=advance\nreason=strategist_go' ]
+}
+
+@test "[validator] valid NO_GO PIVOT and INCOMPLETE records block" {
+    for verdict_worth in "NO_GO no" "PIVOT conditional" "INCOMPLETE conditional"; do
+        write_record
+        replace_field classification redundancy_only
+        replace_field positive_scope_test pass
+        replace_field no_new_behavior_test pass
+        replace_field invocation_reason both
+        read -r selected_verdict selected_worth <<<"$verdict_worth"
+        replace_field verdict "$selected_verdict"
+        replace_field worth_building "$selected_worth"
+        replace_field rationale "strategist did not approve"
+        replace_field most_efficient_path "return to product definition"
+        replace_field safety_assessment "no later gate is bypassed"
+        replace_field gate_status block
+        replace_field route return_to_prd
+        run_helper
+        [ "$status" -eq 1 ]
+        [ "${lines[0]}" = "result=block" ]
+    done
+}
+
+@test "[validator] ambiguous predicate pairs are complete but non-advancing" {
+    for pair in "unknown unknown" "unknown pass" "pass unknown"; do
+        write_record
+        read -r selected_positive selected_behavior <<<"$pair"
+        replace_field classification ambiguous
+        replace_field positive_scope_test "$selected_positive"
+        replace_field no_new_behavior_test "$selected_behavior"
+        replace_field invocation_reason both
+        replace_field verdict INCOMPLETE
+        replace_field worth_building conditional
+        replace_field rationale "scope evidence is unresolved"
+        replace_field most_efficient_path "return to product definition"
+        replace_field safety_assessment "do not advance"
+        replace_field gate_status block
+        replace_field route return_to_prd
+        run_helper
+        [ "$status" -eq 1 ]
+    done
+}
+
+@test "[validator] every allowed non-matching predicate pair preserves routing" {
+    for pair in "fail fail" "fail pass" "fail unknown" "pass fail" "unknown fail"; do
+        write_record
+        read -r selected_positive selected_behavior <<<"$pair"
+        replace_field positive_scope_test "$selected_positive"
+        replace_field no_new_behavior_test "$selected_behavior"
+        run_helper
+        [ "$status" -eq 0 ]
+        [ "${lines[0]}" = "result=normal_route" ]
+    done
+}
+
+@test "[validator] every complexity and invocation-reason truth-table row is executable" {
+    for complexity_reason in "L1 redundancy_gate" "L2 redundancy_gate" "L3 both" "L4 both"; do
+        read -r selected_complexity selected_reason <<<"$complexity_reason"
+
+        write_record
+        replace_field complexity "$selected_complexity"
+        replace_field classification redundancy_only
+        replace_field positive_scope_test pass
+        replace_field no_new_behavior_test pass
+        replace_field invocation_reason "$selected_reason"
+        replace_field verdict GO
+        replace_field worth_building yes
+        replace_field rationale "the reduction is worth doing"
+        replace_field most_efficient_path "remove the unused surface"
+        replace_field safety_assessment "rollback remains available"
+        replace_field gate_status pass
+        run_helper_at_complexity "$selected_complexity"
+        [ "$status" -eq 0 ]
+
+        for verdict_worth in "NO_GO no" "PIVOT conditional" "INCOMPLETE conditional"; do
+            read -r selected_verdict selected_worth <<<"$verdict_worth"
+            replace_field verdict "$selected_verdict"
+            replace_field worth_building "$selected_worth"
+            replace_field gate_status block
+            replace_field route return_to_prd
+            run_helper_at_complexity "$selected_complexity"
+            [ "$status" -eq 1 ]
+        done
+
+        replace_field classification ambiguous
+        replace_field positive_scope_test unknown
+        replace_field no_new_behavior_test pass
+        replace_field verdict INCOMPLETE
+        replace_field worth_building conditional
+        run_helper_at_complexity "$selected_complexity"
+        [ "$status" -eq 1 ]
+    done
+
+    for normal_tuple in \
+        "L1 none no" "L1 redundancy_gate yes" \
+        "L2 none no" "L2 redundancy_gate yes" \
+        "L3 complexity_gate yes" "L3 both yes" \
+        "L4 complexity_gate yes" "L4 both yes"; do
+        read -r selected_complexity selected_reason selected_invoked <<<"$normal_tuple"
+        write_record
+        replace_field complexity "$selected_complexity"
+        replace_field invocation_reason "$selected_reason"
+        replace_field strategist_invoked "$selected_invoked"
+        run_helper_at_complexity "$selected_complexity"
+        [ "$status" -eq 0 ]
+        [ "${lines[0]}" = "result=normal_route" ]
+    done
+}
+
+@test "[validator] missing duplicate and unknown keys are malformed" {
+    for key in schema_version task_id invocation_id scope_digest complexity \
+        classification positive_scope_test no_new_behavior_test scope_evidence \
+        invocation_reason strategist_invoked verdict worth_building rationale \
+        most_efficient_path safety_assessment gate_status route; do
+        write_record
+        sed "/^${key}=/d" "$RECORD" >"$RECORD.next" && mv "$RECORD.next" "$RECORD"
+        chmod 600 "$RECORD"
+        run_helper
+        [ "$status" -eq 2 ]
+    done
+
+    write_record
+    printf '%s\n' 'route=proceed' >>"$RECORD"
+    run_helper
+    [ "$status" -eq 2 ]
+
+    write_record
+    printf '%s\n' 'extra_key=no' >>"$RECORD"
+    run_helper
+    [ "$status" -eq 2 ]
+}
+
+@test "[validator] task invocation digest and complexity bindings are exact" {
+    write_record
+    replace_field task_id TUNE-9999
+    run_helper
+    [ "$status" -eq 2 ]
+
+    write_record
+    replace_field invocation_id plan-other
+    run_helper
+    [ "$status" -eq 2 ]
+
+    write_record
+    replace_field scope_digest aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+    run_helper
+    [ "$status" -eq 2 ]
+
+    write_record
+    replace_field complexity L2
+    run_helper
+    [ "$status" -eq 2 ]
+}
+
+@test "[validator] unsafe task and invocation components fail before path access" {
+    write_record
+    for bad_task in ../TUNE-0141 /TUNE-0141 -TUNE-0141 TUNE/0141 $'TUNE-0141\t'; do
+        run "$HELPER" --root "$TEST_ROOT" --record "$RECORD_REL" --task "$bad_task" \
+            --complexity L3 --invocation "$INVOCATION_ID" --scope-digest "$DIGEST"
+        [ "$status" -eq 64 ]
+    done
+    long_invocation="i$(printf '%0100d' 0)"
+    for bad_invocation in ../plan /plan -plan plan/id "$long_invocation" $'plan\tbad'; do
+        run "$HELPER" --root "$TEST_ROOT" --record "$RECORD_REL" --task "$TASK_ID" \
+            --complexity L3 --invocation "$bad_invocation" --scope-digest "$DIGEST"
+        [ "$status" -eq 64 ]
+    done
+}
+
+@test "[validator] out-of-root and non-canonical record paths are rejected" {
+    write_record
+    run "$HELPER" --root "$TEST_ROOT" --record "../$RECORD_REL" --task "$TASK_ID" \
+        --complexity L3 --invocation "$INVOCATION_ID" --scope-digest "$DIGEST"
+    [ "$status" -eq 2 ]
+
+    run "$HELPER" --root "$TEST_ROOT" --record "/tmp/$INVOCATION_ID.record" --task "$TASK_ID" \
+        --complexity L3 --invocation "$INVOCATION_ID" --scope-digest "$DIGEST"
+    [ "$status" -eq 2 ]
+}
+
+@test "[validator] wrong mode symlink and symlinked intermediate component are rejected" {
+    write_record
+    chmod 644 "$RECORD"
+    run_helper
+    [ "$status" -eq 2 ]
+
+    write_record
+    mv "$RECORD" "$RECORD.target"
+    ln -s "$RECORD.target" "$RECORD"
+    run_helper
+    [ "$status" -eq 2 ]
+
+    alt_root="$BATS_TEST_TMPDIR/alt-$BATS_TEST_NUMBER"
+    mkdir -p "$alt_root/.auto/strategist-gate/$TASK_ID"
+    chmod 700 "$alt_root/.auto/strategist-gate/$TASK_ID"
+    mv "$TEST_ROOT/datarim" "$TEST_ROOT/datarim.real"
+    ln -s "$alt_root" "$TEST_ROOT/datarim"
+    run_helper
+    [ "$status" -eq 2 ]
+}
+
+@test "[validator] task directory must be current-user-owned mode 0700" {
+    write_record
+    chmod 755 "$TASK_DIR"
+    run_helper
+    [ "$status" -eq 2 ]
+}
+
+@test "[validator] wrong ownership is rejected when the fixture can change owner" {
+    [ "$(id -u)" -eq 0 ] || skip "requires root to construct a wrong-owner fixture"
+    write_record
+    chown 65534 "$TASK_DIR"
+    run_helper
+    [ "$status" -eq 2 ]
+}
+
+@test "[validator] descriptor and task-directory swaps are rejected" {
+    for swap_kind in record directory; do
+        write_record
+        replacement="$BATS_TEST_TMPDIR/replacement-$BATS_TEST_NUMBER-$swap_kind.record"
+        cp "$RECORD" "$replacement"
+        chmod 600 "$replacement"
+        make_swapping_stat "$swap_kind"
+        run env \
+            PATH="$SWAP_WRAPPER_DIR:$PATH" \
+            REAL_STAT_BIN="$REAL_STAT_BIN" \
+            SWAP_COUNT="$SWAP_COUNT_FILE" \
+            SWAP_KIND="$swap_kind" \
+            SWAP_RECORD="$RECORD" \
+            SWAP_REPLACEMENT="$replacement" \
+            SWAP_TASK_DIR="$TASK_DIR" \
+            "$HELPER" --root "$TEST_ROOT" --record "$RECORD_REL" --task "$TASK_ID" \
+            --complexity L3 --invocation "$INVOCATION_ID" --scope-digest "$DIGEST"
+        [ "$status" -eq 2 ]
+    done
+}
+
+@test "[validator] invalid evidence paths and line references are rejected" {
+    for evidence in "/tmp/x:1" "../tasks/x:1" "-option:1" "--option:1" \
+        "datarim/tasks/TUNE-9999-init-task.md:1" "datarim/tasks/$TASK_ID-init-task.md:0"; do
+        write_record
+        replace_field scope_evidence "$evidence"
+        run_helper
+        [ "$status" -eq 2 ]
+    done
+}
+
+@test "[validator] controls UTF-8 oversized values and secret-like payloads are rejected" {
+    write_record
+    sed '/^rationale=/d' "$RECORD" >"$RECORD.next"
+    printf 'rationale=not_app\0licable\n' >>"$RECORD.next"
+    mv "$RECORD.next" "$RECORD"
+    chmod 600 "$RECORD"
+    run_helper
+    [ "$status" -eq 2 ]
+
+    write_record
+    sed '/^rationale=/d' "$RECORD" >"$RECORD.next"
+    printf 'rationale=not_app\0licable' >>"$RECORD.next"
+    mv "$RECORD.next" "$RECORD"
+    chmod 600 "$RECORD"
+    run_helper
+    [ "$status" -eq 2 ]
+
+    write_record
+    replace_field rationale $'bad\tvalue'
+    run_helper
+    [ "$status" -eq 2 ]
+
+    write_record
+    replace_field rationale "café"
+    run_helper
+    [ "$status" -eq 2 ]
+
+    write_record
+    replace_field rationale "$(printf '%0501d' 0)"
+    run_helper
+    [ "$status" -eq 2 ]
+
+    for payload in "token=abc" "password: abc" "Authorization: Bearer abc" \
+        "eyJhbGciOiJIUzI1NiJ9.payload.signature" "-----BEGIN PRIVATE KEY-----" \
+        "api_key=abc" "route=/dr-do" "(route=/dr-do)" "next_step=/dr-do" \
+        "Next Step: /dr-do" "see(../secrets)" "path=/etc/passwd" \
+        "operator@example.com" "+1 (555) 123-4567"; do
+        write_record
+        replace_field rationale "$payload"
+        run_helper
+        [ "$status" -eq 2 ]
+    done
+}
+
+@test "[validator] contradictory truth-table tuples are rejected" {
+    write_record
+    replace_field classification redundancy_only
+    run_helper
+    [ "$status" -eq 2 ]
+
+    write_record
+    replace_field positive_scope_test unknown
+    replace_field no_new_behavior_test pass
+    run_helper
+    [ "$status" -eq 2 ]
+
+    write_record
+    replace_field invocation_reason both
+    replace_field strategist_invoked no
+    run_helper
+    [ "$status" -eq 2 ]
+}
+
+@test "[validator] complexity matrix rejects L1 complexity_gate and L3 none" {
+    write_record
+    replace_field complexity L1
+    run "$HELPER" --root "$TEST_ROOT" --record "$RECORD_REL" --task "$TASK_ID" \
+        --complexity L1 --invocation "$INVOCATION_ID" --scope-digest "$DIGEST"
+    [ "$status" -eq 2 ]
+
+    write_record
+    replace_field invocation_reason none
+    replace_field strategist_invoked no
+    run_helper
+    [ "$status" -eq 2 ]
+}
+
+@test "[contract] dr-plan mandates semantic classification strategist dispatch and validated logging" {
+    grep -qF 'redundancy_only' "$COMMAND"
+    grep -qF 'non_matching' "$COMMAND"
+    grep -qF 'ambiguous' "$COMMAND"
+    grep -qF 'keyword' "$COMMAND"
+    grep -qF 'exactly one strategist invocation' "$COMMAND"
+    grep -qF 'atomic no-clobber' "$COMMAND"
+    grep -qF 'check-strategist-gate-record.sh' "$COMMAND"
+    grep -qF 'persist the exact validated' "$COMMAND"
+    grep -qF 'return_to_prd' "$COMMAND"
+    grep -qF 'separate parent-owned decision' "$COMMAND"
+    grep -qF 'non-advancing even though the specialized helper returns' "$COMMAND"
+}
+
+@test "[contract] strategist proposes assessment only and cannot route or write" {
+    grep -qF 'Closed redundancy-gate response' "$STRATEGIST"
+    grep -qF 'intentional redundancy' "$STRATEGIST"
+    grep -qF 'most_efficient_path' "$STRATEGIST"
+    grep -qF 'must not write' "$STRATEGIST"
+    grep -qF 'must not select' "$STRATEGIST"
+}
+
+@test "[contract] strategist GO unlocks Step 4 without weakening later hard gates" {
+    step3_line="$(grep -n '^3\.  \*\*Strategist Gate' "$COMMAND" | cut -d: -f1)"
+    step4_line="$(grep -n '^4\.  \*\*Detailed Design' "$COMMAND" | cut -d: -f1)"
+    [ -n "$step3_line" ]
+    [ -n "$step4_line" ]
+    [ "$step3_line" -lt "$step4_line" ]
+    grep -qF 'unlocks Step 4 only' "$COMMAND"
+    grep -qF 'AUTOMATIC SPEC-GRAPH VALIDATION' "$COMMAND"
+    grep -qF 'AUTOMATIC POST-STEP SELF-VERIFICATION' "$COMMAND"
+    grep -qF 'Stage Snapshot Emission' "$COMMAND"
+}
+
+@test "[docs] shipped references describe the same mandatory redundancy gate" {
+    for file in \
+        CLAUDE.md \
+        README.md \
+        documentation/explanation/pipeline.md \
+        documentation/reference/agents.md \
+        documentation/reference/commands.md \
+        documentation/tutorials/getting-started.md \
+        skills/visual-maps/utility-and-dependencies.md; do
+        grep -Eqi 'redundancy|reductive' "$REPO_ROOT/$file"
+        grep -Eqi 'strategist' "$REPO_ROOT/$file"
+    done
+    grep -qF 'check-strategist-gate-record.sh' \
+        "$REPO_ROOT/documentation/reference/commands.md"
+    grep -qF 'architectural-superseding probe' \
+        "$REPO_ROOT/documentation/tutorials/getting-started.md"
+}


### PR DESCRIPTION
Relands **TUNE-0141**, one of the 22 tasks the TUNE-0541 sweep found marked `done`
with none of its content in `origin/main`. The work was implemented and verified
inside a worktree branch; the pull request was never opened.

Verdict: **GENUINELY-LOST-WORK-EXISTS** — see
`documentation/archive/framework/TUNE-0541-verdict-table.md`.

Cherry-picked onto current `main` from the original worktree branch. The branch's
merge-base *is* an ancestor of `main`, so this is a clean single-commit reland
rather than part of the re-rooted 0141/0206/0365 chain.

Verified before opening: `shellcheck --severity=warning` (CI's own severity) clean
on every shell file the commit ships, and every `.bats` file it touches run green.

The `closure-gate.sh` merged in #278 reports this branch's work as absent from
`main` today, and will report it present once this merges — that transition is the
gate's intended signal.