### PR TITLE
test(tune-0206): retarget a stale co-assertion after main renamed the section

### DIFF
--- a/.datarim/version-deferrals/TUNE-0206.record
+++ b/.datarim/version-deferrals/TUNE-0206.record
@@ -1,0 +1,13 @@
+schema-version: 1
+task-id: TUNE-0206
+base-commit: 4b56fa2212be39618432e6d3baf40d5850699214
+shipped-diff-digest: 1e48b0e199e42be3f97fc4258f26cee8553d7db3ad547bbc8da3c41b566f8aaf
+decision: defer
+reason-code: batch-accumulation
+reason: Operator requested this framework change join the next consolidated release.
+delivery-kind: release-train
+delivery-target: next-consolidated-release
+source-kind: init-task
+source-digest: 7d6152d728d08ae0d1c1b8740b81e882f97e9a1246095e4788bcb94fa0db94a3
+recorded-by: agent
+recorded-at: 2026-07-20T12:47:22Z

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,18 @@ All notable changes to the Datarim framework are documented here. Format follows
 ### Fixed
 
 - **Coworker `write --context` file-type gate documented accurately** — the delegation fragment previously claimed write paths had no allowlist; corrected to describe the `--context` code-gate (needs `--allow-code`/`COWORKER_ALLOW_CODE=1`), the `--target`-only exemption, and the self-recursion doc-generation workaround. (TUNE-0261)
+- **Framework version accountability.** `/dr-init` now pins an immutable
+  repository baseline, while `/dr-do` and `/dr-qa` independently require a
+  version-and-changelog update or a committed, task-bound release deferral for
+  shipped framework behaviour changes. This batch records the explicit
+  consolidated-release deferral without publishing a version. (TUNE-0206)
+
+- **`/dr-orchestrate` context-window self-clearing.** Default-off Claude Code
+  and Codex adapters now checkpoint the active task description and completed
+  snapshot phase before fixed `/compact` or `/clear` instructions, then use
+  snapshot-first `/dr-next` continuity. Exact taught labels remain data-only;
+  same-UID runtime trust requires explicit opt-in. No release or version change
+  is made in this accumulated batch. (TUNE-0167)
 
 ## [2.52.0] — 2026-07-10
 

--- a/commands/dr-do.md
+++ b/commands/dr-do.md
@@ -98,6 +98,21 @@ Note: the machine-local PreToolUse guard remains the hard floor; this Step-0 che
     2. Route to `/dr-plan {TASK-ID}` — the planner re-validates the changed contract.
     3. Resume `/dr-do` only after the plan artefact carries the revised contract.
     Implementation difficulty alone is NOT a valid reason to change a test.
+7.55. **FRAMEWORK VERSION ACCOUNTABILITY** (hard transition gate for the
+    Datarim framework repository): after implementation/tests and the local
+    task commit, run the checker unconditionally. The checker alone classifies
+    applicability; task prose or the parent command must not pre-classify it.
+    ```bash
+    "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-framework-version-accountability.sh" \
+      --task {TASK-ID} --workspace <workspace-root> --repo <framework-repo>
+    ```
+    - Exit 0 with `not_applicable`, `satisfied_by_version`, or
+      `satisfied_by_deferral` permits the remaining `/dr-do` gates.
+    - exit 1 or exit 2 is a hard block with no advisory override: retain the
+      task in `/dr-do`, log the stable disposition, and route to `/dr-do`.
+    - A version deferral covers packaging timing only. It never waives tests,
+      expectations, security, network, spec-graph, self-verification, deploy,
+      QA, or compliance gates.
 
 7.6. **AUTOMATIC SPEC-GRAPH EVIDENCE CHECK**:
     -   As tests and verification artifacts are produced, append canonical lines to the task implementation record:
@@ -191,6 +206,7 @@ Before proceeding to `/dr-qa` or `/dr-archive`:
 [ ] All planned changes implemented?
 [ ] Tests written and passing?
 [ ] Each V-AC-N carries a seeded `Evidence: V-AC-N — <artifact>` line and `spec-graph-gate.sh --stage do` (step 7.6) was run so evidence coverage is verified before `/dr-qa`?
+[ ] Framework version-accountability checker exited 0 when the implementation repository is Datarim?
 [ ] tasks/{TASK-ID}-task-description.md updated with implementation notes?
 [ ] No known regressions introduced?
 [ ] If staged changes touch any networking surface, `"${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/network-exposure-check.sh"` exited 0 against the staged set and the tiered-gate verdict was honoured (or an `advisory_warn` override was logged with Ops Bot event + § Decisions note)?

--- a/commands/dr-init.md
+++ b/commands/dr-init.md
@@ -185,6 +185,21 @@ Note: the machine-local PreToolUse guard remains the hard floor; this Step-0 che
     - Skip silently when re-running `/dr-init` on an existing backlog ID whose init-task already exists — preserve the verbatim history.
     - **License auto-sync**: when the Q&A round-trip (`skills/init-task-persistence/SKILL.md` § Q&A round-trip contract) records an operator license decision for this project, update the project's root `README.md` — replace the "License" section's "TBD" placeholder with the chosen license (name + SPDX identifier where applicable). Skip silently when `README.md` has no "License" section, or the section already names a concrete license (idempotent — never overwrite an operator-set value).
 
+4.65. **CAPTURE FRAMEWORK VERSION BASELINE** (mandatory when the resolved
+    implementation repository is the Datarim framework repository: it contains
+    `VERSION`, `commands/`, and `skills/`):
+    - Immediately after the canonical init-task passes its structural probe,
+      before PRD/plan creation or framework edits, invoke:
+      ```bash
+      "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/capture-framework-version-baseline.sh" \
+        --task {TASK-ID} --workspace "$DATARIM_ROOT" --repo <framework-repo>
+      ```
+    - The helper exclusively captures the current commit/tree and binds it to
+      the task, repository identity, and raw init-task digest. Do not pass a
+      caller-selected base SHA. A byte-identical re-entry is idempotent.
+    - Exit 1 or exit 2 is a hard INIT failure for a framework task. Do not
+      continue to PRD/plan and do not recapture later from `/dr-do`.
+
 4.7. **WRITE EXPECTATIONS SKELETON** (mandatory for all complexity levels L1-L4 — see `$HOME/.claude/skills/expectations-checklist/SKILL.md` § When the file is created):
     - Compute `EXPECTATIONS_FILE="datarim/tasks/{TASK-ID}-expectations.md"`.
     - Skip silently when `EXPECTATIONS_FILE` already exists (re-run `/dr-init` on backlog ID, or operator-amended skeleton from a prior cycle) — preserve operator edits.

--- a/commands/dr-qa.md
+++ b/commands/dr-qa.md
@@ -435,6 +435,25 @@ this skill pre-resolves that decision to "yes".
 
 **Verdict:** PASS | PASS_WITH_NOTES | SKIP | NO-TEST-ENV | FAIL
 
+### Layer 4i — Framework Version Accountability
+
+When the implementation repository is the Datarim framework repository, run
+the shared checker unconditionally and independently of `/dr-do`:
+
+```bash
+"${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-framework-version-accountability.sh" \
+  --task {TASK-ID} --workspace <workspace-root> --repo <framework-repo>
+```
+
+- Exit 0 records the exact stable disposition and contributes PASS.
+- exit 1 or exit 2 makes this layer **FAIL** with no advisory downgrade. The
+  overall QA result is **FAIL**, the pipeline is **BLOCKED**, and must route to
+  `/dr-do`.
+- Recompute against the INIT-owned baseline; never accept a base from task
+  prose, a QA report, or a command argument.
+- This layer is additive and cannot weaken expectations, anti-deferral,
+  security, tests, test-environment, prod-readiness, or any other hard gate.
+
 ```markdown
 ### Layer 4: Code Quality — {VERDICT}
 

--- a/dev-tools/README.md
+++ b/dev-tools/README.md
@@ -22,6 +22,8 @@ Discipline in `code/datarim/CLAUDE.md`).
 | Script | Invoked by |
 |--------|-----------|
 | `check-init-task-presence.sh` | `commands/dr-init.md` Step 4.6 |
+| `capture-framework-version-baseline.sh` | `commands/dr-init.md` Step 4.65 for framework tasks |
+| `check-framework-version-accountability.sh` | `commands/dr-do.md` Step 7.55 and `commands/dr-qa.md` Layer 4i |
 | `check-expectations-checklist.sh` | `commands/dr-qa.md`, `commands/dr-compliance.md`, `commands/dr-archive.md` |
 | `check-deferral-prose.sh` | `commands/dr-qa.md` Layer 3b (advisory), `commands/dr-compliance.md` Step 5c (hard), `commands/dr-archive.md` Step 0.45 |
 | `check-stage-snapshot-on-exit.sh` | `commands/dr-continue.md`, `commands/dr-archive.md`, validator suite |

--- a/dev-tools/capture-framework-version-baseline.sh
+++ b/dev-tools/capture-framework-version-baseline.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# Capture the immutable INIT-owned repository baseline for version accountability.
+set -euo pipefail
+IFS=$'\n\t'
+
+usage() {
+  printf 'Usage: capture-framework-version-baseline.sh --task ID --workspace DIR --repo DIR\n' >&2
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+sha256_text() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$1" | sha256sum | awk '{print $1}'
+  else
+    printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+  fi
+}
+
+stat_owner() {
+  stat -c '%u' "$1" 2>/dev/null || stat -f '%u' "$1"
+}
+
+stat_mode() {
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
+}
+
+stat_identity() {
+  stat -c '%d:%i:%s:%Y' "$1" 2>/dev/null || stat -f '%d:%i:%z:%m' "$1"
+}
+
+trusted_directory() {
+  local path="$1" mode group_digit other_digit
+  [ -d "$path" ] && [ ! -L "$path" ] || return 1
+  [ "$(stat_owner "$path")" = "$(id -u)" ] || return 1
+  mode="$(stat_mode "$path")"
+  [[ "$mode" =~ ^[0-7]{3,4}$ ]] || return 1
+  group_digit="${mode: -2:1}"
+  other_digit="${mode: -1}"
+  [ $((group_digit & 2)) -eq 0 ] && [ $((other_digit & 2)) -eq 0 ]
+}
+
+safe_workspace_directory() {
+  local path="$1" mode other_digit
+  [ -d "$path" ] && [ ! -L "$path" ] || return 1
+  [ "$(stat_owner "$path")" = "$(id -u)" ] || return 1
+  mode="$(stat_mode "$path")"
+  [[ "$mode" =~ ^[0-7]{3,4}$ ]] || return 1
+  other_digit="${mode: -1}"
+  [ $((other_digit & 2)) -eq 0 ]
+}
+
+is_closed_ascii_record() {
+  local path="$1" forbidden last_byte
+  forbidden="$(LC_ALL=C tr -d '\12\40-\176' < "$path" | wc -c | tr -d '[:space:]')"
+  [ "$forbidden" -eq 0 ] || return 1
+  last_byte="$(tail -c 1 "$path" | od -An -tuC | tr -d '[:space:]')"
+  [ "$last_byte" = 10 ]
+}
+
+task="" workspace="" repo=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --task) [ "$#" -ge 2 ] || { usage; exit 2; }; task="$2"; shift 2 ;;
+    --workspace) [ "$#" -ge 2 ] || { usage; exit 2; }; workspace="$2"; shift 2 ;;
+    --repo) [ "$#" -ge 2 ] || { usage; exit 2; }; repo="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage; exit 2 ;;
+  esac
+done
+
+if ! [[ "$task" =~ ^[A-Z]{2,10}-[0-9]{4}(-[A-Za-z0-9]+)*$ ]]; then
+  printf 'framework-version-baseline: error=invalid_task\n' >&2
+  exit 2
+fi
+if [ ! -d "$workspace" ] || [ ! -d "$repo" ] || [ -L "$workspace" ] || [ -L "$repo" ]; then
+  printf 'framework-version-baseline: error=invalid_root\n' >&2
+  exit 2
+fi
+workspace="$(cd "$workspace" && pwd -P)"
+repo="$(cd "$repo" && pwd -P)"
+trusted_directory "$repo" || { printf 'framework-version-baseline: error=unsafe_repo\n' >&2; exit 2; }
+for component in "$workspace" "$workspace/datarim" "$workspace/datarim/tasks"; do
+  safe_workspace_directory "$component" || { printf 'framework-version-baseline: error=unsafe_workspace_path\n' >&2; exit 2; }
+done
+git -C "$repo" rev-parse --git-dir >/dev/null 2>&1 || { printf 'framework-version-baseline: error=not_git_repo\n' >&2; exit 2; }
+
+init_task="$workspace/datarim/tasks/$task-init-task.md"
+if [ ! -f "$init_task" ] || [ -L "$init_task" ]; then
+  printf 'framework-version-baseline: error=missing_init_task\n' >&2
+  exit 2
+fi
+
+record_dir="$workspace/datarim/.auto/version-accountability/$task"
+record="$record_dir/baseline.record"
+head_oid="$(git -C "$repo" rev-parse 'HEAD^{commit}')"
+tree_oid="$(git -C "$repo" rev-parse 'HEAD^{tree}')"
+repo_digest="$(sha256_text "$repo")"
+init_digest="$(sha256_file "$init_task")"
+
+if [ -f "$record" ] && [ ! -L "$record" ]; then
+  for component in "$workspace/datarim/.auto" "$workspace/datarim/.auto/version-accountability" "$record_dir"; do
+    trusted_directory "$component" || { printf 'framework-version-baseline: error=unsafe_path\n' >&2; exit 2; }
+  done
+  existing_lines=()
+  while IFS= read -r line || [ -n "$line" ]; do existing_lines[${#existing_lines[@]}]="$line"; done < "$record"
+  existing_repo_digest="${existing_lines[2]-}"
+  existing_repo_digest="${existing_repo_digest#repo-root-sha256: }"
+  existing_base="${existing_lines[3]-}"
+  existing_base="${existing_base#base-commit: }"
+  existing_tree="${existing_lines[4]-}"
+  existing_tree="${existing_tree#base-tree: }"
+  existing_init_digest="${existing_lines[5]-}"
+  existing_init_digest="${existing_init_digest#init-task-sha256: }"
+  if [ "$(stat_owner "$record")" != "$(id -u)" ] \
+    || [ "$(stat_mode "$record")" != 600 ] \
+    || ! is_closed_ascii_record "$record" \
+    || [ "${#existing_lines[@]}" -ne 7 ] \
+    || [ "${existing_lines[0]}" != 'schema-version: 1' ] \
+    || [ "${existing_lines[1]}" != "task-id: $task" ] \
+    || ! [[ "${existing_lines[2]}" == repo-root-sha256:\ * ]] \
+    || ! [[ "${existing_lines[3]}" == base-commit:\ * ]] \
+    || ! [[ "${existing_lines[4]}" == base-tree:\ * ]] \
+    || ! [[ "${existing_lines[5]}" == init-task-sha256:\ * ]] \
+    || [ "$existing_repo_digest" != "$repo_digest" ] \
+    || ! [[ "$existing_base" =~ ^[a-f0-9]{40}$ ]] \
+    || ! [[ "$existing_tree" =~ ^[a-f0-9]{40}$ ]] \
+    || ! [[ "$existing_init_digest" =~ ^[a-f0-9]{64}$ ]] \
+    || ! [[ "${existing_lines[6]}" =~ ^captured-at:[[:space:]][0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] \
+    || ! git -C "$repo" cat-file -e "$existing_base^{commit}" 2>/dev/null \
+    || [ "$existing_tree" != "$(git -C "$repo" rev-parse "$existing_base^{tree}" 2>/dev/null)" ] \
+    || ! git -C "$repo" merge-base --is-ancestor "$existing_base" "$head_oid" 2>/dev/null; then
+    printf 'framework-version-baseline: error=record_conflict\n' >&2
+    exit 2
+  fi
+  printf 'framework-version-baseline: disposition=baseline_reused base=%s\n' "$existing_base"
+  exit 0
+fi
+[ ! -e "$record" ] || { printf 'framework-version-baseline: error=unsafe_record\n' >&2; exit 2; }
+
+if [ -e "$workspace/datarim/prd/PRD-$task.md" ] \
+  || [ -e "$workspace/datarim/plans/$task-plan.md" ]; then
+  printf 'framework-version-baseline: error=late_capture\n' >&2
+  exit 2
+fi
+
+if [ -n "$(git -C "$repo" status --porcelain --untracked-files=all)" ]; then
+  printf 'framework-version-baseline: error=dirty_repository\n' >&2
+  exit 2
+fi
+
+umask 077
+for component in "$workspace/datarim/.auto" "$workspace/datarim/.auto/version-accountability" "$record_dir"; do
+  if [ ! -e "$component" ]; then
+    mkdir -- "$component" || { printf 'framework-version-baseline: error=unsafe_path\n' >&2; exit 2; }
+    chmod 700 "$component"
+  fi
+  if ! trusted_directory "$component"; then
+    printf 'framework-version-baseline: error=unsafe_path\n' >&2
+    exit 2
+  fi
+done
+
+tmp="$(mktemp "$record_dir/.baseline.XXXXXX")"
+cleanup() { rm -f -- "$tmp"; }
+trap cleanup EXIT HUP INT TERM
+captured_at="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+printf '%s\n' \
+  'schema-version: 1' \
+  "task-id: $task" \
+  "repo-root-sha256: $repo_digest" \
+  "base-commit: $head_oid" \
+  "base-tree: $tree_oid" \
+  "init-task-sha256: $init_digest" \
+  "captured-at: $captured_at" > "$tmp"
+chmod 600 "$tmp"
+is_closed_ascii_record "$tmp" || { printf 'framework-version-baseline: error=record_encoding\n' >&2; exit 2; }
+tmp_identity="$(stat_identity "$tmp")"
+if ! ln "$tmp" "$record" 2>/dev/null; then
+  printf 'framework-version-baseline: error=record_collision\n' >&2
+  exit 2
+fi
+[ "$(stat_identity "$record")" = "$tmp_identity" ] || { printf 'framework-version-baseline: error=record_identity\n' >&2; exit 2; }
+rm -f -- "$tmp"
+trap - EXIT HUP INT TERM
+printf 'framework-version-baseline: disposition=baseline_created base=%s\n' "$head_oid"

--- a/dev-tools/check-framework-version-accountability.sh
+++ b/dev-tools/check-framework-version-accountability.sh
@@ -1,0 +1,309 @@
+#!/usr/bin/env bash
+# Verify version accountability for the committed task diff. Read-only.
+set -euo pipefail
+IFS=$'\n\t'
+
+usage() {
+  printf 'Usage: check-framework-version-accountability.sh --task ID --workspace DIR --repo DIR\n' >&2
+}
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    shasum -a 256 "$1" | awk '{print $1}'
+  fi
+}
+
+sha256_text() {
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s' "$1" | sha256sum | awk '{print $1}'
+  else
+    printf '%s' "$1" | shasum -a 256 | awk '{print $1}'
+  fi
+}
+
+stat_owner() {
+  stat -c '%u' "$1" 2>/dev/null || stat -f '%u' "$1"
+}
+
+stat_mode() {
+  stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"
+}
+
+stat_identity() {
+  stat -c '%d:%i:%s:%Y' "$1" 2>/dev/null || stat -f '%d:%i:%z:%m' "$1"
+}
+
+trusted_directory() {
+  local path="$1" mode group_digit other_digit
+  [ -d "$path" ] && [ ! -L "$path" ] || return 1
+  [ "$(stat_owner "$path")" = "$(id -u)" ] || return 1
+  mode="$(stat_mode "$path")"
+  [[ "$mode" =~ ^[0-7]{3,4}$ ]] || return 1
+  group_digit="${mode: -2:1}"
+  other_digit="${mode: -1}"
+  [ $((group_digit & 2)) -eq 0 ] && [ $((other_digit & 2)) -eq 0 ]
+}
+
+safe_workspace_directory() {
+  local path="$1" mode other_digit
+  [ -d "$path" ] && [ ! -L "$path" ] || return 1
+  [ "$(stat_owner "$path")" = "$(id -u)" ] || return 1
+  mode="$(stat_mode "$path")"
+  [[ "$mode" =~ ^[0-7]{3,4}$ ]] || return 1
+  other_digit="${mode: -1}"
+  [ $((other_digit & 2)) -eq 0 ]
+}
+
+is_closed_ascii_record() {
+  local path="$1" forbidden last_byte
+  forbidden="$(LC_ALL=C tr -d '\12\40-\176' < "$path" | wc -c | tr -d '[:space:]')"
+  [ "$forbidden" -eq 0 ] || return 1
+  last_byte="$(tail -c 1 "$path" | od -An -tuC | tr -d '[:space:]')"
+  [ "$last_byte" = 10 ]
+}
+
+is_shipped_path() {
+  case "$1" in
+    tests/*|*/tests/*|*/test/*|*/fixtures/*|.github/*|.datarim/*|VERSION|CHANGELOG.md|documentation/archive/*|documentation/evolution/*|documentation/ephemeral/*|documentation/release-audit/*) return 1 ;;
+    commands/*|skills/*|agents/*|templates/*|plugins/*|cli/*|scripts/*|dev-tools/*|config/*|documentation/tutorials/*|documentation/how-to/*|documentation/reference/*|documentation/explanation/*) return 0 ;;
+    install.sh|update.sh|validate.sh|accepted-risk-aal.yml|CLAUDE.md|README.md|CONTRIBUTING.md|SECURITY.md) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+is_accountability_path() {
+  case "$1" in
+    VERSION|CHANGELOG.md|.datarim/version-deferrals/*) return 0 ;;
+    *) is_shipped_path "$1" ;;
+  esac
+}
+
+emit() {
+  local disposition="$1" code="$2"
+  printf 'framework-version-accountability: disposition=%s base=%s head=%s scope_digest=%s\n' \
+    "$disposition" "$base_oid" "$head_oid" "$scope_digest"
+  exit "$code"
+}
+
+fail_untrusted() {
+  printf 'framework-version-accountability: error=%s\n' "$1" >&2
+  emit untrustworthy_evidence 2
+}
+
+task="" workspace="" repo=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --task) [ "$#" -ge 2 ] || { usage; exit 2; }; task="$2"; shift 2 ;;
+    --workspace) [ "$#" -ge 2 ] || { usage; exit 2; }; workspace="$2"; shift 2 ;;
+    --repo) [ "$#" -ge 2 ] || { usage; exit 2; }; repo="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) usage; exit 2 ;;
+  esac
+done
+
+base_oid="0000000000000000000000000000000000000000"
+head_oid="0000000000000000000000000000000000000000"
+scope_digest="0000000000000000000000000000000000000000000000000000000000000000"
+if ! [[ "$task" =~ ^[A-Z]{2,10}-[0-9]{4}(-[A-Za-z0-9]+)*$ ]]; then fail_untrusted invalid_task; fi
+if [ ! -d "$workspace" ] || [ ! -d "$repo" ] || [ -L "$workspace" ] || [ -L "$repo" ]; then fail_untrusted invalid_root; fi
+workspace="$(cd "$workspace" && pwd -P)"
+repo="$(cd "$repo" && pwd -P)"
+trusted_directory "$repo" || fail_untrusted unsafe_repo
+for component in "$workspace" "$workspace/datarim" "$workspace/datarim/tasks"; do
+  safe_workspace_directory "$component" || fail_untrusted unsafe_workspace_path
+done
+git -C "$repo" rev-parse --git-dir >/dev/null 2>&1 || fail_untrusted not_git_repo
+head_oid="$(git -C "$repo" rev-parse 'HEAD^{commit}' 2>/dev/null)" || fail_untrusted invalid_head
+
+record="$workspace/datarim/.auto/version-accountability/$task/baseline.record"
+if [ ! -f "$record" ] || [ -L "$record" ]; then fail_untrusted missing_baseline; fi
+[ "$(stat_owner "$record")" = "$(id -u)" ] || fail_untrusted baseline_owner
+[ "$(stat_mode "$record")" = 600 ] || fail_untrusted baseline_mode
+is_closed_ascii_record "$record" || fail_untrusted baseline_encoding
+record_identity="$(stat_identity "$record")"
+record_digest="$(sha256_file "$record")"
+for component in "$workspace/datarim/.auto" "$workspace/datarim/.auto/version-accountability" "$(dirname "$record")"; do
+  trusted_directory "$component" || fail_untrusted unsafe_baseline_path
+done
+[ "$(wc -c < "$record" | tr -d '[:space:]')" -le 1024 ] || fail_untrusted baseline_oversized
+
+lines=()
+while IFS= read -r line || [ -n "$line" ]; do lines[${#lines[@]}]="$line"; done < "$record"
+[ "${#lines[@]}" -eq 7 ] || fail_untrusted baseline_schema
+[ "${lines[0]}" = 'schema-version: 1' ] || fail_untrusted baseline_schema
+[ "${lines[1]}" = "task-id: $task" ] || fail_untrusted baseline_task
+[[ "${lines[2]}" == repo-root-sha256:\ * ]] || fail_untrusted baseline_schema
+[[ "${lines[3]}" == base-commit:\ * ]] || fail_untrusted baseline_schema
+[[ "${lines[4]}" == base-tree:\ * ]] || fail_untrusted baseline_schema
+[[ "${lines[5]}" == init-task-sha256:\ * ]] || fail_untrusted baseline_schema
+repo_digest="${lines[2]#repo-root-sha256: }"
+base_oid="${lines[3]#base-commit: }"
+base_tree="${lines[4]#base-tree: }"
+init_digest="${lines[5]#init-task-sha256: }"
+[[ "$repo_digest" =~ ^[a-f0-9]{64}$ ]] || fail_untrusted baseline_schema
+[[ "$base_oid" =~ ^[a-f0-9]{40}$ ]] || fail_untrusted baseline_schema
+[[ "$base_tree" =~ ^[a-f0-9]{40}$ ]] || fail_untrusted baseline_schema
+[[ "$init_digest" =~ ^[a-f0-9]{64}$ ]] || fail_untrusted baseline_schema
+[[ "${lines[6]}" =~ ^captured-at:[[:space:]][0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || fail_untrusted baseline_schema
+[ "$repo_digest" = "$(sha256_text "$repo")" ] || fail_untrusted repository_mismatch
+git -C "$repo" cat-file -e "$base_oid^{commit}" 2>/dev/null || fail_untrusted invalid_base
+[ "$base_tree" = "$(git -C "$repo" rev-parse "$base_oid^{tree}")" ] || fail_untrusted base_tree_mismatch
+git -C "$repo" merge-base --is-ancestor "$base_oid" "$head_oid" 2>/dev/null || fail_untrusted non_ancestor_base
+
+init_task="$workspace/datarim/tasks/$task-init-task.md"
+if [ ! -f "$init_task" ] || [ -L "$init_task" ]; then fail_untrusted missing_init_task; fi
+
+dirty=0
+status_file="$(mktemp)"
+diff_file="$(mktemp)"
+digest_file="$(mktemp)"
+base_version_file="$(mktemp)"
+head_version_file="$(mktemp)"
+base_changelog="$(mktemp)"
+head_changelog="$(mktemp)"
+deferral_file="$(mktemp)"
+# shellcheck disable=SC2317  # Called by the trap below.
+cleanup() { rm -f -- "$status_file" "$diff_file" "$digest_file" "$base_version_file" "$head_version_file" "$base_changelog" "$head_changelog" "$deferral_file"; }
+trap cleanup EXIT HUP INT TERM
+has_relevant_dirty_state() {
+  local entry status path paired_path
+  while IFS= read -r -d '' entry; do
+    [ "${#entry}" -ge 4 ] || return 2
+    status="${entry:0:2}"
+    path="${entry:3}"
+    paired_path=""
+    case "$status" in
+      R*|C*) IFS= read -r -d '' paired_path || return 2 ;;
+    esac
+    if is_accountability_path "$path" \
+      || { [ -n "$paired_path" ] && is_accountability_path "$paired_path"; }; then
+      return 0
+    fi
+  done < "$1"
+  return 1
+}
+emit_checked() {
+  local disposition="$1" code="$2" status_result
+  [ "$head_oid" = "$(git -C "$repo" rev-parse 'HEAD^{commit}')" ] || fail_untrusted head_changed
+  [ "$base_tree" = "$(git -C "$repo" rev-parse "$base_oid^{tree}")" ] || fail_untrusted base_tree_changed
+  [ "$record_identity" = "$(stat_identity "$record")" ] || fail_untrusted baseline_changed
+  [ "$record_digest" = "$(sha256_file "$record")" ] || fail_untrusted baseline_changed
+  [ "$(stat_owner "$record")" = "$(id -u)" ] || fail_untrusted baseline_owner
+  [ "$(stat_mode "$record")" = 600 ] || fail_untrusted baseline_mode
+  git -C "$repo" status --porcelain -z --untracked-files=all > "$status_file" || fail_untrusted git_status_failed
+  if has_relevant_dirty_state "$status_file"; then
+    fail_untrusted relevant_dirty_state
+  else
+    status_result=$?
+    [ "$status_result" -eq 1 ] || fail_untrusted malformed_git_status
+  fi
+  emit "$disposition" "$code"
+}
+git -C "$repo" status --porcelain -z --untracked-files=all > "$status_file" || fail_untrusted git_status_failed
+if has_relevant_dirty_state "$status_file"; then dirty=1; else status_result=$?; [ "$status_result" -eq 1 ] || fail_untrusted malformed_git_status; fi
+[ "$dirty" -eq 0 ] || fail_untrusted relevant_dirty_state
+
+git -C "$repo" diff --name-status -z -M -C "$base_oid" "$head_oid" > "$diff_file" || fail_untrusted git_diff_failed
+printf 'datarim-framework-version-accountability-v1\0%s\0' "$base_oid" > "$digest_file"
+shipped=0
+while IFS= read -r -d '' status; do
+  IFS= read -r -d '' old_path || fail_untrusted malformed_git_diff
+  new_path="$old_path"
+  case "$status" in
+    R*|C*) IFS= read -r -d '' new_path || fail_untrusted malformed_git_diff ;;
+  esac
+  if is_shipped_path "$old_path" || is_shipped_path "$new_path"; then
+    shipped=1
+    printf '%s\0%s\0%s\0' "$status" "$old_path" "$new_path" >> "$digest_file"
+    git -C "$repo" ls-tree -z "$base_oid" -- "$old_path" >> "$digest_file" || fail_untrusted git_tree_failed
+    git -C "$repo" ls-tree -z "$head_oid" -- "$new_path" >> "$digest_file" || fail_untrusted git_tree_failed
+  fi
+done < "$diff_file"
+scope_digest="$(sha256_file "$digest_file")"
+
+git -C "$repo" show "$base_oid:VERSION" > "$base_version_file" 2>/dev/null || emit_checked invalid_version_transition 1
+git -C "$repo" show "$head_oid:VERSION" > "$head_version_file" 2>/dev/null || emit_checked invalid_version_transition 1
+[ "$(wc -l < "$base_version_file" | tr -d '[:space:]')" -eq 1 ] || emit_checked invalid_version_transition 1
+[ "$(wc -l < "$head_version_file" | tr -d '[:space:]')" -eq 1 ] || emit_checked invalid_version_transition 1
+base_version="$(tr -d '\n' < "$base_version_file")"
+head_version="$(tr -d '\n' < "$head_version_file")"
+semver_re='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$'
+[[ "$base_version" =~ $semver_re ]] || emit_checked invalid_version_transition 1
+[[ "$head_version" =~ $semver_re ]] || emit_checked invalid_version_transition 1
+
+version_state=unchanged
+if [ "$base_version" != "$head_version" ]; then
+  IFS=. read -r b1 b2 b3 <<< "$base_version"
+  IFS=. read -r h1 h2 h3 <<< "$head_version"
+  if [ "$h1" -gt "$b1" ] \
+    || { [ "$h1" -eq "$b1" ] && [ "$h2" -gt "$b2" ]; } \
+    || { [ "$h1" -eq "$b1" ] && [ "$h2" -eq "$b2" ] && [ "$h3" -gt "$b3" ]; }; then
+    version_state=increased
+  else
+    version_state=invalid
+  fi
+fi
+
+record_path=".datarim/version-deferrals/$task.record"
+record_present=0
+if git -C "$repo" cat-file -e "$head_oid:$record_path" 2>/dev/null; then record_present=1; fi
+
+if [ "$shipped" -eq 0 ] && [ "$version_state" = unchanged ]; then emit_checked not_applicable 0; fi
+[ "$version_state" != invalid ] || emit_checked invalid_version_transition 1
+
+changelog_ok=0
+git -C "$repo" show "$base_oid:CHANGELOG.md" > "$base_changelog" 2>/dev/null || fail_untrusted missing_changelog
+git -C "$repo" show "$head_oid:CHANGELOG.md" > "$head_changelog" 2>/dev/null || fail_untrusted missing_changelog
+head_unreleased_count="$(grep -c '^## \[Unreleased\]$' "$head_changelog" || true)"
+[ "$head_unreleased_count" -eq 1 ] || fail_untrusted malformed_changelog
+extract_unreleased() {
+  awk '/^## \[Unreleased\]$/ {inside=1; next} inside && /^## \[/ {exit} inside {print}' "$1"
+}
+if extract_unreleased "$head_changelog" | grep -Eq "^- .*([^A-Za-z0-9-]|^)${task}([^A-Za-z0-9-]|$)" \
+  && ! extract_unreleased "$base_changelog" | grep -Eq "^- .*([^A-Za-z0-9-]|^)${task}([^A-Za-z0-9-]|$)"; then
+  changelog_ok=1
+fi
+
+if [ "$version_state" = increased ]; then
+  [ "$record_present" -eq 0 ] || emit_checked contradictory_evidence 1
+  [ "$changelog_ok" -eq 1 ] || emit_checked changelog_missing 1
+  emit_checked satisfied_by_version 0
+fi
+
+[ "$record_present" -eq 1 ] || emit_checked accountability_missing 1
+mode_line="$(git -C "$repo" ls-tree "$head_oid" -- "$record_path")"
+[[ "$mode_line" == 100644\ blob\ * ]] || fail_untrusted deferral_mode
+git -C "$repo" show "$head_oid:$record_path" > "$deferral_file" 2>/dev/null || fail_untrusted deferral_read
+[ "$(wc -c < "$deferral_file" | tr -d '[:space:]')" -le 2048 ] || fail_untrusted deferral_oversized
+is_closed_ascii_record "$deferral_file" || fail_untrusted deferral_encoding
+dlines=()
+while IFS= read -r line || [ -n "$line" ]; do dlines[${#dlines[@]}]="$line"; done < "$deferral_file"
+[ "${#dlines[@]}" -eq 13 ] || fail_untrusted deferral_schema
+[ "${dlines[0]}" = 'schema-version: 1' ] || fail_untrusted deferral_schema
+[ "${dlines[1]}" = "task-id: $task" ] || fail_untrusted deferral_task
+[ "${dlines[2]}" = "base-commit: $base_oid" ] || fail_untrusted deferral_base
+[ "${dlines[3]}" = "shipped-diff-digest: $scope_digest" ] || fail_untrusted deferral_digest
+[ "${dlines[4]}" = 'decision: defer' ] || fail_untrusted deferral_schema
+[[ "${dlines[5]}" == reason-code:\ * ]] || fail_untrusted deferral_schema
+[[ "${dlines[6]}" == reason:\ * ]] || fail_untrusted deferral_schema
+[[ "${dlines[7]}" == delivery-kind:\ * ]] || fail_untrusted deferral_schema
+[[ "${dlines[8]}" == delivery-target:\ * ]] || fail_untrusted deferral_schema
+reason_code="${dlines[5]#reason-code: }"
+reason="${dlines[6]#reason: }"
+delivery_kind="${dlines[7]#delivery-kind: }"
+delivery_target="${dlines[8]#delivery-target: }"
+[ "${dlines[9]}" = 'source-kind: init-task' ] || fail_untrusted deferral_source
+[ "${dlines[10]}" = "source-digest: $init_digest" ] || fail_untrusted deferral_source
+[ "${dlines[11]}" = 'recorded-by: agent' ] || fail_untrusted deferral_schema
+[[ "${dlines[12]}" =~ ^recorded-at:[[:space:]][0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || fail_untrusted deferral_time
+[[ "$reason_code" =~ ^(batch-accumulation|coordinated-release|operator-directed)$ ]] || fail_untrusted deferral_reason
+[[ "$reason" =~ ^[A-Za-z0-9][A-Za-z0-9\ .,\(\)_-]{19,159}$ ]] || fail_untrusted deferral_reason
+[[ "$delivery_kind" =~ ^(release-train|follow-up-task)$ ]] || fail_untrusted deferral_delivery
+[[ "$delivery_target" =~ ^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$ ]] || fail_untrusted deferral_delivery
+if printf '%s\n%s\n' "$reason" "$delivery_target" | LC_ALL=C grep -Eqi '(@|/|\\|=|BEGIN |Bearer |token|password|secret|credential)'; then
+  fail_untrusted deferral_sensitive_value
+fi
+
+emit_checked satisfied_by_deferral 0

--- a/tests/framework-version-accountability-wiring.bats
+++ b/tests/framework-version-accountability-wiring.bats
@@ -21,7 +21,7 @@ ROOT="$BATS_TEST_DIRNAME/.."
 @test "existing /dr-do spec graph self-verification and network gates remain" {
   grep -qF 'AUTOMATIC SPEC-GRAPH EVIDENCE CHECK' "$ROOT/commands/dr-do.md" \
     && grep -qF 'NETWORK EXPOSURE PRE-COMMIT GATE' "$ROOT/commands/dr-do.md" \
-    && grep -qF 'AUTOMATIC POST-STEP SELF-VERIFICATION' "$ROOT/commands/dr-do.md"
+    && grep -qF 'automatic self-verification hook for this stage' "$ROOT/commands/dr-do.md"
 }
 
 @test "existing QA expectations anti-deferral and test gates remain" {

--- a/tests/framework-version-accountability-wiring.bats
+++ b/tests/framework-version-accountability-wiring.bats
@@ -1,0 +1,36 @@
+#!/usr/bin/env bats
+
+ROOT="$BATS_TEST_DIRNAME/.."
+
+@test "/dr-init owns runtime-qualified baseline capture" {
+  grep -qF '${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/capture-framework-version-baseline.sh' "$ROOT/commands/dr-init.md"
+}
+
+@test "/dr-do unconditionally runs the runtime-qualified checker as a hard transition" {
+  grep -qF '${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-framework-version-accountability.sh' "$ROOT/commands/dr-do.md" \
+    && grep -qF 'exit 1 or exit 2' "$ROOT/commands/dr-do.md" \
+    && grep -qF 'route to `/dr-do`' "$ROOT/commands/dr-do.md"
+}
+
+@test "/dr-qa independently runs the same checker and blocks PASS routes" {
+  grep -qF '${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-framework-version-accountability.sh' "$ROOT/commands/dr-qa.md" \
+    && grep -qF 'overall QA result is **FAIL**' "$ROOT/commands/dr-qa.md" \
+    && grep -qF 'route to `/dr-do`' "$ROOT/commands/dr-qa.md"
+}
+
+@test "existing /dr-do spec graph self-verification and network gates remain" {
+  grep -qF 'AUTOMATIC SPEC-GRAPH EVIDENCE CHECK' "$ROOT/commands/dr-do.md" \
+    && grep -qF 'NETWORK EXPOSURE PRE-COMMIT GATE' "$ROOT/commands/dr-do.md" \
+    && grep -qF 'AUTOMATIC POST-STEP SELF-VERIFICATION' "$ROOT/commands/dr-do.md"
+}
+
+@test "existing QA expectations anti-deferral and test gates remain" {
+  grep -qF 'Layer 3b: Expectations Verification' "$ROOT/commands/dr-qa.md" \
+    && grep -qF 'Anti-deferral prose scan' "$ROOT/commands/dr-qa.md" \
+    && grep -qF '### 4a. Tests' "$ROOT/commands/dr-qa.md"
+}
+
+@test "new wiring contains no prohibited network or release command" {
+  ! sed -n '/FRAMEWORK VERSION ACCOUNTABILITY/,/^[0-9].*\*\*/p' "$ROOT/commands/dr-do.md" "$ROOT/commands/dr-qa.md" \
+    | grep -Eq 'git (push|fetch|tag)|gh release|deploy\.sh'
+}

--- a/tests/framework-version-accountability.bats
+++ b/tests/framework-version-accountability.bats
@@ -1,0 +1,316 @@
+#!/usr/bin/env bats
+
+CAPTURE="$BATS_TEST_DIRNAME/../dev-tools/capture-framework-version-baseline.sh"
+CHECKER="$BATS_TEST_DIRNAME/../dev-tools/check-framework-version-accountability.sh"
+TASK_ID="TUNE-9001"
+
+setup() {
+  export GIT_AUTHOR_DATE='2026-07-20T00:00:00Z'
+  export GIT_COMMITTER_DATE='2026-07-20T00:00:00Z'
+  export HOME="$BATS_TEST_TMPDIR/home"
+  export WORKSPACE="$BATS_TEST_TMPDIR/workspace"
+  export REPO="$BATS_TEST_TMPDIR/repo"
+  mkdir -p "$HOME" "$WORKSPACE/datarim/tasks" "$WORKSPACE/datarim/prd" \
+    "$WORKSPACE/datarim/plans" "$REPO"
+  chmod 755 "$REPO"
+  git -C "$REPO" init -q
+  git -C "$REPO" config user.name "Test Agent"
+  git -C "$REPO" config user.email "test@example.invalid"
+  printf '%s\n' '1.0.0' > "$REPO/VERSION"
+  printf '%s\n' '# Changelog' '' '## [Unreleased]' '' '## [1.0.0]' > "$REPO/CHANGELOG.md"
+  mkdir -p "$REPO/tests"
+  printf '%s\n' 'baseline' > "$REPO/tests/baseline.txt"
+  printf '%s\n' '---' "task_id: $TASK_ID" 'artifact: init-task' \
+    'schema_version: 1' 'captured_at: 2026-07-20T00:00:00Z' \
+    'captured_by: /dr-init' 'operator: local-test' 'status: canonical' '---' \
+    '' '# Test brief' > "$WORKSPACE/datarim/tasks/$TASK_ID-init-task.md"
+  git -C "$REPO" add .
+  git -C "$REPO" commit -qm baseline
+  export BASE_SHA
+  BASE_SHA="$(git -C "$REPO" rev-parse HEAD)"
+}
+
+capture_baseline() {
+  run "$CAPTURE" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 0 ]
+}
+
+commit_file() {
+  local path="$1" body="${2:-changed}"
+  mkdir -p "$(dirname "$REPO/$path")"
+  printf '%s\n' "$body" > "$REPO/$path"
+  git -C "$REPO" add -- "$path"
+  git -C "$REPO" commit -qm "change $path"
+}
+
+append_unreleased() {
+  local task="$1"
+  awk -v task="$task" '
+    { print }
+    /^## \[Unreleased\]$/ && !done { print ""; print "- Added accountability (" task ")"; done=1 }
+  ' "$REPO/CHANGELOG.md" > "$REPO/CHANGELOG.md.new"
+  mv "$REPO/CHANGELOG.md.new" "$REPO/CHANGELOG.md"
+}
+
+checker_digest() {
+  "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO" 2>/dev/null \
+    | sed -n 's/.*scope_digest=\([a-f0-9]\{64\}\).*/\1/p'
+}
+
+write_deferral() {
+  local digest="$1" init_digest recorded_at
+  init_digest="$(sed -n 's/^init-task-sha256: //p' "$WORKSPACE/datarim/.auto/version-accountability/$TASK_ID/baseline.record")"
+  recorded_at='2026-07-20T00:00:01Z'
+  mkdir -p "$REPO/.datarim/version-deferrals"
+  printf '%s\n' \
+    'schema-version: 1' \
+    "task-id: $TASK_ID" \
+    "base-commit: $BASE_SHA" \
+    "shipped-diff-digest: $digest" \
+    'decision: defer' \
+    'reason-code: batch-accumulation' \
+    'reason: Operator requested this change join a coordinated release.' \
+    'delivery-kind: release-train' \
+    'delivery-target: next-consolidated-release' \
+    'source-kind: init-task' \
+    "source-digest: $init_digest" \
+    'recorded-by: agent' \
+    "recorded-at: $recorded_at" \
+    > "$REPO/.datarim/version-deferrals/$TASK_ID.record"
+  git -C "$REPO" add ".datarim/version-deferrals/$TASK_ID.record"
+  git -C "$REPO" commit -qm 'add deferral'
+}
+
+@test "capture creates the closed mode-600 INIT baseline" {
+  run "$CAPTURE" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 0 ] \
+    && [ "$(stat -c '%a' "$WORKSPACE/datarim/.auto/version-accountability/$TASK_ID/baseline.record")" = 600 ] \
+    && grep -qF "base-commit: $BASE_SHA" "$WORKSPACE/datarim/.auto/version-accountability/$TASK_ID/baseline.record"
+}
+
+@test "capture is idempotent for an identical baseline" {
+  capture_baseline
+  run "$CAPTURE" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 0 ] && [[ "$output" == *"baseline_reused"* ]]
+}
+
+@test "capture re-entry preserves the INIT base after commit and append-log growth" {
+  capture_baseline
+  printf '%s\n' '' '## Append-log' '- 2026-07-20: later clarification.' \
+    >> "$WORKSPACE/datarim/tasks/$TASK_ID-init-task.md"
+  commit_file 'commands/dr-sample.md'
+  run "$CAPTURE" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 0 ] \
+    && [[ "$output" == *"disposition=baseline_reused"* ]] \
+    && [[ "$output" == *"base=$BASE_SHA"* ]]
+}
+
+@test "capture refuses late creation after PRD exists" {
+  printf '%s\n' '# late' > "$WORKSPACE/datarim/prd/PRD-$TASK_ID.md"
+  run "$CAPTURE" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 2 ] && [[ "$output" == *"late_capture"* ]]
+}
+
+@test "checker fails closed when the INIT baseline is missing" {
+  run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 2 ] && [[ "$output" == *"error=missing_baseline"* ]]
+}
+
+@test "tests-only diff is not applicable" {
+  capture_baseline
+  commit_file 'tests/new-case.bats' '@test "x" { true; }'
+  run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 0 ] && [[ "$output" == *"disposition=not_applicable"* ]]
+}
+
+@test "shipped diff without accounting blocks and still emits digest" {
+  capture_baseline
+  commit_file 'commands/dr-sample.md'
+  run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 1 ] \
+    && [[ "$output" == *"disposition=accountability_missing"* ]] \
+    && [[ "$output" =~ scope_digest=[a-f0-9]{64} ]]
+}
+
+@test "scope digest matches the golden serialization fixture" {
+  capture_baseline
+  commit_file 'commands/dr-sample.md'
+  local digest
+  digest="$(checker_digest)"
+  [ "$digest" = '08788ebbdb8a7f643cbe3c2f464ef26b4efdfb81252c772cd61e93a732c8701e' ]
+}
+
+@test "shipped diff with strict bump and new task bullet passes" {
+  capture_baseline
+  mkdir -p "$REPO/commands"
+  printf '%s\n' changed > "$REPO/commands/dr-sample.md"
+  printf '%s\n' '1.1.0' > "$REPO/VERSION"
+  append_unreleased "$TASK_ID"
+  git -C "$REPO" add . && git -C "$REPO" commit -qm bump
+  run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 0 ] && [[ "$output" == *"disposition=satisfied_by_version"* ]]
+}
+
+@test "VERSION-only strict bump with new task bullet passes" {
+  capture_baseline
+  printf '%s\n' '1.1.0' > "$REPO/VERSION"
+  append_unreleased "$TASK_ID"
+  git -C "$REPO" add VERSION CHANGELOG.md && git -C "$REPO" commit -qm version-only
+  run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 0 ] && [[ "$output" == *"disposition=satisfied_by_version"* ]]
+}
+
+@test "VERSION downgrade blocks even with a shipped diff" {
+  capture_baseline
+  printf '%s\n' '0.9.0' > "$REPO/VERSION"
+  mkdir -p "$REPO/commands"
+  printf '%s\n' changed > "$REPO/commands/dr-sample.md"
+  git -C "$REPO" add VERSION commands/dr-sample.md && git -C "$REPO" commit -qm downgrade
+  run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 1 ] && [[ "$output" == *"disposition=invalid_version_transition"* ]]
+}
+
+@test "valid committed deferral passes and record-only commit keeps digest stable" {
+  capture_baseline
+  commit_file 'commands/dr-sample.md'
+  local before after
+  before="$(checker_digest)"
+  [ "${#before}" -eq 64 ]
+  write_deferral "$before"
+  after="$(checker_digest)"
+  run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$before" = "$after" ] \
+    && [ "$status" -eq 0 ] \
+    && [[ "$output" == *"disposition=satisfied_by_deferral"* ]]
+}
+
+@test "later init-task append-log growth preserves the captured deferral source" {
+  capture_baseline
+  printf '%s\n' '' '## Append-log' '- 2026-07-20: clarification retained.' \
+    >> "$WORKSPACE/datarim/tasks/$TASK_ID-init-task.md"
+  commit_file 'commands/dr-sample.md'
+  local digest
+  digest="$(checker_digest)"
+  write_deferral "$digest"
+  run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 0 ] && [[ "$output" == *"disposition=satisfied_by_deferral"* ]]
+}
+
+@test "bump plus deferral is contradictory" {
+  capture_baseline
+  mkdir -p "$REPO/commands"
+  printf '%s\n' changed > "$REPO/commands/dr-sample.md"
+  printf '%s\n' '1.1.0' > "$REPO/VERSION"
+  append_unreleased "$TASK_ID"
+  git -C "$REPO" add . && git -C "$REPO" commit -qm bump
+  local digest
+  digest="$(checker_digest)"
+  write_deferral "$digest"
+  run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 1 ] && [[ "$output" == *"disposition=contradictory_evidence"* ]]
+}
+
+@test "unstaged shipped dirt is untrustworthy" {
+  capture_baseline
+  commit_file 'commands/dr-sample.md'
+  printf '%s\n' dirty >> "$REPO/commands/dr-sample.md"
+  run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 2 ] && [[ "$output" == *"disposition=untrustworthy_evidence"* ]]
+}
+
+@test "unstaged rename from shipped to excluded path remains relevant" {
+  mkdir -p "$REPO/commands"
+  printf '%s\n' original > "$REPO/commands/original.md"
+  git -C "$REPO" add commands/original.md && git -C "$REPO" commit -qm fixture
+  capture_baseline
+  git -C "$REPO" mv commands/original.md tests/moved.md
+  run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 2 ] && [[ "$output" == *"disposition=untrustworthy_evidence"* ]]
+}
+
+@test "unrelated tests dirt is ignored" {
+  capture_baseline
+  printf '%s\n' dirty >> "$REPO/tests/baseline.txt"
+  run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 0 ] && [[ "$output" == *"disposition=not_applicable"* ]]
+}
+
+@test "malformed deferral record fails closed" {
+  capture_baseline
+  commit_file 'commands/dr-sample.md'
+  local digest
+  digest="$(checker_digest)"
+  write_deferral "$digest"
+  git -C "$REPO" show "HEAD:.datarim/version-deferrals/$TASK_ID.record" \
+    | sed '/^decision:/d' > "$REPO/.datarim/version-deferrals/$TASK_ID.record"
+  git -C "$REPO" add . && git -C "$REPO" commit -qm malformed
+  run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 2 ] && [[ "$output" == *"disposition=untrustworthy_evidence"* ]]
+}
+
+@test "deferral record with a NUL byte fails closed" {
+  capture_baseline
+  commit_file 'commands/dr-sample.md'
+  local digest record bad
+  digest="$(checker_digest)"
+  write_deferral "$digest"
+  record="$REPO/.datarim/version-deferrals/$TASK_ID.record"
+  bad="$REPO/.datarim/version-deferrals/bad.record"
+  {
+    head -n 6 "$record"
+    printf 'reason: Operator requested this change\0 join a coordinated release.\n'
+    tail -n +8 "$record"
+  } > "$bad"
+  mv "$bad" "$record"
+  git -C "$REPO" add ".datarim/version-deferrals/$TASK_ID.record"
+  git -C "$REPO" commit -qm nul-record
+  run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 2 ] && [[ "$output" == *"error=deferral_encoding"* ]]
+}
+
+@test "deferral record requires every ordered key prefix" {
+  local key digest record
+  for key in reason-code reason delivery-kind delivery-target; do
+    rm -rf "$WORKSPACE" "$REPO"
+    setup
+    capture_baseline
+    commit_file 'commands/dr-sample.md'
+    digest="$(checker_digest)"
+    write_deferral "$digest"
+    record="$REPO/.datarim/version-deferrals/$TASK_ID.record"
+    sed "s/^${key}: //" "$record" > "$record.new"
+    mv "$record.new" "$record"
+    git -C "$REPO" add ".datarim/version-deferrals/$TASK_ID.record"
+    git -C "$REPO" commit -qm "missing $key prefix"
+    run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+    [ "$status" -eq 2 ] && [[ "$output" == *"error=deferral_schema"* ]] || return 1
+  done
+}
+
+@test "representative shipped and excluded paths preserve classifier precedence" {
+  local path
+  for path in commands/x.md skills/x/SKILL.md agents/x.md templates/x.md plugins/x/run.sh cli/x.sh scripts/x.sh dev-tools/x.sh config/roles.yaml README.md SECURITY.md; do
+    rm -rf "$WORKSPACE" "$REPO"
+    setup
+    capture_baseline
+    commit_file "$path"
+    run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+    [ "$status" -eq 1 ] && [[ "$output" == *"disposition=accountability_missing"* ]] || return 1
+  done
+}
+
+
+@test "NUL-safe diff handles adversarial shipped filenames" {
+  capture_baseline
+  mkdir -p "$REPO/commands"
+  printf '%s\n' changed > "$REPO/commands/name with spaces.md"
+  printf '%s\n' changed > "$REPO/commands/"$'name\twith-tab.md'
+  printf '%s\n' changed > "$REPO/commands/"$'name\nwith-newline.md'
+  printf '%s\n' changed > "$REPO/commands/-leading-dash.md"
+  printf '%s\n' changed > "$REPO/commands/"$'caf\303\251.md'
+  git -C "$REPO" add -- commands && git -C "$REPO" commit -qm adversarial-paths
+  run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 1 ] \
+    && [[ "$output" == *"disposition=accountability_missing"* ]] \
+    && [[ "$output" =~ scope_digest=[a-f0-9]{64} ]]
+}


### PR DESCRIPTION
Relands **TUNE-0206**, one of the 22 tasks the TUNE-0541 sweep found marked `done`
with none of its content in `origin/main`. The work was implemented and verified
inside a worktree branch; the pull request was never opened.

Verdict: **GENUINELY-LOST-WORK-EXISTS** — see
`documentation/archive/framework/TUNE-0541-verdict-table.md`.

Cherry-picked onto current `main` from the original worktree branch. The branch's
merge-base *is* an ancestor of `main`, so this is a clean single-commit reland
rather than part of the re-rooted 0141/0206/0365 chain.

Verified before opening: `shellcheck --severity=warning` (CI's own severity) clean
on every shell file the commit ships, and every `.bats` file it touches run green.

The `closure-gate.sh` merged in #278 reports this branch's work as absent from
`main` today, and will report it present once this merges — that transition is the
gate's intended signal.