### PR TITLE
fix(evolution): main is red — a shipped skill cites task IDs the gate forbids

### DIFF
--- a/skills/evolution/SKILL.md
+++ b/skills/evolution/SKILL.md
@@ -282,9 +282,9 @@ mandatory contract, not a judgment call.
    the four scanned scopes will itself trip the gate — reference banned markers abstractly in shipped
    text, never literally.)
 
-**Source:** reflection-TUNE-0150 § Evolution Proposal 2 (Class B). Founding incidents — Datarim v2.0.0
-absorption of 14 external skills (TUNE-0114); dead-cross-reference cleanup (TUNE-0150); regression gate
-(TUNE-0151). This pattern is the sibling of `## Pattern: Split-Architecture Metrics for Absorption
+**Source:** `documentation/how-to/evolution-log.md` — the Class B proposal accepted after the v2.0.0
+absorption of 14 external skills, its dead-cross-reference cleanup, and the regression gate that
+followed. This pattern is the sibling of `## Pattern: Split-Architecture Metrics for Absorption
 Tasks` above — both encode contracts an absorption task must satisfy.
 
 ---


### PR DESCRIPTION
## main is currently red

`origin/main` @ `937a4b9` fails the `security` workflow's **`task-id-gate`** job. Every open PR in this repo therefore shows a red required check that has nothing to do with its own change — including #298, which is how I found this.

```
$ bash scripts/task-id-gate.sh skills          # on origin/main @ 937a4b9
skills/evolution/SKILL.md:285:TUNE-0150
skills/evolution/SKILL.md:286:TUNE-0114
skills/evolution/SKILL.md:286:TUNE-0150
skills/evolution/SKILL.md:287:TUNE-0151
FAIL: 4 matches in 1 files
```

Localised by bisecting the scope invariant: `T11: skills/ scope is gate-clean` **passes** at `9efcc72` and **fails** at `937a4b9`, so the cause is one of the eight commits merged in between. `git log -S` points at **#280**, which added a `**Source:**` provenance line naming four task IDs.

## Why it is a violation

Critical Rule 8 (`CLAUDE.md`):

> Task IDs MUST NOT appear in `skills/*.md`, `agents/*.md`, `commands/*.md`, `templates/*.md`. Provenance lives in `documentation/how-to/evolution-log.md`, `documentation/archive/`, git log.

The offending line sits **three lines below** a paragraph in the same skill telling authors to "reference banned markers abstractly in shipped text, never literally". The gate was right; the content was not.

## Fix

Cite the evolution log, and describe the founding incidents by what they were rather than by their IDs. No provenance is lost — the log is where it is supposed to live, and it still holds the IDs.

## Verification

```
bash scripts/task-id-gate.sh skills      PASS   (was: 4 matches in 1 files)
bats tests/task-id-gate.bats             17/17  (T11-T14 scope invariants green)
```

Worth a follow-up beyond this fix: #280 merged with this check red, which is the same shape as the defects the current sweep is chasing — a gate exists, the content violates it, and the change ships anyway. The `security` workflow is a required check, so how a red run passed the merge gate is worth a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HNz4nbteLZARLWKcJBLgTD