### PR TITLE
fix(tune-0541): un-red main — de-identify task IDs in a shipped skill

### DIFF
--- a/skills/evolution/SKILL.md
+++ b/skills/evolution/SKILL.md
@@ -282,9 +282,9 @@ mandatory contract, not a judgment call.
    the four scanned scopes will itself trip the gate — reference banned markers abstractly in shipped
    text, never literally.)
 
-**Source:** reflection-TUNE-0150 § Evolution Proposal 2 (Class B). Founding incidents — Datarim v2.0.0
-absorption of 14 external skills (TUNE-0114); dead-cross-reference cleanup (TUNE-0150); regression gate
-(TUNE-0151). This pattern is the sibling of `## Pattern: Split-Architecture Metrics for Absorption
+**Source:** the reflection that raised this as an Evolution Proposal (Class B). Founding incidents — the
+Datarim v2.0.0 absorption of 14 external skills; the dead-cross-reference cleanup that followed it; and the
+regression gate added afterwards. This pattern is the sibling of `## Pattern: Split-Architecture Metrics for Absorption
 Tasks` above — both encode contracts an absorption task must satisfy.
 
 ---


### PR DESCRIPTION
`main` is failing `task-id-gate` because the TUNE-0153 reland (#280) introduced literal task IDs into `skills/evolution/SKILL.md`, one of the four shipped runtime scopes the gate protects.

**How it got in:** I merged #280 with `--admin` on the six *required* status contexts. `task-id-gate` is not among the six, so its red state did not block the merge and I did not check it. The branch's own bats were green — this gate is repo-wide and CI-only.

**Fix:** rewrite the Source line abstractly. That is exactly what the same file instructs two paragraphs earlier — "reference banned markers abstractly in shipped text, never literally".

Verified: `scripts/task-id-gate.sh` clean on all four scopes; `tests/task-id-gate.bats` green.