### PR TITLE
feat(dr-orchestrate): confirmed auto-learning — reland TUNE-0166

### DIFF
--- a/.github/workflows/dev-tools-lint.yml
+++ b/.github/workflows/dev-tools-lint.yml
@@ -42,6 +42,7 @@ jobs:
           bats dev-tools/tests/check-github-actions-execution.bats
           bats dev-tools/tests/rename-task-prefix.bats
           bats dev-tools/tests/cross-kb-evolution-digest.bats
+          bats dev-tools/tests/orchestrate-phase3-acceptance.bats
 
   linter-run:
     name: doc-fanout-lint run (warning-only)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -160,6 +160,8 @@ All notable changes to the Datarim framework are documented here. Format follows
 
 ### Added
 
+- **`/dr-orchestrate` Phase 3 confirmed auto-learning.** Successful trusted resolutions can emit an actor/session-bound `Save as rule? [Y/N]` callback. Affirmative one-time callbacks persist exact learned matches with 24-hour re-validation and an immutable seven-day TTL; learned actions remain subject to per-space policy and the Supreme-Directive hard-gated floor. This batch does not change release or plugin versions. (TUNE-0166)
+
 - **New Reference skill `image-prompting`** — a reusable playbook that turns a content brief into a precise, repeatable prompt for instruction-following image generators (the gpt-image family and equivalents): blog/article covers, video thumbnails, social-post images, illustrations, infographics/diagrams, logo marks, and edits of existing images. Covers the full method — intake → spec → prompt → verify loop, prompt anatomy, composition, style/medium, camera/lens, light, mood, palette, text-in-image constraints, negative constraints + invariants, native aspect/size handling, iterative refinement, plus a `prompt-templates.md` fragment with nine fill-in-the-blank templates and a ship-readiness verification checklist. Wired into the `writer` and `editor` agents (load-when-needed) and the agent↔skill dependency visual map. Completes the deferred merge of TUNE-0466 (skill authored + archived COMPLIANT, branch merge was an outstanding operator action). (TUNE-0466, TUNE-0480)
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -230,6 +230,14 @@ Before writing ANY file to `datarim/`:
 | `/factcheck` | Standalone | Fact-check articles and posts before publication |
 | `/humanize` | Standalone | Remove AI writing patterns from text |
 
+> **`/dr-orchestrate` Phase 3 — auto-learning with operator confirmation.** A resolved
+> action may propose `Save as rule?`, bound to the authenticated actor and session. Only an
+> explicit confirmation persists it; replay, expiry, wrong context, or malformed input fails
+> closed. Learned rules become due for re-validation after 24 hours and expire on an
+> immutable seven-day TTL. Re-validation proposes confirmation and never executes a due
+> rule, and every learned action stays subject to per-space policy and the immutable
+> hard-gated floor.
+
 Command files: `$HOME/.claude/commands/{name}.md` (28 commands, including the plugin command)
 
 ### /dr-verify (on-demand, tri-layer architecture)

--- a/README.md
+++ b/README.md
@@ -131,7 +131,10 @@ Stages in `[brackets]` are conditional — included when the agent determines th
   closed threshold gate) for unknown prompts and bumps plugin autonomy from
   L1 (manual) to L2 (assisted). Flock-race-safe cooldown on Linux, audit
   schema v2 with confidence + backend metadata, hash-only matched text
-  invariant preserved. Install via `dr-plugin enable dr-orchestrate`. See
+  invariant preserved. Phase 3 adds an L4 baseline with actor/session-bound
+  Save-as-rule confirmation, exact learned matches, 24-hour re-validation,
+  and an immutable seven-day TTL. Learned actions remain constrained by
+  per-space policy and the hard-gated floor. Install via `dr-plugin enable dr-orchestrate`. See
   `plugins/dr-orchestrate/README.md`.
 
 - **Multi-runtime coworker delegation enforcement** — `dev-tools/coworker-hook-guard.sh`

--- a/commands/dr-orchestrate.md
+++ b/commands/dr-orchestrate.md
@@ -1,7 +1,7 @@
 ---
 id: dr-orchestrate
-title: /dr-orchestrate — Self-Driving Datarim Pipeline (Phase 2)
-description: "Tmux-based pipeline runner. Phase 2 adds multi-backend subagent inference for unknown prompts (autonomy L1→L2). Command and autonomy policy are core; the tmux/bot transport runner is an opt-in plugin."
+title: /dr-orchestrate — Self-Driving Datarim Pipeline (Phase 3)
+description: "Tmux-based pipeline runner. Phase 3 adds operator-confirmed learned rules with a seven-day TTL and 24-hour re-validation (autonomy L4). Command and autonomy policy are core; the runner is an opt-in plugin."
 usage: |
   dr-orchestrate run
   dr-orchestrate run --dry-run
@@ -10,8 +10,8 @@ options:
   --dry-run: "Log decisions without executing"
   --interval: "Poll cycle interval in seconds (default: 5)"
   --unknown-prompt: "Resolve a parser-miss prompt via the subagent inference chain"
-autonomy: L2
-phase: 2
+autonomy: L4
+phase: 3
 ---
 
 # /dr-orchestrate
@@ -22,22 +22,28 @@ selection-neutral and version hints are advisory only.
 
 Phase 2 — Subagent Inference Layer (v2.4.0).
 
+Phase 3 — Auto-learning with operator confirmation.
+
 ## Cycle
 
 1. `tmux capture-pane -p -t <pane>` — captures the current pane buffer.
 2. **Snapshot-First Resume.** If the buffer or job-queue identifies an active TASK-ID and `datarim/snapshots/{TASK-ID}.snapshot.md` is valid (`dev-tools/check-stage-snapshot-on-exit.sh --validate-frontmatter --task <ID>` returns exit 0), read the snapshot before invoking `semantic_parser.sh` and pass `recommended_next` to `subagent_resolver.sh` as `--hint <command>`. The snapshot read happens before resolver dispatch, so the resolver can still return a different command — the snapshot is a hint, not a constraint. If the snapshot is absent or malformed, skip this step without warning (V-AC-7 — the seventh verification acceptance criterion) and continue with prior behaviour. Consumer-side contract: `skills/dr-next-snapshot-replay/SKILL.md`.
-3. `semantic_parser.sh parse` — rule-based pass returns `{command, confidence, source}`.
-4. **Hit (confidence > 0)** — Phase 1 path: log `make_event` v1, JSONL append.
+3. `semantic_parser.sh parse` — rule-based pass returns the selected action, confidence, and provenance. Learned matches are exact and must still name an action in the bundled/user trust registry.
+4. **Hit (confidence > 0)** — apply the immutable action gate, write a cycle checkpoint, execute through the controlled pane seam, and append schema-v2 audit evidence.
 5. **Miss (confidence == 0)** — Phase 2 path:
    - `subagent_resolver.sh resolve` — multi-backend chain (coworker → claude → codex), 15s per backend, lenient JSON parse, FD-3 close.
    - Confidence threshold gate (default `0.80`):
-     - Pass → when resolver JSON includes `action_kind`, call
+     - Pass → derive `framework_command` for slash commands and call
        `plugins/dr-orchestrate/scripts/action_gate.sh` before autonomous execution. Space-policy
        `auto` proceeds; `operator` or invalid policy routes to escalation.
-       Then audit `outcome: resolved` (schema v2); decision-cooldown 60s
-       enforces a single autonomous decision per pane per minute.
+       Then checkpoint and execute once. A successful resolution emits a
+       `Save as rule? [Y/N]` proposal bound to the authenticated actor/session.
      - Fail / chain_exhausted → `escalation_backend.sh emit` (mock JSONL by default; the `dev-bot` backend remains a stub until a real consumer service exists) + audit `outcome: escalated`.
-6. Every `tmux send-keys` still passes through the security floor: whitelist → escape-block → micro-cooldown (500 ms) + decision-cooldown (60 s) → fail-closed.
+6. `Y` atomically persists or renews the exact learned match; `N`, replay,
+   expiry, wrong context, or malformed input fails closed. Rules become due
+   after 24 hours and expire after seven days; re-validation proposes confirmation
+   but never executes a due rule.
+7. Every `tmux send-keys` still passes through the security floor: whitelist → escape-block → micro-cooldown (500 ms) + decision-cooldown (60 s) → fail-closed. Per-space policy and the immutable hard-gated floor remain authoritative at L4.
 
 ## Configuration (user-config.yaml)
 
@@ -69,10 +75,10 @@ escalation:
 ## CLI examples
 
 ```bash
-# default Phase 2 cycle: parse → (rule-hit | resolver → autonomous-or-escalate)
+# default Phase 3 cycle: parse → gate → execute → optional Save-as-rule proposal
 dr-orchestrate run --pane "%5"
 
-# dry-run отображает baseline без mutation
+# dry-run reports the baseline without mutation
 dr-orchestrate run --dry-run
 
 # manual resolver invocation with inline text

--- a/dev-tools/check-auto-restart.sh
+++ b/dev-tools/check-auto-restart.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# Verify single-host tmux recovery and idempotent interrupted-cycle marking.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+# shellcheck source=../plugins/dr-orchestrate/tests/helpers/phase3-env.bash
+source "$ROOT/plugins/dr-orchestrate/tests/helpers/phase3-env.bash"
+
+usage() {
+  echo "usage: check-auto-restart.sh --session <name> --expect-restore" >&2
+  exit 2
+}
+
+SESSION=""; EXPECT_RESTORE=0
+while (( $# > 0 )); do
+  case "$1" in
+    --session) SESSION="${2:-}"; shift 2 ;;
+    --expect-restore) EXPECT_RESTORE=1; shift ;;
+    *) usage ;;
+  esac
+done
+[[ "$SESSION" =~ ^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$ ]] || usage
+(( EXPECT_RESTORE == 1 )) || usage
+
+phase3_env_setup
+trap phase3_env_cleanup EXIT
+MANAGER="$PHASE3_PLUGIN_ROOT/scripts/tmux_manager.sh"
+AUDIT_SINK="$PHASE3_PLUGIN_ROOT/scripts/audit_sink.sh"
+[[ -x "$MANAGER" && -x "$AUDIT_SINK" ]] || {
+  echo "FAIL: recovery dependencies are not executable" >&2
+  exit 1
+}
+
+# shellcheck source=../plugins/dr-orchestrate/scripts/tmux_manager.sh
+source "$MANAGER"
+# shellcheck source=../plugins/dr-orchestrate/scripts/audit_sink.sh
+source "$AUDIT_SINK"
+
+UNRELATED="phase3-unrelated-$$"
+tmux new-session -d -s "$UNRELATED"
+unrelated_pane="$(tmux display-message -p -t "$UNRELATED:0.0" '#{pane_id}')"
+
+tmux kill-session -t "$SESSION" >/dev/null 2>&1 || true
+session_recover "$SESSION"
+tmux has-session -t "$SESSION"
+
+tmux set-option -t "$SESSION" remain-on-exit on
+respawn_once="$PHASE3_ENV_ROOT/respawn-once.sh"
+respawn_marker="$PHASE3_ENV_ROOT/respawn.marker"
+cat >"$respawn_once" <<'SH'
+#!/usr/bin/env bash
+if [[ ! -e "${PHASE3_RESPAWN_MARKER:?}" ]]; then
+  : >"$PHASE3_RESPAWN_MARKER"
+  exit 0
+fi
+exec sleep 600
+SH
+chmod 700 "$respawn_once"
+tmux set-environment -g PHASE3_RESPAWN_MARKER "$respawn_marker"
+tmux respawn-pane -k -t "$SESSION:0.0" "$respawn_once"
+dead=0
+for _ in $(seq 1 100); do
+  [[ "$(tmux display-message -p -t "$SESSION:0.0" '#{pane_dead}')" == 1 ]] && { dead=1; break; }
+done
+(( dead == 1 )) || { echo "FAIL: fixture pane did not become inactive" >&2; exit 1; }
+session_recover "$SESSION"
+[[ "$(tmux display-message -p -t "$SESSION:0.0" '#{pane_dead}')" == 0 ]] || {
+  echo "FAIL: inactive retained pane was not respawned" >&2
+  exit 1
+}
+
+CYCLE_ID="phase3-cycle-$$"
+PANE_ID="$SESSION:0.0"
+emit "$DR_ORCH_AUDIT_FILE" \
+  "$(make_cycle_checkpoint prepare "$CYCLE_ID" "$SESSION" "$PANE_ID" /dr-plan pending)"
+recover_cycle_checkpoint "$DR_ORCH_AUDIT_FILE" "$SESSION" "$PANE_ID"
+recover_cycle_checkpoint "$DR_ORCH_AUDIT_FILE" "$SESSION" "$PANE_ID"
+recovery_count="$(jq -s --arg cycle "$CYCLE_ID" \
+  '[.[] | select(.event=="cycle_checkpoint" and .phase=="recovery" and .cycle_id==$cycle)] | length' \
+  "$DR_ORCH_AUDIT_FILE")"
+[[ "$recovery_count" == 1 ]] || { echo "FAIL: checkpoint recovery was not idempotent" >&2; exit 1; }
+[[ ! -s "$DR_ORCH_ACTION_EXECUTOR_LOG" ]] || { echo "FAIL: recovery replayed an action" >&2; exit 1; }
+[[ "$(tmux display-message -p -t "$UNRELATED:0.0" '#{pane_id}')" == "$unrelated_pane" ]] || {
+  echo "FAIL: unrelated tmux session changed" >&2
+  exit 1
+}
+
+echo "PASS: session=$SESSION recreated=true pane_respawned=true recovery_events=1 action_replays=0"

--- a/dev-tools/check-escape-false-positives.sh
+++ b/dev-tools/check-escape-false-positives.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# Measure the observed false-positive rate on a fixed deterministic corpus.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+# shellcheck source=../plugins/dr-orchestrate/tests/helpers/phase3-env.bash
+source "$ROOT/plugins/dr-orchestrate/tests/helpers/phase3-env.bash"
+
+usage() {
+  echo "usage: check-escape-false-positives.sh --iterations <positive-integer>" >&2
+  exit 2
+}
+
+ITERATIONS=""
+while (( $# > 0 )); do
+  case "$1" in
+    --iterations) ITERATIONS="${2:-}"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+[[ "$ITERATIONS" =~ ^[1-9][0-9]*$ ]] || usage
+(( ITERATIONS <= 100000 )) || { echo "FAIL: iterations exceeds deterministic safety cap" >&2; exit 1; }
+
+phase3_env_setup
+trap phase3_env_cleanup EXIT
+SECURITY="$PHASE3_PLUGIN_ROOT/scripts/security.sh"
+[[ -x "$SECURITY" ]] || { echo "FAIL: security helper is not executable" >&2; exit 1; }
+# shellcheck source=../plugins/dr-orchestrate/scripts/security.sh
+source "$SECURITY"
+
+CANARY="$PHASE3_ENV_ROOT/escape-canary"
+malicious=(
+  $'\x1b[31mred\x1b[0m'
+  $'\x1b]0;title\x07'
+  $'\x1bP1;2|payload\x1b\\'
+  $'prefix\x1b[2Jsuffix'
+  $'\x1b]0;$(touch '"$CANARY"$')\x07'
+)
+for payload in "${malicious[@]}"; do
+  if check_escape "$payload" >/dev/null 2>&1; then
+    echo "FAIL: malicious escape fixture was accepted" >&2
+    exit 1
+  fi
+done
+[[ ! -e "$CANARY" ]] || { echo "FAIL: escape fixture produced a side effect" >&2; exit 1; }
+
+false_positives=0
+for ((i = 1; i <= ITERATIONS; i++)); do
+  safe="/dr-plan TUNE-$((100000 + i)) safe_case_$i"
+  if ! check_escape "$safe" >/dev/null 2>&1 \
+    || ! check_whitelist "$safe" >/dev/null 2>&1; then
+    false_positives=$((false_positives + 1))
+  fi
+done
+
+printf 'iterations=%d false_positives=%d observed_rate=%d/%d fixed_corpus_only=true population_confidence_claim=false\n' \
+  "$ITERATIONS" "$false_positives" "$false_positives" "$ITERATIONS"
+(( false_positives == 0 ))

--- a/dev-tools/check-orchestrate-docs.sh
+++ b/dev-tools/check-orchestrate-docs.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Verify the six Phase 3 Class B shipped documentation surfaces.
+set -euo pipefail
+
+(( $# == 0 )) || { echo "usage: check-orchestrate-docs.sh" >&2; exit 2; }
+ROOT="${DR_ORCH_DOCS_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)}"
+# Baseline = where this work diverged from the canonical default branch.
+# It was previously pinned to a hard-coded sha from the pre-re-root history;
+# that commit is not reachable from origin/main, so every check below failed
+# for any correct tree once the work was relanded. Deriving it keeps all three
+# checks (plugin version, VERSION, release-claim scan) scoped to this branch's
+# own additions, which is what they were always meant to assert.
+BASE="${DR_ORCH_DOCS_BASE:-$(git -C "$ROOT" merge-base HEAD origin/main 2>/dev/null \
+        || git -C "$ROOT" rev-parse HEAD)}"
+FRONTMATTER_CHECK="${DR_ORCH_FRONTMATTER_CHECK:-$ROOT/dev-tools/check-frontmatter-english.sh}"
+BODY_CHECK="${DR_ORCH_BODY_CHECK:-$ROOT/dev-tools/check-body-english.sh}"
+files=(
+  commands/dr-orchestrate.md
+  plugins/dr-orchestrate/plugin.yaml
+  plugins/dr-orchestrate/README.md
+  README.md
+  CLAUDE.md
+  CHANGELOG.md
+)
+
+for file in "${files[@]}"; do
+  [[ -f "$ROOT/$file" ]] || { echo "FAIL: missing shipped surface: $file" >&2; exit 1; }
+  grep -Eiq 'Phase[[:space:]]+3' "$ROOT/$file" || { echo "FAIL: $file lacks Phase 3" >&2; exit 1; }
+  grep -Eiq 'confirm|Save[- ]as[- ]rule|Save as rule' "$ROOT/$file" || { echo "FAIL: $file lacks confirmation contract" >&2; exit 1; }
+  grep -Eiq 'seven-day|7-day|604800' "$ROOT/$file" || { echo "FAIL: $file lacks seven-day TTL" >&2; exit 1; }
+  grep -Eiq '24[- ]hour|24h|86400' "$ROOT/$file" || { echo "FAIL: $file lacks 24-hour window" >&2; exit 1; }
+  grep -Eiq 're-validation|revalidation' "$ROOT/$file" || { echo "FAIL: $file lacks re-validation contract" >&2; exit 1; }
+  grep -Eiq 'hard[- ]gat|immutable.*gate' "$ROOT/$file" || { echo "FAIL: $file lacks hard-gate contract" >&2; exit 1; }
+done
+
+corpus="$(mktemp)"
+scan_root="$(mktemp -d)"
+trap 'rm -f -- "$corpus"; rm -rf -- "$scan_root"' EXIT
+for file in "${files[@]}"; do
+  printf '\nFILE: %s\n' "$file" >>"$corpus"
+  cat "$ROOT/$file" >>"$corpus"
+done
+
+git -C "$ROOT" cat-file -e "$BASE^{commit}" 2>/dev/null || { echo "FAIL: base commit unavailable: $BASE" >&2; exit 1; }
+base_version="$(git -C "$ROOT" show "$BASE:plugins/dr-orchestrate/plugin.yaml" | yq -r '.version')"
+current_version="$(yq -r '.version' "$ROOT/plugins/dr-orchestrate/plugin.yaml")"
+[[ -n "$base_version" && "$base_version" == "$current_version" ]] || {
+  echo "FAIL: plugin manifest version changed ($base_version -> $current_version)" >&2
+  exit 1
+}
+git -C "$ROOT" diff --quiet "$BASE" -- VERSION || { echo "FAIL: VERSION changed in batch mode" >&2; exit 1; }
+
+added_lines="$scan_root/added-lines.txt"
+git -C "$ROOT" diff --unified=0 "$BASE" -- "${files[@]}" \
+  | awk '/^\+\+\+/{next} /^\+/{sub(/^\+/, ""); print}' >"$added_lines"
+if grep -Eiq '(^|[^[:alnum:]])v?[0-9]+\.[0-9]+\.[0-9]+([^[:alnum:]]|$)|(^|[[:space:]])released([[:space:]]|:)' "$added_lines"; then
+  echo "FAIL: task-added documentation makes a release/version claim" >&2
+  exit 1
+fi
+
+mkdir -p "$scan_root/repo/commands"
+git -C "$scan_root/repo" init -q
+index=0
+for file in "${files[@]}"; do
+  case "$file" in
+    *.md)
+      index=$((index + 1))
+      git -C "$ROOT" diff --unified=0 "$BASE" -- "$file" \
+        | awk '/^\+\+\+/{next} /^\+/{sub(/^\+/, ""); print}' \
+        >"$scan_root/repo/commands/surface-$index.md"
+      ;;
+  esac
+done
+"$FRONTMATTER_CHECK" "$scan_root/repo" >/dev/null
+"$BODY_CHECK" --root "$scan_root/repo" --scope commands >/dev/null
+if LC_ALL=C grep -qE $'\xD0[\x80-\xBF]|\xD1[\x80-\xBF]|\xD2[\x80-\xBF]|\xD3[\x80-\xBF]' \
+  "$ROOT/plugins/dr-orchestrate/plugin.yaml"; then
+  echo "FAIL: plugin manifest contains non-English Cyrillic text" >&2
+  exit 1
+fi
+
+echo "PASS: phase3_docs=6 confirmation=true ttl=604800 revalidation=86400 hard_gate=true version_unchanged=true english=true"

--- a/dev-tools/check-orchestrate-regression.sh
+++ b/dev-tools/check-orchestrate-regression.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Run the sorted recursive dr-orchestrate Bats manifest with count/skip guards.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+
+usage() {
+  echo 'usage: check-orchestrate-regression.sh --baseline-files N --minimum-files N --baseline-tests N [--allow-skip redis-unavailable]' >&2
+  exit 2
+}
+
+BASELINE_FILES=""; MINIMUM_FILES=""; BASELINE_TESTS=""; ALLOW_SKIP=""
+while (( $# > 0 )); do
+  case "$1" in
+    --baseline-files) BASELINE_FILES="${2:-}"; shift 2 ;;
+    --minimum-files) MINIMUM_FILES="${2:-}"; shift 2 ;;
+    --baseline-tests) BASELINE_TESTS="${2:-}"; shift 2 ;;
+    --allow-skip) ALLOW_SKIP="${2:-}"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+for value in "$BASELINE_FILES" "$MINIMUM_FILES" "$BASELINE_TESTS"; do
+  [[ "$value" =~ ^[0-9]+$ ]] || usage
+done
+[[ -z "$ALLOW_SKIP" || "$ALLOW_SKIP" == redis-unavailable ]] || usage
+(( MINIMUM_FILES >= BASELINE_FILES )) || { echo "FAIL: minimum-files is below baseline-files" >&2; exit 1; }
+
+REGRESSION_TMP="$(mktemp -d "${TMPDIR:-/tmp}/dr-orchestrate-regression.XXXXXX")"
+cleanup() {
+  tmux kill-server >/dev/null 2>&1 || true
+  rm -rf -- "$REGRESSION_TMP"
+}
+trap cleanup EXIT
+export HOME="$REGRESSION_TMP/home"
+export XDG_CONFIG_HOME="$REGRESSION_TMP/config"
+export TMUX_TMPDIR="$REGRESSION_TMP/tmux"
+unset TMUX
+unset AUDIT_DIR STATE_DIR DR_ORCH_STATE_DIR DR_ORCH_RULES_USER DR_ORCH_RULES_LEARNED
+unset DR_ORCH_PROPOSALS_DIR DR_ORCH_TOMBSTONES_DIR DR_ORCH_DELIVERY_DIR DR_ORCH_LEARNED_AUDIT
+unset DR_ORCH_PROPOSAL_MOCK_LOG DR_ORCH_PROPOSAL_QUEUE DR_ORCH_ACTION_EXECUTOR_LOG
+unset DR_ORCH_AUTONOMY_AUDIT DR_AUTONOMY_AUDIT DR_ORCH_FB_RULES DR_AUTONOMY_RULES
+unset DATARIM_SPACES_ROOT DATARIM_ACTIVE_SPACE PHASE3_NETWORK_LOG
+mkdir -p "$HOME" "$XDG_CONFIG_HOME" "$TMUX_TMPDIR"
+chmod 700 "$HOME" "$XDG_CONFIG_HOME" "$TMUX_TMPDIR"
+
+TEST_ROOT="${DR_ORCH_REGRESSION_TEST_ROOT:-$ROOT/plugins/dr-orchestrate/tests}"
+BATS_BIN="${DR_ORCH_BATS_BIN:-$(command -v bats || true)}"
+[[ -d "$TEST_ROOT" && -x "$BATS_BIN" ]] || { echo "FAIL: test root or Bats executable unavailable" >&2; exit 1; }
+
+mapfile -t bats_files < <(LC_ALL=C find "$TEST_ROOT" -type f -name '*.bats' -print | LC_ALL=C sort)
+file_count="${#bats_files[@]}"
+(( file_count >= BASELINE_FILES && file_count >= MINIMUM_FILES )) || {
+  echo "FAIL: recursive Bats files=$file_count baseline=$BASELINE_FILES minimum=$MINIMUM_FILES" >&2
+  exit 1
+}
+
+required_raw="${DR_ORCH_REQUIRED_PHASE3_SUITES:-test_resolver_history.bats:test_learned_rules.bats}"
+IFS=: read -r -a required_suites <<<"$required_raw"
+for required in "${required_suites[@]}"; do
+  found=0
+  for file in "${bats_files[@]}"; do
+    [[ "$file" == */"$required" || "$file" == "$TEST_ROOT/$required" ]] && { found=1; break; }
+  done
+  (( found == 1 )) || { echo "FAIL: required Phase 3 suite missing: $required" >&2; exit 1; }
+done
+
+test_count=0
+for file in "${bats_files[@]}"; do
+  count="$(LC_ALL=C grep -cE '^[[:space:]]*@test[[:space:]]+' "$file" || true)"
+  (( count > 0 )) || { echo "FAIL: zero-test Bats file: $file" >&2; exit 1; }
+  test_count=$((test_count + count))
+done
+(( test_count > BASELINE_TESTS )) || {
+  echo "FAIL: recursive tests=$test_count must exceed baseline=$BASELINE_TESTS" >&2
+  exit 1
+}
+
+tap="$REGRESSION_TMP/regression.tap"
+set +e
+"$BATS_BIN" --tap "${bats_files[@]}" >"$tap" 2>&1
+bats_status=$?
+set -e
+cat "$tap"
+(( bats_status == 0 )) || { echo "FAIL: recursive Bats run exited $bats_status" >&2; exit 1; }
+
+while IFS= read -r skip_line; do
+  [[ -n "$skip_line" ]] || continue
+  if [[ "$ALLOW_SKIP" != redis-unavailable ]] \
+    || ! grep -Eiq 'redis' <<<"$skip_line"; then
+    echo "FAIL: unapproved skip: $skip_line" >&2
+    exit 1
+  fi
+done < <(grep -Ei '^ok [0-9]+ .*# skip' "$tap" || true)
+
+echo "PASS: recursive_files=$file_count recursive_tests=$test_count baseline_files=$BASELINE_FILES baseline_tests=$BASELINE_TESTS"

--- a/dev-tools/check-rule-ttl.sh
+++ b/dev-tools/check-rule-ttl.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# Verify learned-rule TTL and re-validation boundaries without wall-clock sleep.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+# shellcheck source=../plugins/dr-orchestrate/tests/helpers/phase3-env.bash
+source "$ROOT/plugins/dr-orchestrate/tests/helpers/phase3-env.bash"
+
+usage() {
+  echo "usage: check-rule-ttl.sh --ttl <seconds> --revalidate <seconds>" >&2
+  exit 2
+}
+
+TTL=""; REVALIDATE=""
+while (( $# > 0 )); do
+  case "$1" in
+    --ttl) TTL="${2:-}"; shift 2 ;;
+    --revalidate) REVALIDATE="${2:-}"; shift 2 ;;
+    *) usage ;;
+  esac
+done
+[[ "$TTL" =~ ^[1-9][0-9]*$ && "$REVALIDATE" =~ ^[1-9][0-9]*$ ]] || usage
+[[ "$TTL" == 604800 && "$REVALIDATE" == 86400 ]] || {
+  echo "FAIL: Phase 3 requires ttl=604800 and revalidate=86400" >&2
+  exit 1
+}
+
+phase3_env_setup
+trap phase3_env_cleanup EXIT
+LOADER="$PHASE3_PLUGIN_ROOT/scripts/rules_loader.sh"
+LIFECYCLE="$PHASE3_PLUGIN_ROOT/scripts/learned_rules.sh"
+[[ -x "$LOADER" && -x "$LIFECYCLE" ]] || {
+  echo "FAIL: learned-rule loader/lifecycle is not executable" >&2
+  exit 1
+}
+
+NOW=2000000000
+export DR_ORCH_NOW_EPOCH="$NOW"
+HASH="$(printf 'phase3-ttl' | shasum -a 256 | awk '{print $1}')"
+
+write_boundary_rules() {
+  cat >"$DR_ORCH_RULES_LEARNED" <<YAML
+patterns:
+  - match: "fresh rule"
+    action: "/dr-plan"
+    confidence: 0.95
+    created_at: $((NOW - REVALIDATE))
+    last_validated_at: $((NOW - REVALIDATE + 1))
+    expires_at: $((NOW + TTL - REVALIDATE))
+    proposal_hash: "$HASH"
+    generation: "$HASH"
+  - match: "due rule"
+    action: "/dr-plan"
+    confidence: 0.95
+    created_at: $((NOW - REVALIDATE))
+    last_validated_at: $((NOW - REVALIDATE))
+    expires_at: $((NOW + TTL - REVALIDATE))
+    proposal_hash: "$HASH"
+    generation: "$HASH"
+  - match: "expired rule"
+    action: "/dr-plan"
+    confidence: 0.95
+    created_at: $((NOW - TTL))
+    last_validated_at: $((NOW - REVALIDATE + 1))
+    expires_at: $NOW
+    proposal_hash: "$HASH"
+    generation: "$HASH"
+YAML
+  chmod 600 "$DR_ORCH_RULES_LEARNED"
+}
+
+assert_boundary_loads() {
+  local active inactive
+  active="$(bash "$LOADER" load)"
+  inactive="$(bash "$LOADER" load_inactive_learned)"
+  [[ "$(jq -r '[.[] | select(.provenance=="learned") | .match] | sort | join(",")' <<<"$active")" == "fresh rule" ]] || return 1
+  [[ "$(jq -r '[.[].match] | sort | join(",")' <<<"$inactive")" == "due rule,expired rule" ]] || return 1
+}
+
+assert_purge_and_renewed_load() {
+  bash "$LIFECYCLE" maintenance >/dev/null
+  [[ "$(yq -r '[.patterns[] | select(.match=="expired rule")] | length' "$DR_ORCH_RULES_LEARNED")" == 0 ]] || return 1
+  yq -i '(.patterns[] | select(.match=="due rule") | .last_validated_at) = env(DR_ORCH_NOW_EPOCH)' \
+    "$DR_ORCH_RULES_LEARNED"
+  local active
+  active="$(bash "$LOADER" load)"
+  [[ "$(jq -r '[.[] | select(.provenance=="learned") | .match] | sort | join(",")' <<<"$active")" == "due rule,fresh rule" ]] || return 1
+}
+
+write_boundary_rules
+assert_boundary_loads || { echo "FAIL: exact due/expiry boundary was not fail-closed" >&2; exit 1; }
+assert_purge_and_renewed_load || { echo "FAIL: purge or renewed-rule load contract failed" >&2; exit 1; }
+echo "PASS: ttl=$TTL revalidate=$REVALIDATE boundaries=fresh,due,expired sleep_calls=0"

--- a/dev-tools/e2e-test-orchestrate.sh
+++ b/dev-tools/e2e-test-orchestrate.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Hermetic Phase 3 intent-to-mock-notification acceptance workflow.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+# shellcheck source=../plugins/dr-orchestrate/tests/helpers/phase3-env.bash
+source "$ROOT/plugins/dr-orchestrate/tests/helpers/phase3-env.bash"
+
+usage() {
+  echo 'usage: e2e-test-orchestrate.sh --intent <text> --expect-audit --expect-telegram' >&2
+  exit 2
+}
+
+INTENT=""; EXPECT_AUDIT=0; EXPECT_TELEGRAM=0
+while (( $# > 0 )); do
+  case "$1" in
+    --intent) INTENT="${2:-}"; shift 2 ;;
+    --expect-audit) EXPECT_AUDIT=1; shift ;;
+    --expect-telegram) EXPECT_TELEGRAM=1; shift ;;
+    *) usage ;;
+  esac
+done
+[[ -n "$INTENT" && "$INTENT" != -* && "$INTENT" != *$'\n'* && ${#INTENT} -le 256 ]] || usage
+(( EXPECT_AUDIT == 1 && EXPECT_TELEGRAM == 1 )) || usage
+
+phase3_env_setup
+trap phase3_env_cleanup EXIT
+LIFECYCLE="$PHASE3_PLUGIN_ROOT/scripts/learned_rules.sh"
+PARSER="$PHASE3_PLUGIN_ROOT/scripts/semantic_parser.sh"
+GATE="$PHASE3_PLUGIN_ROOT/scripts/action_gate.sh"
+RUNNER="$PHASE3_PLUGIN_ROOT/scripts/cmd_run.sh"
+for dependency in "$LIFECYCLE" "$PARSER" "$GATE" "$RUNNER"; do
+  [[ -x "$dependency" ]] || { echo "FAIL: missing executable integration dependency: $dependency" >&2; exit 1; }
+done
+
+cat >"$PHASE3_ENV_ROOT/bin/dr-orch-mock-e2e" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' '{"action":"/dr-plan","confidence":0.95,"reason":"e2e fixture"}'
+MOCK
+chmod 700 "$PHASE3_ENV_ROOT/bin/dr-orch-mock-e2e"
+export DR_ORCH_SUBAGENT_CHAIN=mock-e2e
+
+# An omitted action_kind must first normalize to framework_command and traverse
+# the immutable space gate. Prove deny-before-executor ordering before enabling
+# the same hermetic space for the successful cycle.
+sed -i 's/cross_project_write: auto/cross_project_write: operator/' \
+  "$DATARIM_SPACES_ROOT/phase3-test/space.yml"
+blocked_output="$(bash "$RUNNER" --pane phase3-missing:0.0 --unknown-prompt "$INTENT")"
+[[ "$blocked_output" == *"reason=space_policy"* ]] || {
+  echo "FAIL: inferred action_kind fallback did not gate before execution" >&2
+  exit 1
+}
+[[ ! -s "$DR_ORCH_ACTION_EXECUTOR_LOG" ]] || {
+  echo "FAIL: space-denied inference reached the executor" >&2
+  exit 1
+}
+[[ ! -d "$DR_ORCH_DELIVERY_DIR" \
+  || -z "$(find "$DR_ORCH_DELIVERY_DIR" -maxdepth 1 -type f -print -quit)" ]] || {
+  echo "FAIL: space-denied inference created a proposal" >&2
+  exit 1
+}
+sed -i 's/cross_project_write: operator/cross_project_write: auto/' \
+  "$DATARIM_SPACES_ROOT/phase3-test/space.yml"
+
+# The first cycle is intentionally a parser miss. It must traverse the actual
+# inference -> gate -> controlled executor -> proposal integration path.
+bash "$RUNNER" --pane phase3-missing:0.0 --unknown-prompt "$INTENT" >/dev/null
+notification="$(find "$DR_ORCH_DELIVERY_DIR" -maxdepth 1 -type f -name '*.json' -print -quit)"
+proposal_id="$(jq -r '.proposal_id // .callback_id // .id // empty' "$notification")"
+[[ "$proposal_id" =~ ^[A-Za-z0-9_-]{16,256}$ ]] || {
+  echo "FAIL: proposal did not emit a bounded opaque callback ID" >&2
+  exit 1
+}
+[[ -n "$notification" && -s "$notification" ]] || { echo "FAIL: mock notification was not emitted" >&2; exit 1; }
+jq -e --arg id "$proposal_id" '.proposal_id==$id and (.prompt|type=="string")' "$notification" >/dev/null || {
+  echo "FAIL: mock notification is not bound to the callback ID" >&2
+  exit 1
+}
+
+bash "$LIFECYCLE" consume_callback "$proposal_id" Y \
+  "$DR_ORCH_ACTOR" "$DR_ORCH_SESSION_CONTEXT" >/dev/null
+decision="$(bash "$PARSER" parse "$INTENT")"
+[[ "$(jq -r '.action' <<<"$decision")" == /dr-plan \
+  && "$(jq -r '.provenance' <<<"$decision")" == learned ]] || {
+  echo "FAIL: affirmative callback did not create an exact learned hit" >&2
+  exit 1
+}
+
+payload="$(jq -n -c --arg command /dr-plan '{command:$command}')"
+bash "$GATE" gate --action framework_command --payload "$payload" >/dev/null
+: >"$DR_ORCH_ACTION_EXECUTOR_LOG"
+DR_ORCH_PANE_CAPTURE_OVERRIDE="$INTENT" \
+  bash "$RUNNER" --pane "$SESSION_NAME:0.0" >/dev/null
+[[ "$(tail -n 1 "$DR_ORCH_ACTION_EXECUTOR_LOG")" == /dr-plan ]] || {
+  echo "FAIL: controlled executor seam did not receive /dr-plan" >&2
+  exit 1
+}
+[[ -z "$(find "$DR_ORCH_DELIVERY_DIR" -maxdepth 1 -type f -name '*.json' -print -quit)" ]] || {
+  echo "FAIL: active learned hit emitted a redundant proposal" >&2
+  exit 1
+}
+
+audit_file="$(find "$AUDIT_DIR" -maxdepth 1 -type f -name 'audit-*.jsonl' -print -quit)"
+[[ -n "$audit_file" && -s "$audit_file" ]] || { echo "FAIL: cycle audit was not written" >&2; exit 1; }
+jq -e -s 'any(.[]; .event=="cycle_checkpoint" and .phase=="prepare") and
+  any(.[]; .event=="cycle_checkpoint" and .phase=="terminal") and
+  any(.[]; .event=="learned_rule_prepare") and
+  any(.[]; .event=="learned_rule_commit") and
+  any(.[]; .outcome=="resolved")' "$audit_file" >/dev/null || {
+  echo "FAIL: canonical audit lacks cycle, learned mutation, or resolved evidence" >&2
+  exit 1
+}
+! grep -Fq -- "$proposal_id" "$audit_file" || { echo "FAIL: raw callback ID leaked into audit" >&2; exit 1; }
+[[ ! -s "$PHASE3_NETWORK_LOG" ]] || { echo "FAIL: workflow attempted a network client" >&2; exit 1; }
+
+echo "PASS: intent_to_proposal_to_callback_to_learned_hit_to_gate_to_executor_to_audit_to_mock_notification"

--- a/dev-tools/rules/fb-rules.yaml
+++ b/dev-tools/rules/fb-rules.yaml
@@ -135,6 +135,7 @@ always_gated_floor:
 
 # Runtime action kind → spaces/{name}/space.yml autonomy.policy key.
 action_autonomy_map:
+  framework_command: cross_project_write
   feature_branch_push: feature_branch_push
   merge_main: merge_main
   prod_deploy: prod_deploy

--- a/dev-tools/tests/orchestrate-phase3-acceptance.bats
+++ b/dev-tools/tests/orchestrate-phase3-acceptance.bats
@@ -1,0 +1,144 @@
+#!/usr/bin/env bats
+# Acceptance contracts for the six TUNE-0166 Phase 3 verification helpers.
+
+setup() {
+  REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd -P)"
+  TTL="$REPO_ROOT/dev-tools/check-rule-ttl.sh"
+  RESTART="$REPO_ROOT/dev-tools/check-auto-restart.sh"
+  ESCAPE="$REPO_ROOT/dev-tools/check-escape-false-positives.sh"
+  E2E="$REPO_ROOT/dev-tools/e2e-test-orchestrate.sh"
+  REGRESSION="$REPO_ROOT/dev-tools/check-orchestrate-regression.sh"
+  DOCS="$REPO_ROOT/dev-tools/check-orchestrate-docs.sh"
+  PHASE3_ENV="$REPO_ROOT/plugins/dr-orchestrate/tests/helpers/phase3-env.bash"
+}
+
+make_regression_fixture() {
+  REGRESSION_ROOT="$BATS_TEST_TMPDIR/regression-tests"
+  mkdir -p "$REGRESSION_ROOT/nested/deeper"
+  printf '%s\n' '#!/usr/bin/env bats' '@test "resolver" { true; }' \
+    >"$REGRESSION_ROOT/nested/test_resolver_history.bats"
+  printf '%s\n' '#!/usr/bin/env bats' '@test "learned" { true; }' \
+    >"$REGRESSION_ROOT/nested/deeper/test_learned_rules.bats"
+  FAKE_BATS="$BATS_TEST_TMPDIR/fake-bats"
+  cat >"$FAKE_BATS" <<'SH'
+#!/usr/bin/env bash
+case "${FAKE_BATS_MODE:-pass}" in
+  pass) printf '1..2\nok 1 resolver\nok 2 learned\n' ;;
+  redis) printf '1..2\nok 1 resolver # skip Redis not available\nok 2 learned\n' ;;
+  bad-skip) printf '1..2\nok 1 resolver # skip unrelated dependency\nok 2 learned\n' ;;
+esac
+SH
+  chmod +x "$FAKE_BATS"
+  export REGRESSION_ROOT FAKE_BATS
+}
+
+run_fixture_regression() {
+  env DR_ORCH_REGRESSION_TEST_ROOT="$REGRESSION_ROOT" \
+    DR_ORCH_BATS_BIN="$FAKE_BATS" \
+    DR_ORCH_REQUIRED_PHASE3_SUITES='test_resolver_history.bats:test_learned_rules.bats' \
+    FAKE_BATS_MODE="${FAKE_BATS_MODE:-pass}" \
+    "$REGRESSION" --baseline-files 1 --minimum-files 2 --baseline-tests 1 "$@"
+}
+
+@test "Phase 3 acceptance helpers are executable" {
+  [ -x "$TTL" ] && [ -x "$RESTART" ] && [ -x "$ESCAPE" ] \
+    && [ -x "$E2E" ] && [ -x "$REGRESSION" ] && [ -x "$DOCS" ] \
+    && [ -x "$PHASE3_ENV" ]
+}
+
+@test "TTL helper rejects missing boundary arguments" {
+  run "$TTL" --ttl 604800
+  [ "$status" -eq 2 ]
+}
+
+@test "TTL helper rejects a non-canonical exact boundary" {
+  run "$TTL" --ttl 604800 --revalidate 86399
+  [ "$status" -eq 1 ]
+}
+
+@test "restart helper requires explicit restore expectation" {
+  run "$RESTART" --session datarim
+  [ "$status" -eq 2 ]
+}
+
+@test "escape corpus helper rejects zero iterations" {
+  run "$ESCAPE" --iterations 0
+  [ "$status" -eq 2 ]
+}
+
+@test "e2e helper requires audit and Telegram-mock expectations" {
+  run "$E2E" --intent "run dr-plan" --expect-audit
+  [ "$status" -eq 2 ]
+}
+
+@test "regression helper rejects an invalid skip policy" {
+  run "$REGRESSION" --baseline-files 42 --minimum-files 44 --baseline-tests 332 --allow-skip anything
+  [ "$status" -eq 2 ]
+}
+
+@test "docs helper rejects arguments" {
+  run "$DOCS" unexpected
+  [ "$status" -eq 2 ]
+}
+
+@test "deterministic safe corpus reports zero false positives" {
+  run "$ESCAPE" --iterations 100
+  [ "$status" -eq 0 ] && [[ "$output" == *"false_positives=0"* ]] \
+    && [[ "$output" == *"population_confidence_claim=false"* ]]
+}
+
+@test "TTL helper enforces fresh, due, expired, purge, and renewed boundaries" {
+  run "$TTL" --ttl 604800 --revalidate 86400
+  [ "$status" -eq 0 ] && [[ "$output" == *"sleep_calls=0"* ]]
+}
+
+@test "auto-restart helper recovers without replay or unrelated-session mutation" {
+  run "$RESTART" --session datarim --expect-restore
+  [ "$status" -eq 0 ] && [[ "$output" == *"action_replays=0"* ]]
+}
+
+@test "e2e helper reaches the outbound mock without network" {
+  run "$E2E" --intent "run dr-plan" --expect-audit --expect-telegram
+  [ "$status" -eq 0 ] && [[ "$output" == *"to_mock_notification"* ]]
+}
+
+@test "regression helper discovers required suites recursively" {
+  make_regression_fixture
+  run run_fixture_regression
+  [ "$status" -eq 0 ] && [[ "$output" == *"recursive_files=2"* ]]
+}
+
+@test "regression helper rejects a recursively discovered zero-test file" {
+  make_regression_fixture
+  : >"$REGRESSION_ROOT/nested/zero.bats"
+  run run_fixture_regression
+  [ "$status" -eq 1 ] && [[ "$output" == *"zero-test Bats file"* ]]
+}
+
+@test "regression helper rejects an unapproved skip" {
+  make_regression_fixture
+  export FAKE_BATS_MODE=bad-skip
+  run run_fixture_regression --allow-skip redis-unavailable
+  [ "$status" -eq 1 ] && [[ "$output" == *"unapproved skip"* ]]
+}
+
+@test "regression helper permits only the labelled Redis availability skip" {
+  make_regression_fixture
+  export FAKE_BATS_MODE=redis
+  run run_fixture_regression --allow-skip redis-unavailable
+  [ "$status" -eq 0 ]
+}
+
+@test "documentation helper validates all six Class B surfaces" {
+  run "$DOCS"
+  [ "$status" -eq 0 ] && [[ "$output" == *"phase3_docs=6"* ]]
+}
+
+@test "documentation helper enforces each required contract per surface" {
+  helper="$REPO_ROOT/dev-tools/check-orchestrate-docs.sh"
+  grep -qF 'FAIL: $file lacks confirmation contract' "$helper"
+  grep -qF 'FAIL: $file lacks seven-day TTL' "$helper"
+  grep -qF 'FAIL: $file lacks 24-hour window' "$helper"
+  grep -qF 'FAIL: $file lacks re-validation contract' "$helper"
+  grep -qF 'FAIL: $file lacks hard-gate contract' "$helper"
+}

--- a/plugins/dr-orchestrate/README.md
+++ b/plugins/dr-orchestrate/README.md
@@ -1,6 +1,6 @@
-# dr-orchestrate Plugin — Phase 2 (Subagent Inference + Bot-Interaction Interface)
+# dr-orchestrate Plugin — Phase 3 (Confirmed Auto-learning)
 
-> Class B plugin. Status: Phase 2 (Datarim v2.5.0, plugin v0.3.0).
+> Class B plugin. Phase 3 is implemented in the accumulated-release branch; the plugin manifest version remains unchanged until release.
 
 ## Install
 
@@ -16,9 +16,9 @@ dr-orchestrate run --dry-run
 dr-orchestrate run --unknown-prompt [text]
 ```
 
-Опционально перед запуском скопировать `user-config.template.yaml` → `user-config.yaml`,
-выставить `chmod 600`, заполнить ключи. Default `key_injection: false` — без ручного
-включения плагин не будет посылать send-keys.
+Optionally copy `user-config.template.yaml` to `user-config.yaml`, set mode 0600,
+and fill in the required keys. With the default `key_injection: false`, the
+plugin does not send keys until the operator enables it.
 
 ## Autonomy Levels
 
@@ -34,7 +34,29 @@ Pipeline phases by feature set (not a fixed autonomy level):
 
 - **Phase 1** — lean rule-based tmux runner.
 - **Phase 2** — multi-backend subagent inference (coworker → claude → codex) + race-safe cooldown + audit schema v2.
-- Phase 3 (planned) — auto-learning rules, Y/N callback, 24 h re-validation.
+- **Phase 3** — actor/session-bound Save-as-rule confirmation, exact learned rules, 24-hour re-validation, and a seven-day TTL.
+
+## Confirmed Auto-learning (Phase 3)
+
+After a successful trusted resolution, the plugin queues a `Save as rule? [Y/N]`
+proposal containing only an opaque callback identifier. A `Y` callback must
+match the authenticated actor and session, may be consumed once, and persists
+the normalized intent as an exact match. `N`, replay, expiry, stale generation,
+or context mismatch leaves the learned-rule file unchanged.
+Bot transports deliver the answer through the `on_callback` hook with an ID,
+answer, actor, and session; no network endpoint or Telegram credential is added
+by this phase.
+
+Learned actions never expand the trust registry. Every dispatch must already
+exist in bundled or user rules and must pass `framework_command` through the
+per-space `cross_project_write` policy immediately before execution. The
+immutable hard-gated floor remains authoritative at the Phase 3 L4 baseline.
+
+Fresh learned rules are usable for 24 hours. A due rule is excluded until a
+new successful resolution produces another confirmed proposal; confirmation
+updates `last_validated_at` without extending the immutable seven-day expiry.
+Expired rules are purged by maintenance. Mutable state defaults to a private
+mode-0700 directory, with mode-0600 atomic files and lock-held updates.
 
 ## Subagent Inference (Phase 2)
 
@@ -76,8 +98,8 @@ first, and fails closed on missing, malformed, unknown, or unresolved policy.
 
 ## Security Floor
 
-Перед любым `tmux send-keys` и перед любым autonomous decision выполняется
-фиксированный pipeline:
+Before every `tmux send-keys` call and autonomous decision, the fixed security
+pipeline runs:
 
 | Layer | Source | Behaviour |
 |-------|--------|-----------|
@@ -90,7 +112,7 @@ first, and fails closed on missing, malformed, unknown, or unresolved policy.
 | Flock-safe lock | `flock -n` per (pane, kind) | Linux only; macOS one-time WARN, non-atomic fallback |
 | Violation tracker | 5 hits / hour → 1 h pane block | persistent state |
 
-Все блокировки и события пишутся в JSONL audit. Schema v2 carries
+All blocks and events are written to the JSONL audit. Schema v2 carries
 `schema_version: 2`, `confidence`, `subagent_model`, `backend_used`,
 `escalation_backend`, `stage`, `outcome`, and a grep-redacted `reason`.
 `matched_text_hash` (sha256) preserves the hash-only invariant — raw pane text
@@ -152,9 +174,12 @@ a clean `chain_exhausted` envelope so the escalation path always runs.
 - `scripts/tmux_manager.sh` — session / pane CRUD.
 - `scripts/security.sh` — whitelist + escape + flock-safe cooldown + violation tracker.
 - `scripts/secrets_backend.sh` — YAML backend with mode-0600 enforcement.
-- `scripts/audit_sink.sh` — JSONL emit + schema v1 + schema v2 events + redaction.
+- `scripts/audit_sink.sh` — JSONL emit, schema v1/v2 events, cycle checkpoints, and recovery.
 - `scripts/semantic_parser.sh` — rule-based first-pass classifier.
 - `scripts/rules_loader.sh` — 3-source rules merge (default → user → learned).
+- `scripts/resolver.sh` — bounded compatibility history and deterministic alternative ranking.
+- `scripts/learned_rules.sh` — proposal, callback, TTL, re-validation, and maintenance lifecycle.
+- `scripts/proposal_backend.sh` — private idempotent mock/event callback queue.
 - `scripts/subagent_resolver.sh` — multi-backend AI CLI dispatch.
 - `scripts/escalation_backend.sh` — mock | dev-bot escalation sink (callback HMAC + Redis pub/sub backends).
 - `scripts/orchestrator-input-handler.sh` — inbound HTTP body validator + atomic inbox enqueue.
@@ -165,7 +190,7 @@ a clean `chain_exhausted` envelope so the escalation path always runs.
 - `rules/default.yaml` — bootstrap slash-command patterns.
 - `agents/dr-orchestrate-resolver.md` — declarative spec for the resolver subprocess.
 - `commands/dr-orchestrate.md` — command surface.
-- `tests/*.bats` — V-AC coverage (Phase 1 + Phase 2).
+- `tests/*.bats` — recursive V-AC coverage for Phase 1 through Phase 3.
 
 ## Bot Interaction Config
 
@@ -186,9 +211,9 @@ as simple as setting `provider: terminal` (or removing the block entirely).
 See `openapi/orchestrator-interface.yaml` for the full wire contract and
 `scripts/bot_interaction_dispatcher.sh` for the sourced env-export logic.
 
-## Out of Scope (Phase 2 + v0.3.0)
+## Out of Scope
 
-Telegram bridge UI, auto-learned rules write path (Phase 3), Vault
+Live Telegram callback transport (tracked separately), Vault
 `secrets_backend.sh` rewrite, embedding/vector classification, multi-host SSH,
 Docker / K8s orchestration, native Windows, stateful session store (Redis
 SETEX deferred), SSE/WebSocket outbound transport (deferred).

--- a/plugins/dr-orchestrate/plugin.yaml
+++ b/plugins/dr-orchestrate/plugin.yaml
@@ -1,10 +1,10 @@
 schema_version: 1
 id: dr-orchestrate
-title: "Datarim Orchestrator (Phase 2 — Subagent Inference + Bot-Interaction Interface)"
+title: "Datarim Orchestrator (Phase 3 — Confirmed Auto-learning)"
 version: 0.4.0
 author: "Pavel Valentov / Arcanada"
 license: MIT
-description: "tmux-based self-driving Datarim pipeline runner — Phase 2 adds multi-backend subagent inference for unknown prompts. Autonomy is resolved per-space from space.yml § autonomy.policy via resolve-space-autonomy.sh / action_gate.sh — full-autonomy spaces run all reversible actions without asking; only the Supreme-Directive hard-gated floor escalates to the operator. v0.3.0 adds bot-interaction interface: OpenAPI 3.1 inbound contract + adnanh/webhook reference impl + HMAC-SHA256 outbound emitter + Redis pub/sub opt-in backend."
+description: "tmux-based self-driving Datarim pipeline runner. Phase 3 adds actor/session-bound Save-as-rule confirmation, exact learned matches, 24-hour re-validation, and a seven-day TTL. Autonomy is resolved per space; the immutable hard-gated floor remains authoritative."
 categories:
   - scripts
   - rules

--- a/plugins/dr-orchestrate/rules/fb-rules.yaml
+++ b/plugins/dr-orchestrate/rules/fb-rules.yaml
@@ -135,6 +135,7 @@ always_gated_floor:
 
 # Runtime action kind → spaces/{name}/space.yml autonomy.policy key.
 action_autonomy_map:
+  framework_command: cross_project_write
   feature_branch_push: feature_branch_push
   merge_main: merge_main
   prod_deploy: prod_deploy

--- a/plugins/dr-orchestrate/scripts/audit_sink.sh
+++ b/plugins/dr-orchestrate/scripts/audit_sink.sh
@@ -15,6 +15,10 @@
 # remove an existing field's meaning/shape.
 set -euo pipefail
 
+AUDIT_SINK_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/lib" && pwd)"
+# shellcheck source=lib/portable-stat.sh
+source "$AUDIT_SINK_LIB_DIR/portable-stat.sh"
+
 now_iso() { date -u +%FT%TZ; }
 
 hash_sha256() { printf '%s' "${1:-}" | shasum -a 256 | awk '{print $1}'; }
@@ -35,10 +39,152 @@ redact_reason() {
 # emit <file> <json-payload> — append payload as one JSONL line. Creates parent
 # directory if needed. The day-rotated file path is the caller's responsibility;
 # emit only writes verbatim.
+_safe_append_open() {
+  local path="$1" migrate_legacy="${2:-0}" path_identity fd_identity mode parent parent_mode
+  parent="$(dirname -- "$path")"
+  [[ -d "$parent" && ! -L "$parent" && "$(portable_uid "$parent")" == "$(id -u)" ]] \
+    || { echo "ERR: unsafe append parent" >&2; return 1; }
+  parent_mode="$(portable_mode "$parent")" || return 1
+  (( (8#$parent_mode & 8#022) == 0 )) \
+    || { echo "ERR: writable append parent" >&2; return 1; }
+  [[ ! -L "$path" ]] || { echo "ERR: append path is a symlink" >&2; return 1; }
+  if [[ ! -e "$path" ]]; then
+    ( set -o noclobber; umask 077; : >"$path" ) 2>/dev/null || true
+  fi
+  [[ -f "$path" && ! -L "$path" && "$(portable_uid "$path")" == "$(id -u)" ]] \
+    || { echo "ERR: unsafe append path" >&2; return 1; }
+  mode="$(portable_mode "$path")" || return 1
+  if [[ "$migrate_legacy" == 1 && "$mode" == 644 ]]; then
+    chmod 0600 "$path" || return 1
+    mode="$(portable_mode "$path")" || return 1
+  fi
+  [[ "$mode" == 600 ]] || { echo "ERR: unsafe append mode" >&2; return 1; }
+  exec {SAFE_APPEND_FD}>>"$path" || return 1
+  path_identity="$(portable_identity "$path")" || { exec {SAFE_APPEND_FD}>&-; return 1; }
+  fd_identity="$(portable_identity "/dev/fd/$SAFE_APPEND_FD")" \
+    || { exec {SAFE_APPEND_FD}>&-; return 1; }
+  [[ ! -L "$path" && -f "/dev/fd/$SAFE_APPEND_FD" && "$path_identity" == "$fd_identity" ]] \
+    || { echo "ERR: append path changed during open" >&2; exec {SAFE_APPEND_FD}>&-; return 1; }
+}
+
+_safe_read_file() {
+  local path="$1" fd path_identity fd_identity mode parent parent_mode
+  parent="$(dirname -- "$path")"
+  [[ -d "$parent" && ! -L "$parent" && "$(portable_uid "$parent")" == "$(id -u)" ]] \
+    || { echo "ERR: unsafe read parent" >&2; return 1; }
+  parent_mode="$(portable_mode "$parent")" || return 1
+  (( (8#$parent_mode & 8#022) == 0 )) \
+    || { echo "ERR: writable read parent" >&2; return 1; }
+  [[ -f "$path" && ! -L "$path" && "$(portable_uid "$path")" == "$(id -u)" ]] \
+    || { echo "ERR: unsafe read path" >&2; return 1; }
+  mode="$(portable_mode "$path")" || return 1
+  if [[ "$mode" == 644 ]]; then
+    chmod 0600 "$path" || return 1
+    mode="$(portable_mode "$path")" || return 1
+  fi
+  [[ "$mode" == 600 ]] || { echo "ERR: unsafe read mode" >&2; return 1; }
+  exec {fd}<"$path" || return 1
+  path_identity="$(portable_identity "$path")" || { exec {fd}>&-; return 1; }
+  fd_identity="$(portable_identity "/dev/fd/$fd")" || { exec {fd}>&-; return 1; }
+  [[ ! -L "$path" && -f "/dev/fd/$fd" && "$path_identity" == "$fd_identity" ]] \
+    || { echo "ERR: read path changed during open" >&2; exec {fd}>&-; return 1; }
+  cat <&"$fd"
+  exec {fd}>&-
+}
+
 emit() {
   local file="$1"; local payload="$2"
+  umask 077
   mkdir -p "$(dirname "$file")"
-  printf '%s\n' "$payload" >> "$file"
+  [[ ! -L "$file" ]] || { echo "ERR: audit path is a symlink" >&2; return 1; }
+  local lock="${file}.lock"
+  _safe_append_open "$lock" || return 1
+  local audit_lock_fd="$SAFE_APPEND_FD"
+  flock -w 5 "$audit_lock_fd" || { exec {audit_lock_fd}>&-; return 1; }
+  _safe_append_open "$file" 1 || { flock -u "$audit_lock_fd"; exec {audit_lock_fd}>&-; return 1; }
+  local audit_data_fd="$SAFE_APPEND_FD"
+  printf '%s\n' "$payload" >&"$audit_data_fd"
+  exec {audit_data_fd}>&-
+  flock -u "$audit_lock_fd"
+  exec {audit_lock_fd}>&-
+}
+
+# make_cycle_checkpoint <phase> <cycle_id> <session> <pane> <action> <proposal_status> [outcome]
+# Raw pane text, callback capability and action payloads never enter this ledger.
+make_cycle_checkpoint() {
+  local phase="$1" cycle_id="$2" session="$3" pane="$4" action="$5"
+  local proposal_status="$6" outcome="${7:-}"
+  jq -n -c --arg ts "$(now_iso)" --arg phase "$phase" --arg cycle "$cycle_id" \
+    --arg session "$session" --arg pane "$pane" --arg action_hash "$(hash_sha256 "$action")" \
+    --arg proposal "$proposal_status" --arg outcome "$outcome" \
+    '{schema_version:3,event:"cycle_checkpoint",timestamp:$ts,phase:$phase,
+      cycle_id:$cycle,session:$session,pane_id:$pane,selected_action_hash:$action_hash,
+      proposal_status:$proposal,outcome:$outcome}'
+}
+
+# Mark only the latest trailing prepare for a session/pane as interrupted.
+# Recovery is ledger-only and deliberately has no executor hook.
+recover_cycle_checkpoint() {
+  local file="$1" session="$2" pane="$3"
+  [[ -s "$file" ]] || return 0
+  local cycle recovered content recovery_lock="${file}.recovery.lock"
+  _safe_append_open "$recovery_lock" || return 2
+  local recovery_fd="$SAFE_APPEND_FD"
+  flock -w 5 "$recovery_fd" || { exec {recovery_fd}>&-; return 2; }
+  content="$(_safe_read_file "$file")" \
+    || { flock -u "$recovery_fd"; exec {recovery_fd}>&-; return 2; }
+  cycle="$(jq -rs --arg session "$session" --arg pane "$pane" '
+    [ .[] | select(.event=="cycle_checkpoint" and .session==$session and .pane_id==$pane) ]
+    | if length==0 then "" else .[-1] as $last
+      | if $last.phase=="prepare" then $last.cycle_id else "" end end' <<<"$content" 2>/dev/null)" \
+    || { flock -u "$recovery_fd"; exec {recovery_fd}>&-; return 2; }
+  cycle="${cycle#\"}"; cycle="${cycle%\"}"
+  if [[ -z "$cycle" ]]; then flock -u "$recovery_fd"; exec {recovery_fd}>&-; return 0; fi
+  recovered="$(jq -rs --arg cycle "$cycle" \
+    '[.[] | select(.event=="cycle_checkpoint" and .cycle_id==$cycle and .phase=="recovery")] | length' \
+    <<<"$content")"
+  if [[ "$recovered" != "0" ]]; then flock -u "$recovery_fd"; exec {recovery_fd}>&-; return 0; fi
+  emit "$file" "$(make_cycle_checkpoint recovery "$cycle" "$session" "$pane" "" interrupted recovered_interrupted)"
+  flock -u "$recovery_fd"
+  exec {recovery_fd}>&-
+}
+
+# Recover across day-rotated ledgers so a UTC-midnight crash is not lost.
+recover_latest_cycle_checkpoint() {
+  local audit_dir="$1" output_file="$2" session="$3" pane="$4"
+  local combined file cycle recovered event recovery_lock="$audit_dir/.checkpoint-recovery.lock"
+  umask 077
+  mkdir -p "$audit_dir"
+  _safe_append_open "$recovery_lock" || return 2
+  local recovery_fd="$SAFE_APPEND_FD"
+  flock -w 5 "$recovery_fd" || { exec {recovery_fd}>&-; return 2; }
+  combined="$(mktemp "$audit_dir/.checkpoint-recovery.XXXXXX")" \
+    || { flock -u "$recovery_fd"; exec {recovery_fd}>&-; return 2; }
+  while IFS= read -r file; do _safe_read_file "$file" >>"$combined" || {
+      rm -f "$combined"
+      flock -u "$recovery_fd"
+      exec {recovery_fd}>&-
+      return 2
+    }; done \
+    < <(find "$audit_dir" -maxdepth 1 -type f -name 'audit-*.jsonl' -print | LC_ALL=C sort)
+  cycle="$(jq -rs --arg session "$session" --arg pane "$pane" '
+    [ .[] | select(.event=="cycle_checkpoint" and .session==$session and .pane_id==$pane) ]
+    | if length==0 then "" else .[-1] as $last
+      | if $last.phase=="prepare" then $last.cycle_id else "" end end' "$combined" 2>/dev/null)" \
+    || { rm -f "$combined"; flock -u "$recovery_fd"; exec {recovery_fd}>&-; return 2; }
+  cycle="${cycle#\"}"; cycle="${cycle%\"}"
+  if [[ -n "$cycle" ]]; then
+    recovered="$(jq -rs --arg cycle "$cycle" \
+      '[.[] | select(.event=="cycle_checkpoint" and .cycle_id==$cycle and .phase=="recovery")] | length' \
+      "$combined")"
+    if [[ "$recovered" == 0 ]]; then
+      event="$(make_cycle_checkpoint recovery "$cycle" "$session" "$pane" "" interrupted recovered_interrupted)"
+      emit "$output_file" "$event"
+    fi
+  fi
+  rm -f "$combined"
+  flock -u "$recovery_fd"
+  exec {recovery_fd}>&-
 }
 
 # make_event <matched_text> <command> <exit_code> <duration_ms> <pane_id>

--- a/plugins/dr-orchestrate/scripts/cmd_run.sh
+++ b/plugins/dr-orchestrate/scripts/cmd_run.sh
@@ -8,6 +8,15 @@ set -euo pipefail
 DR_ORCH_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 export DR_ORCH_DIR
 
+# Stateful modules must see one canonical root. Keep STATE_DIR as the legacy
+# compatibility alias, but never let source order select a different root.
+AUDIT_DIR="${AUDIT_DIR:-$HOME/.local/share/datarim-orchestrate}"
+DR_ORCH_STATE_DIR="${DR_ORCH_STATE_DIR:-${STATE_DIR:-$AUDIT_DIR/state}}"
+STATE_DIR="$DR_ORCH_STATE_DIR"
+export AUDIT_DIR DR_ORCH_STATE_DIR STATE_DIR
+umask 077
+mkdir -p "$AUDIT_DIR" "$DR_ORCH_STATE_DIR"
+
 DRY_RUN=0
 PANE_ID=""
 UNKNOWN_PROMPT=0
@@ -29,9 +38,8 @@ while (( $# > 0 )); do
 usage: dr-orchestrate run [--dry-run] [--pane <pane_id>]
        dr-orchestrate run --unknown-prompt [text]
 
-Phase 2 (TUNE-0165) adds subagent inference for parser misses: confidence-0
-parses fall through to subagent_resolver.sh → autonomous-or-escalate, with
-audit schema v2 emitted at each stage.
+Phase 3 (TUNE-0166) adds trusted action execution plus actor/session-bound
+Save-as-rule confirmation, 24-hour re-validation, and a seven-day rule TTL.
 USAGE
                exit 0 ;;
     *)         echo "ERR: unknown arg '$1'" >&2; exit 2 ;;
@@ -50,17 +58,52 @@ source "$DR_ORCH_DIR/scripts/audit_sink.sh"
 source "$DR_ORCH_DIR/scripts/semantic_parser.sh"
 # shellcheck source=bot_interaction_dispatcher.sh
 source "$DR_ORCH_DIR/scripts/bot_interaction_dispatcher.sh"
+# shellcheck source=learned_rules.sh
+source "$DR_ORCH_DIR/scripts/learned_rules.sh"
 USER_CONFIG_YAML="${DR_ORCH_USER_CONFIG:-$DR_ORCH_DIR/user-config.yaml}"
 [[ -f "$USER_CONFIG_YAML" ]] && bot_interaction_load "$USER_CONFIG_YAML" || true
 
 SESSION_NAME="${SESSION_NAME:-datarim}"
-AUDIT_DIR="${AUDIT_DIR:-$HOME/.local/share/datarim-orchestrate}"
-STATE_DIR="${STATE_DIR:-$AUDIT_DIR/state}"
 CONFIDENCE_THRESHOLD="${DR_ORCH_CONFIDENCE_THRESHOLD:-0.80}"
-export STATE_DIR
-mkdir -p "$AUDIT_DIR" "$STATE_DIR"
 
 AUDIT_FILE="$AUDIT_DIR/audit-$(date -u +%Y-%m-%d).jsonl"
+DR_ORCH_AUDIT_FILE="$AUDIT_FILE"
+export DR_ORCH_AUDIT_FILE
+
+trusted_action() {
+  local action="$1"
+  load_trusted_actions | jq -e --arg action "$action" 'index($action) != null' >/dev/null
+}
+
+# execute_selected_action <action> <pane> <cycle_id> <confidence> <intent> <propose>
+# The write-ahead checkpoint is mandatory. A test seam records the action
+# instead of touching tmux, while production uses the existing safe pane path.
+execute_selected_action() {
+  local action="$1" pane="$2" cycle_id="$3" confidence="$4" intent="$5"
+  local should_propose="${6:-0}"
+  trusted_action "$action" || return 3
+  local payload
+  payload="$(jq -n -c --arg command "$action" '{command:$command}')"
+  bash "$DR_ORCH_DIR/scripts/action_gate.sh" gate \
+    --action framework_command --payload "$payload" >/dev/null || return 10
+  check_cooldown "$pane" decision 2>/dev/null || return 11
+  emit "$AUDIT_FILE" "$(make_cycle_checkpoint prepare "$cycle_id" "$SESSION_NAME" "$pane" "$action" pending)" \
+    || return 12
+  local rc=0
+  if [[ -n "${DR_ORCH_ACTION_EXECUTOR_LOG:-}" ]]; then
+    printf '%s\n' "$action" >> "$DR_ORCH_ACTION_EXECUTOR_LOG" || rc=$?
+  else
+    pane_send "$pane" "$action" || rc=$?
+  fi
+  emit "$AUDIT_FILE" "$(make_cycle_checkpoint terminal "$cycle_id" "$SESSION_NAME" "$pane" "$action" pending "exit_$rc")" \
+    || return 12
+  if (( rc == 0 && should_propose == 1 )); then
+    learned_rules_propose "$intent" "$action" "$confidence" \
+      "${DR_ORCH_ACTOR:-${USER:-agent}}" "${DR_ORCH_SESSION_CONTEXT:-$SESSION_NAME}" \
+      >/dev/null 2>&1 || true
+  fi
+  return "$rc"
+}
 
 # resolve_and_route <pane_text> <pane_id> <start_ms> — Phase 2 unknown-prompt
 # handler. Calls subagent_resolver.sh, gates on confidence threshold, either
@@ -86,6 +129,7 @@ resolve_and_route() {
   awk -v c="$conf" -v t="$CONFIDENCE_THRESHOLD" 'BEGIN{ exit !(c+0 >= t+0) }' && pass=1
 
   if (( pass )); then
+    [[ -n "$action_kind" ]] || action_kind="framework_command"
     if [[ -n "$action_kind" ]]; then
       local gate_rc
       set +e
@@ -105,9 +149,10 @@ resolve_and_route() {
         return 0
       fi
     fi
-    local outcome="resolved"
-    if ! check_cooldown "$pane" decision 2>/dev/null; then
-      outcome="blocked_decision_cooldown"
+    local outcome="resolved" cycle_id
+    cycle_id="$(hash_sha256 "$start_ms:$pane:$text")"
+    if ! execute_selected_action "$action" "$pane" "$cycle_id" "$conf" "$text" 1; then
+      outcome="blocked_execution"
     fi
     local evt
     evt="$(make_event_v2 "$text" "$action" 0 "$dur" "$pane" \
@@ -164,9 +209,12 @@ if (( UNKNOWN_PROMPT )); then
 fi
 
 tmux_version_check
-session_init "$SESSION_NAME"
+session_recover "$SESSION_NAME"
 
 PANE_ID="${PANE_ID:-${SESSION_NAME}:0.0}"
+
+learned_rules_maintenance >/dev/null 2>&1 || true
+recover_latest_cycle_checkpoint "$AUDIT_DIR" "$AUDIT_FILE" "$SESSION_NAME" "$PANE_ID" || true
 
 start_ms=$(now_ms)
 text="$(pane_capture "$PANE_ID" 2>/dev/null || true)"
@@ -180,11 +228,13 @@ dur=$(( end_ms - start_ms ))
 # stage=parse, outcome=resolved. expected_outcome read from env (soak driver).
 # Routing unchanged — rule-hit still resolves locally without subagent call.
 if [[ "$confidence" != "0" ]]; then
+  selected_action="$(printf '%s' "$decision" | jq -r '.action // ""')"
   local_outcome="resolved"
-  if ! check_cooldown "$PANE_ID" decision 2>/dev/null; then
-    local_outcome="blocked_decision_cooldown"
+  cycle_id="$(hash_sha256 "$start_ms:$PANE_ID:$text")"
+  if ! execute_selected_action "$selected_action" "$PANE_ID" "$cycle_id" "$confidence" "$text" 0; then
+    local_outcome="blocked_execution"
   fi
-  evt="$(make_event_v2 "$text" "dr-orchestrate run" 0 "$dur" "$PANE_ID" \
+  evt="$(make_event_v2 "$text" "$selected_action" 0 "$dur" "$PANE_ID" \
           "$confidence" "" "" "" "parse" "$local_outcome" "rule_hit")"
   emit "$AUDIT_FILE" "$evt"
   echo "dr-orchestrate run | confidence=$confidence | pane=$PANE_ID | dur=${dur}ms | outcome=$local_outcome | $(date -u +%FT%TZ)"

--- a/plugins/dr-orchestrate/scripts/learned_rules.sh
+++ b/plugins/dr-orchestrate/scripts/learned_rules.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Public learned-rule lifecycle API and CLI.
+
+LEARNED_RULES_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${DR_ORCH_DIR:=$(cd "$LEARNED_RULES_SCRIPT_DIR/.." && pwd)}"
+export DR_ORCH_DIR
+# shellcheck source=/dev/null
+source "$LEARNED_RULES_SCRIPT_DIR/lib/learned-rules-store.sh"
+
+learned_rules_propose() {
+    local intent=${1-} action=${2-} confidence=${3-} actor=${4-} session=${5-}
+    local proposal_id rc
+    [[ $# -eq 5 ]] || {
+        learned_rules_error 'propose requires intent action confidence actor session'
+        return 2
+    }
+    if proposal_id=$(learned_rules_create_proposal "$intent" "$action" "$confidence" "$actor" "$session"); then
+        rc=0
+    else
+        rc=$?
+    fi
+    [[ -n "$proposal_id" ]] && printf '%s\n' "$proposal_id"
+    (( rc == 0 )) || return "$rc"
+    bash "$LEARNED_RULES_SCRIPT_DIR/proposal_backend.sh" emit "$proposal_id" || return
+    if [[ ${DR_ORCH_TEST_CRASH_POINT:-} = after_queue_enqueue ]]; then
+        return 75
+    fi
+    learned_rules_mark_delivered "$proposal_id"
+}
+
+learned_rules_consume_callback() {
+    [[ $# -eq 4 ]] || {
+        learned_rules_error 'consume_callback requires id Y|N actor session'
+        return 2
+    }
+    learned_rules_consume "$1" "$2" "$3" "$4"
+}
+
+learned_rules_maintenance() {
+    [[ $# -eq 0 ]] || return 2
+    learned_rules_store_maintenance
+}
+
+learned_rules_main() {
+    local command=${1-}
+    [[ $# -gt 0 ]] && shift
+    case "$command" in
+        propose)
+            learned_rules_propose "$@"
+            ;;
+        consume_callback)
+            learned_rules_consume_callback "$@"
+            ;;
+        maintenance)
+            learned_rules_maintenance "$@"
+            ;;
+        *)
+            learned_rules_error 'usage: learned_rules.sh propose <intent> <action> <confidence> <actor> <session> | consume_callback <id> <Y|N> <actor> <session> | maintenance'
+            return 2
+            ;;
+    esac
+}
+
+if [[ ${BASH_SOURCE[0]} == "$0" ]]; then
+    set -euo pipefail
+    learned_rules_main "$@"
+fi

--- a/plugins/dr-orchestrate/scripts/lib/learned-rules-common.sh
+++ b/plugins/dr-orchestrate/scripts/lib/learned-rules-common.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+# Shared validation and persistence primitives for learned-rule lifecycle state.
+
+readonly LEARNED_RULE_PROPOSAL_TTL=900
+readonly LEARNED_RULE_LIFETIME=604800
+readonly LEARNED_RULE_REVALIDATE_AFTER=86400
+readonly LEARNED_RULE_PROPOSAL_CAP=128
+readonly LEARNED_RULE_RULE_CAP=256
+readonly LEARNED_RULE_TOMBSTONE_CAP=512
+readonly LEARNED_RULE_TOMBSTONE_BYTES_CAP=1048576
+readonly LEARNED_RULE_QUEUE_CAP=128
+readonly LEARNED_RULE_QUEUE_BYTES_CAP=65536
+export LEARNED_RULE_PROPOSAL_TTL LEARNED_RULE_LIFETIME LEARNED_RULE_REVALIDATE_AFTER
+export LEARNED_RULE_PROPOSAL_CAP LEARNED_RULE_RULE_CAP LEARNED_RULE_TOMBSTONE_CAP
+export LEARNED_RULE_TOMBSTONE_BYTES_CAP LEARNED_RULE_QUEUE_CAP LEARNED_RULE_QUEUE_BYTES_CAP
+
+LEARNED_RULES_COMMON_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=portable-stat.sh
+source "$LEARNED_RULES_COMMON_LIB_DIR/portable-stat.sh"
+
+learned_rules_error() {
+    printf 'learned-rules: %s\n' "$*" >&2
+}
+
+learned_rules_now() {
+    local now=${DR_ORCH_NOW_EPOCH:-}
+    if [[ -z "$now" ]]; then
+        now=$(date +%s)
+    fi
+    [[ "$now" =~ ^[0-9]+$ ]] || {
+        learned_rules_error 'invalid current time'
+        return 2
+    }
+    printf '%s\n' "$now"
+}
+
+learned_rules_sha256() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 | awk '{print $1}'
+    else
+        learned_rules_error 'SHA-256 implementation unavailable'
+        return 2
+    fi
+}
+
+learned_rules_random_id() {
+    local value=''
+    if [[ "${DR_ORCH_TEST_ENTROPY_FAIL:-0}" == 1 ]]; then
+        learned_rules_error 'cryptographic entropy source unavailable'
+        return 2
+    elif [[ -n "${DR_ORCH_TEST_ENTROPY_HEX:-}" ]]; then
+        value="$DR_ORCH_TEST_ENTROPY_HEX"
+    elif command -v openssl >/dev/null 2>&1; then
+        value=$(openssl rand -hex 32) || value=''
+    elif [[ -r /dev/urandom ]] && command -v od >/dev/null 2>&1; then
+        value=$(od -An -N32 -tx1 /dev/urandom | tr -d ' \n') || value=''
+    fi
+    [[ "$value" =~ ^[0-9a-f]{64}$ ]] || {
+        learned_rules_error 'cryptographic entropy source unavailable'
+        return 2
+    }
+    printf '%s\n' "$value"
+}
+
+learned_rules_validate_utf8() {
+    local value=${1-}
+    printf '%s' "$value" | iconv -f UTF-8 -t UTF-8 >/dev/null 2>&1 || {
+        learned_rules_error 'invalid UTF-8'
+        return 2
+    }
+}
+
+learned_rules_has_forbidden_controls() {
+    local value=${1-} allow_tab=${2:-0}
+    printf '%s' "$value" | iconv -f UTF-8 -t UTF-32LE 2>/dev/null | od -An -tu4 | \
+        awk -v allow_tab="$allow_tab" '
+            { for (i = 1; i <= NF; i++) {
+                cp = $i
+                if ((cp <= 31 && !(allow_tab == 1 && cp == 9)) || (cp >= 127 && cp <= 159)) { bad = 1; exit }
+            }}
+            END { exit bad }
+        '
+}
+
+learned_rules_validate_context() {
+    local value=${1-} label=${2:-context}
+    learned_rules_validate_utf8 "$value" || return
+    [[ -n "$value" && ${#value} -le 256 ]] || {
+        learned_rules_error "invalid $label"
+        return 2
+    }
+    if ! learned_rules_has_forbidden_controls "$value" 0; then
+        learned_rules_error "invalid $label"
+        return 2
+    fi
+}
+
+learned_rules_normalize_match() {
+    local raw=${1-} normalized bytes
+    learned_rules_validate_utf8 "$raw" || return
+    if ! learned_rules_has_forbidden_controls "$raw" 1; then
+        learned_rules_error 'control character in match'
+        return 2
+    fi
+    normalized=$(printf '%s' "$raw" | sed $'s/^[ \t]*//; s/[ \t]*$//; s/[ \t][ \t]*/ /g')
+    bytes=$(LC_ALL=C printf '%s' "$normalized" | wc -c | tr -d ' ')
+    [[ "$bytes" -ge 1 && "$bytes" -le 256 ]] || {
+        learned_rules_error 'match must be 1..256 bytes'
+        return 2
+    }
+    [[ "$normalized" != -* ]] || {
+        learned_rules_error 'leading option form is forbidden'
+        return 2
+    }
+    case "$normalized" in
+        *'/'*|*\\*|*'..'*|*';'*|*'&'*|*'|'*|*'<'*|*'>'*|*'$'*|*'`'*|*'('*|*')'*|*'{'*|*'}'*|*'['*|*']'*|*'*'*|*'?'*|*'!'*)
+            learned_rules_error 'path or shell syntax is forbidden in match'
+            return 2
+            ;;
+    esac
+    printf '%s\n' "$normalized"
+}
+
+learned_rules_validate_confidence() {
+    local value=${1-}
+    jq -en --arg value "$value" '($value | tonumber?) as $n | $n != null and $n >= 0 and $n <= 1' >/dev/null || {
+        learned_rules_error 'confidence must be numeric in [0,1]'
+        return 2
+    }
+}
+
+learned_rules_init_paths() {
+    LEARNED_RULES_STATE_DIR=${DR_ORCH_STATE_DIR:-${STATE_DIR:-${HOME}/.local/share/dr-orchestrate/state}}
+    LEARNED_RULES_FILE=${DR_ORCH_RULES_LEARNED:-"$LEARNED_RULES_STATE_DIR/learned-rules.yaml"}
+    LEARNED_RULES_PROPOSALS_DIR=${DR_ORCH_PROPOSALS_DIR:-"$LEARNED_RULES_STATE_DIR/learned-rule-proposals"}
+    LEARNED_RULES_TOMBSTONES_DIR=${DR_ORCH_TOMBSTONES_DIR:-"$LEARNED_RULES_STATE_DIR/learned-rule-tombstones"}
+    LEARNED_RULES_DELIVERY_DIR=${DR_ORCH_DELIVERY_DIR:-"$LEARNED_RULES_STATE_DIR/learned-rule-delivery"}
+    LEARNED_RULES_AUDIT_DIR=${AUDIT_DIR:-${HOME}/.local/share/datarim-orchestrate}
+    LEARNED_RULES_AUDIT_FILE=${DR_ORCH_LEARNED_AUDIT:-${DR_ORCH_AUDIT_FILE:-"$LEARNED_RULES_AUDIT_DIR/audit-$(date -u +%Y-%m-%d).jsonl"}}
+    LEARNED_RULES_LOCK_FILE="$LEARNED_RULES_STATE_DIR/.learned-rules.lock"
+    LEARNED_RULES_KEY_FILE="$LEARNED_RULES_STATE_DIR/.learned-rules-capability-key"
+    export LEARNED_RULES_STATE_DIR LEARNED_RULES_FILE LEARNED_RULES_PROPOSALS_DIR
+    export LEARNED_RULES_TOMBSTONES_DIR LEARNED_RULES_DELIVERY_DIR
+    export LEARNED_RULES_AUDIT_DIR LEARNED_RULES_AUDIT_FILE
+    export LEARNED_RULES_LOCK_FILE LEARNED_RULES_KEY_FILE
+}
+
+learned_rules_assert_contained() {
+    local path=$1 root_abs path_abs
+    root_abs=$(realpath -m -- "$LEARNED_RULES_STATE_DIR") || return 2
+    path_abs=$(realpath -m -- "$path") || return 2
+    [[ "$path_abs" == "$root_abs" || "$path_abs" == "$root_abs/"* ]] || {
+        learned_rules_error "state path escapes configured root: $path"
+        return 2
+    }
+}
+
+learned_rules_assert_not_symlink() {
+    local path=$1 cursor
+    [[ "$path" == /* ]] || path="$PWD/$path"
+    cursor=$path
+    while :; do
+        [[ ! -L "$cursor" ]] || {
+            learned_rules_error "symlink state path rejected: $cursor"
+            return 2
+        }
+        [[ "$cursor" != / ]] || break
+        cursor=$(dirname -- "$cursor")
+    done
+}
+
+learned_rules_check_owner_mode() {
+    local path=$1 expected=$2 kind=${3:-file} legacy_mode=${4:-} mode owner
+    [[ -e "$path" ]] || return 0
+    [[ ! -L "$path" ]] || return 2
+    owner=$(portable_uid "$path") || return 2
+    mode=$(portable_mode "$path") || return 2
+    [[ "$owner" = "$(id -u)" ]] || {
+        learned_rules_error "unsafe owner or mode for $path"
+        return 2
+    }
+    if [[ "$kind" = dir ]]; then
+        [[ -d "$path" ]] || return 2
+    else
+        [[ -f "$path" ]] || return 2
+    fi
+    if [[ "$mode" = "$legacy_mode" ]]; then
+        chmod "0$expected" "$path" || return 2
+        mode=$(portable_mode "$path") || return 2
+    fi
+    [[ "$mode" = "$expected" ]] || {
+        learned_rules_error "unsafe owner or mode for $path"
+        return 2
+    }
+}
+
+learned_rules_read_secure() {
+    local path=$1 fd path_identity fd_identity
+    learned_rules_assert_not_symlink "$path" || return
+    learned_rules_check_owner_mode "$path" 600 file || return
+    exec {fd}<"$path" || return 2
+    path_identity=$(portable_identity "$path") || { exec {fd}>&-; return 2; }
+    fd_identity=$(portable_identity "/dev/fd/$fd") || { exec {fd}>&-; return 2; }
+    [[ ! -L "$path" && -f "/dev/fd/$fd" && "$path_identity" = "$fd_identity" ]] || {
+        exec {fd}>&-
+        learned_rules_error "state path changed during open: $path"
+        return 2
+    }
+    cat <&"$fd"
+    exec {fd}>&-
+}
+
+learned_rules_validate_state_directory() {
+    local dir=$1 entry
+    while IFS= read -r -d '' entry; do
+        [[ ! -L "$entry" && -f "$entry" && "$entry" == *.json ]] || {
+            learned_rules_error "invalid state directory entry: $entry"
+            return 2
+        }
+        learned_rules_check_owner_mode "$entry" 600 file || return
+    done < <(find "$dir" -mindepth 1 -maxdepth 1 -print0)
+}
+
+learned_rules_prepare_state() {
+    local path
+    learned_rules_init_paths
+    umask 077
+    for path in "$LEARNED_RULES_FILE" "$LEARNED_RULES_PROPOSALS_DIR" \
+        "$LEARNED_RULES_TOMBSTONES_DIR" "$LEARNED_RULES_DELIVERY_DIR" \
+        "$LEARNED_RULES_LOCK_FILE" "$LEARNED_RULES_KEY_FILE"; do
+        learned_rules_assert_contained "$path" || return
+    done
+    learned_rules_assert_not_symlink "$LEARNED_RULES_STATE_DIR" || return
+    if [[ ! -e "$LEARNED_RULES_STATE_DIR" ]]; then
+        mkdir -p -- "$LEARNED_RULES_STATE_DIR" || return 2
+        chmod 0700 "$LEARNED_RULES_STATE_DIR" || return 2
+    fi
+    learned_rules_check_owner_mode "$LEARNED_RULES_STATE_DIR" 700 dir || return
+    for path in "$LEARNED_RULES_PROPOSALS_DIR" "$LEARNED_RULES_TOMBSTONES_DIR" "$LEARNED_RULES_DELIVERY_DIR"; do
+        learned_rules_assert_not_symlink "$path" || return
+        if [[ ! -e "$path" ]]; then
+            mkdir -m 0700 -- "$path" || return 2
+        fi
+        learned_rules_check_owner_mode "$path" 700 dir || return
+        learned_rules_validate_state_directory "$path" || return
+    done
+    for path in "$LEARNED_RULES_FILE" "$LEARNED_RULES_LOCK_FILE" "$LEARNED_RULES_KEY_FILE"; do
+        learned_rules_assert_not_symlink "$path" || return
+        learned_rules_check_owner_mode "$path" 600 file || return
+    done
+    learned_rules_assert_not_symlink "$LEARNED_RULES_AUDIT_FILE" || return
+    learned_rules_check_owner_mode "$LEARNED_RULES_AUDIT_FILE" 600 file 644 || return
+}
+
+learned_rules_atomic_write() {
+    local path=$1 payload=$2 tmp
+    learned_rules_assert_contained "$path" || return
+    if [[ -n "${DR_ORCH_TEST_ATOMIC_FAIL_BASENAME:-}" \
+      && "$(basename -- "$path")" == "$DR_ORCH_TEST_ATOMIC_FAIL_BASENAME" ]]; then
+        return 2
+    fi
+    learned_rules_assert_not_symlink "$path" || return
+    if [[ -e "$path" ]]; then
+        learned_rules_check_owner_mode "$path" 600 file || return
+    fi
+    tmp=$(mktemp "$(dirname -- "$path")/.learned-rules.tmp.XXXXXX") || return 2
+    chmod 0600 "$tmp" || { rm -f -- "$tmp"; return 2; }
+    if ! printf '%s\n' "$payload" > "$tmp"; then
+        rm -f -- "$tmp"
+        return 2
+    fi
+    mv -f -- "$tmp" "$path" || { rm -f -- "$tmp"; return 2; }
+    chmod 0600 "$path"
+}
+
+learned_rules_sync_file() {
+    local path=$1
+    if sync -f "$path" >/dev/null 2>&1; then
+        return 0
+    fi
+    sync >/dev/null 2>&1 || true
+}

--- a/plugins/dr-orchestrate/scripts/lib/learned-rules-store.sh
+++ b/plugins/dr-orchestrate/scripts/lib/learned-rules-store.sh
@@ -1,0 +1,531 @@
+#!/usr/bin/env bash
+# Locked, bounded persistence for learned-rule proposals and rule records.
+
+LEARNED_RULES_STORE_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "$LEARNED_RULES_STORE_LIB_DIR/learned-rules-common.sh"
+
+learned_rules_lock() {
+    local path_identity fd_identity timeout="${DR_ORCH_LOCK_TIMEOUT_S:-5}"
+    [[ "$timeout" =~ ^[1-9][0-9]*$ && "$timeout" -le 30 ]] || return 2
+    learned_rules_prepare_state || return
+    if [[ ! -e "$LEARNED_RULES_LOCK_FILE" ]]; then
+        ( set -o noclobber; umask 077; : >"$LEARNED_RULES_LOCK_FILE" ) 2>/dev/null || true
+    fi
+    learned_rules_assert_not_symlink "$LEARNED_RULES_LOCK_FILE" || return
+    learned_rules_check_owner_mode "$LEARNED_RULES_LOCK_FILE" 600 file || return
+    exec 9>>"$LEARNED_RULES_LOCK_FILE" || return 2
+    path_identity=$(portable_identity "$LEARNED_RULES_LOCK_FILE") || { exec 9>&-; return 2; }
+    fd_identity=$(portable_identity /dev/fd/9) || { exec 9>&-; return 2; }
+    [[ ! -L "$LEARNED_RULES_LOCK_FILE" && -f /dev/fd/9 \
+       && "$path_identity" = "$fd_identity" ]] || { exec 9>&-; return 2; }
+    flock -w "$timeout" -x 9 || { exec 9>&-; return 2; }
+}
+
+learned_rules_unlock() {
+    flock -u 9 2>/dev/null || true
+    exec 9>&-
+}
+
+learned_rules_ensure_key_locked() {
+    local key
+    if [[ ! -e "$LEARNED_RULES_KEY_FILE" ]]; then
+        key=$(learned_rules_random_id) || return
+        learned_rules_atomic_write "$LEARNED_RULES_KEY_FILE" "$key" || return
+    fi
+    learned_rules_check_owner_mode "$LEARNED_RULES_KEY_FILE" 600 file || return
+    key=$(learned_rules_read_secure "$LEARNED_RULES_KEY_FILE") || return
+    [[ "$key" =~ ^[0-9a-f]{64}$ ]] || {
+        learned_rules_error 'invalid capability key'
+        return 2
+    }
+}
+
+learned_rules_capability_for_record_locked() {
+    local record=$1 key payload output
+    learned_rules_ensure_key_locked || return
+    key=$(learned_rules_read_secure "$LEARNED_RULES_KEY_FILE") || return
+    payload=$(jq -cS '{nonce,actor,session,space,match,action,action_kind,confidence,
+        created_at,expires_at,generation}' <<<"$record") || return 2
+    output=$(printf '%s' "$payload" | openssl dgst -sha256 -mac HMAC \
+        -macopt "hexkey:$key" 2>/dev/null | awk '{print $NF}') || return 2
+    [[ "$output" =~ ^[0-9a-f]{64}$ ]] || return 2
+    printf '%s\n' "$output"
+}
+
+learned_rules_validate_proposal_record_locked() {
+    local record=$1 expected_id=${2:-} expected_hash=${3:-}
+    local match action derived derived_hash
+    jq -e --argjson ttl "$LEARNED_RULE_PROPOSAL_TTL" '
+        def epoch: type=="number" and floor==. and .>=0 and .<=253402300799;
+        type=="object" and
+        (.proposal_hash|type=="string" and test("^[0-9a-f]{64}$")) and
+        (.nonce|type=="string" and test("^[0-9a-f]{64}$")) and
+        (.actor|type=="string") and (.session|type=="string") and (.space|type=="string") and
+        (.match|type=="string") and (.action|type=="string") and
+        .action_kind=="framework_command" and
+        (.confidence|type=="number" and .>=0 and .<=1) and
+        (.created_at|epoch) and (.expires_at|epoch) and .expires_at==(.created_at+$ttl) and
+        (.generation|type=="string" and test("^[0-9a-f]{64}$")) and
+        (.status=="pending" or .status=="delivered")' >/dev/null <<<"$record" || return 2
+    learned_rules_validate_context "$(jq -r '.actor' <<<"$record")" actor || return
+    learned_rules_validate_context "$(jq -r '.session' <<<"$record")" session || return
+    learned_rules_validate_context "$(jq -r '.space' <<<"$record")" space || return
+    match=$(learned_rules_normalize_match "$(jq -r '.match' <<<"$record")") || return
+    [[ "$match" = "$(jq -r '.match' <<<"$record")" ]] || return 2
+    action=$(learned_rules_canonical_action "$(jq -r '.action' <<<"$record")") || return
+    [[ "$action" = "$(jq -r '.action' <<<"$record")" ]] || return 2
+    derived=$(learned_rules_capability_for_record_locked "$record") || return
+    derived_hash=$(printf '%s' "$derived" | learned_rules_sha256) || return
+    [[ "$derived_hash" = "$(jq -r '.proposal_hash' <<<"$record")" ]] || return 2
+    [[ -z "$expected_id" || "$derived" = "$expected_id" ]] || return 2
+    [[ -z "$expected_hash" || "$derived_hash" = "$expected_hash" ]] || return 2
+}
+
+learned_rules_load_rules_locked() {
+    local yaml json
+    if [[ ! -e "$LEARNED_RULES_FILE" ]]; then
+        printf '{"patterns":[]}\n'
+        return 0
+    fi
+    yaml=$(learned_rules_read_secure "$LEARNED_RULES_FILE") || return
+    json=$(printf '%s\n' "$yaml" | yq -o=json '.' 2>/dev/null) || {
+        learned_rules_error 'corrupt learned rules state'
+        return 2
+    }
+    jq -e --argjson rule_cap "$LEARNED_RULE_RULE_CAP" '
+        def epoch: type=="number" and floor==. and .>=0 and .<=253402300799;
+        type == "object" and (.patterns | type == "array") and
+        (.patterns | length <= $rule_cap) and
+        all(.patterns[];
+            (.match | type == "string" and utf8bytelength>=1 and utf8bytelength<=256 and
+              (startswith("-")|not) and (test("[[:cntrl:]]")|not) and
+              (contains("\t")|not) and (startswith(" ")|not) and (endswith(" ")|not) and
+              (contains("  ")|not) and (contains("..")|not) and
+              (test("[/\\\\;&|<>$`(){}*?!]|\\[|\\]")|not)) and
+            (.action | type == "string" and length>=1 and length<=256 and (test("[[:cntrl:]]")|not)) and
+            (.confidence | type == "number" and . >= 0 and . <= 1) and
+            (.created_at | epoch) and (.last_validated_at | epoch) and (.expires_at | epoch) and
+            .last_validated_at>=.created_at and .last_validated_at<=.expires_at and
+            .expires_at==(.created_at + 604800) and
+            (.proposal_hash | type == "string" and test("^[0-9a-f]{64}$")) and
+            (.generation | type == "string" and test("^[0-9a-f]{64}$"))
+        )' >/dev/null <<<"$json" || {
+        learned_rules_error 'invalid learned rules schema'
+        return 2
+    }
+    jq -c '.' <<<"$json"
+}
+
+learned_rules_current_generation_locked() {
+    local rules=$1 match=$2 record
+    record=$(jq -cS --arg match "$match" '[.patterns[] | select(.match == $match)][0] // null | if . == null then "absent" else del(.generation) end' <<<"$rules") || return 2
+    printf '%s' "$record" | learned_rules_sha256
+}
+
+learned_rules_trusted_actions() {
+    local file json
+    for file in "${DR_ORCH_RULES_DEFAULT:-}" "${DR_ORCH_RULES_USER:-}"; do
+        [[ -n "$file" && -f "$file" && ! -L "$file" ]] || continue
+        json=$(yq -o=json '.' "$file" 2>/dev/null) || return 2
+        jq -r '.patterns // [] | .[] | .action | select(type == "string")' <<<"$json"
+    done | LC_ALL=C sort -u
+}
+
+learned_rules_canonical_action() {
+    local requested=$1 candidate trusted
+    learned_rules_validate_context "$requested" action || return
+    trusted=$(learned_rules_trusted_actions) || {
+        learned_rules_error 'trusted action registry is invalid'
+        return 2
+    }
+    candidate=$requested
+    if [[ "$requested" != /* && "$requested" == dr-* ]]; then
+        candidate="/$requested"
+    fi
+    if grep -Fqx -- "$candidate" <<<"$trusted"; then
+        printf '%s\n' "$candidate"
+        return 0
+    fi
+    learned_rules_error 'action is not in the bundled/user trusted registry'
+    return 2
+}
+
+learned_rules_audit_has_locked() {
+    local event=$1 proposal_hash=$2 file found=0 audit_base content
+    while IFS= read -r -d '' file; do
+        found=1
+        learned_rules_assert_not_symlink "$file" || return
+        learned_rules_check_owner_mode "$file" 600 file 644 || return
+        content=$(learned_rules_read_secure "$file") || return
+        [[ -z "$content" ]] || jq -e '.' <<<"$content" >/dev/null 2>&1 || {
+            learned_rules_error 'corrupt audit state'
+            return 2
+        }
+        if [[ -n "$content" ]] && jq -e --arg event "$event" --arg hash "$proposal_hash" \
+            'select(.event == $event and .proposal_hash == $hash)' <<<"$content" >/dev/null 2>&1; then
+            return 0
+        fi
+    done < <(find "$(dirname -- "$LEARNED_RULES_AUDIT_FILE")" -maxdepth 1 -type f \
+        -name 'audit-*.jsonl' -print0 2>/dev/null)
+    audit_base=$(basename -- "$LEARNED_RULES_AUDIT_FILE")
+    if [[ -e "$LEARNED_RULES_AUDIT_FILE" \
+      && ( $found -eq 0 || "$audit_base" != audit-*.jsonl ) ]]; then
+        learned_rules_check_owner_mode "$LEARNED_RULES_AUDIT_FILE" 600 file 644 || return
+        content=$(learned_rules_read_secure "$LEARNED_RULES_AUDIT_FILE") || return
+        [[ -z "$content" ]] \
+          || jq -e '.' <<<"$content" >/dev/null 2>&1 \
+          || { learned_rules_error 'corrupt audit state'; return 2; }
+        [[ -n "$content" ]] && jq -e --arg event "$event" --arg hash "$proposal_hash" \
+          'select(.event == $event and .proposal_hash == $hash)' \
+          <<<"$content" >/dev/null 2>&1 && return 0
+    fi
+    return 1
+}
+
+learned_rules_audit_once_locked() {
+    local event=$1 proposal_hash=$2 now line audit_rc
+    if [[ "${DR_ORCH_TEST_AUDIT_FAIL_EVENT:-}" == "$event" ]]; then
+        return 2
+    fi
+    if learned_rules_audit_has_locked "$event" "$proposal_hash"; then
+        return 0
+    else
+        audit_rc=$?
+        (( audit_rc == 1 )) || return "$audit_rc"
+    fi
+    now=$(learned_rules_now) || return
+    line=$(jq -cn --arg event "$event" --arg hash "$proposal_hash" --argjson at "$now" \
+        '{schema_version:3,event:$event,proposal_hash:$hash,at:$at}') || return 2
+    bash "${DR_ORCH_DIR:?}/scripts/audit_sink.sh" emit "$LEARNED_RULES_AUDIT_FILE" "$line" || return 2
+    learned_rules_sync_file "$LEARNED_RULES_AUDIT_FILE"
+}
+
+learned_rules_dir_stats() {
+    local dir=$1 count=0 bytes=0 file size fd path_identity fd_identity
+    while IFS= read -r -d '' file; do
+        learned_rules_check_owner_mode "$file" 600 file || return
+        exec {fd}<"$file" || return 2
+        path_identity=$(portable_identity "$file") || { exec {fd}>&-; return 2; }
+        fd_identity=$(portable_identity "/dev/fd/$fd") || { exec {fd}>&-; return 2; }
+        [[ ! -L "$file" && "$path_identity" = "$fd_identity" ]] \
+          || { exec {fd}>&-; return 2; }
+        size=$(portable_size "/dev/fd/$fd") || { exec {fd}>&-; return 2; }
+        exec {fd}>&-
+        count=$((count + 1))
+        bytes=$((bytes + size))
+    done < <(find "$dir" -maxdepth 1 -type f -name '*.json' -print0)
+    printf '%s %s\n' "$count" "$bytes"
+}
+
+learned_rules_write_tombstone_locked() {
+    local proposal_hash=$1 reason=$2 now=$3 path record count bytes
+    path="$LEARNED_RULES_TOMBSTONES_DIR/$proposal_hash.json"
+    [[ ! -e "$path" ]] || return 0
+    read -r count bytes < <(learned_rules_dir_stats "$LEARNED_RULES_TOMBSTONES_DIR") || return
+    (( count < LEARNED_RULE_TOMBSTONE_CAP )) || {
+        learned_rules_error 'tombstone record cap reached'
+        return 2
+    }
+    record=$(jq -cn --arg hash "$proposal_hash" --arg reason "$reason" --argjson consumed "$now" '{proposal_hash:$hash,reason:$reason,consumed_at:$consumed}') || return 2
+    (( bytes + ${#record} + 1 <= LEARNED_RULE_TOMBSTONE_BYTES_CAP )) || {
+        learned_rules_error 'tombstone byte cap reached'
+        return 2
+    }
+    learned_rules_atomic_write "$path" "$record"
+}
+
+learned_rules_remove_proposal_locked() {
+    local proposal_hash=$1 reason=$2 now=$3
+    learned_rules_write_tombstone_locked "$proposal_hash" "$reason" "$now" || return
+    rm -f -- "$LEARNED_RULES_PROPOSALS_DIR/$proposal_hash.json" "$LEARNED_RULES_DELIVERY_DIR/$proposal_hash.json"
+}
+
+learned_rules_purge_locked() {
+    local now=$1 file expires consumed hash rules active record
+    while IFS= read -r -d '' file; do
+        record=$(learned_rules_read_secure "$file") || return
+        expires=$(jq -er '.expires_at | select(type == "number")' <<<"$record") || return 2
+        if (( now >= expires )); then
+            hash=$(basename "$file" .json)
+            learned_rules_remove_proposal_locked "$hash" expired "$now" || return
+        fi
+    done < <(find "$LEARNED_RULES_PROPOSALS_DIR" -maxdepth 1 -type f -name '*.json' -print0)
+    while IFS= read -r -d '' file; do
+        record=$(learned_rules_read_secure "$file") || return
+        consumed=$(jq -er '.consumed_at | select(type == "number")' <<<"$record") || return 2
+        if (( now >= consumed + LEARNED_RULE_LIFETIME )); then
+            rm -f -- "$file"
+        fi
+    done < <(find "$LEARNED_RULES_TOMBSTONES_DIR" -maxdepth 1 -type f -name '*.json' -print0)
+    if [[ -e "$LEARNED_RULES_FILE" ]]; then
+        rules=$(learned_rules_load_rules_locked) || return
+        active=$(jq -c --argjson now "$now" '.patterns = [.patterns[] | select(.expires_at > $now)]' <<<"$rules") || return 2
+        if [[ "$active" != "$rules" ]]; then
+            learned_rules_atomic_write "$LEARNED_RULES_FILE" "$active" || return
+            learned_rules_sync_file "$LEARNED_RULES_FILE"
+        fi
+    fi
+}
+
+learned_rules_create_proposal() {
+    local raw_match=$1 requested_action=$2 confidence=$3 actor=$4 session=$5
+    local match action now rules generation nonce proposal_id proposal_hash path record space action_kind
+    local file old_hash count
+    match=$(learned_rules_normalize_match "$raw_match") || return
+    action=$(learned_rules_canonical_action "$requested_action") || return
+    learned_rules_validate_confidence "$confidence" || return
+    learned_rules_validate_context "$actor" actor || return
+    learned_rules_validate_context "$session" session || return
+    space="${DR_ORCH_SPACE_CONTEXT:-${DATARIM_ACTIVE_SPACE:-$session}}"
+    learned_rules_validate_context "$space" space || return
+    action_kind=framework_command
+    now=$(learned_rules_now) || return
+    learned_rules_lock || return
+    learned_rules_purge_locked "$now" || { learned_rules_unlock; return 2; }
+    rules=$(learned_rules_load_rules_locked) || { learned_rules_unlock; return 2; }
+    generation=$(learned_rules_current_generation_locked "$rules" "$match") || { learned_rules_unlock; return 2; }
+
+    while IFS= read -r -d '' file; do
+        record=$(learned_rules_read_secure "$file") || { learned_rules_unlock; return 2; }
+        if jq -e --arg actor "$actor" --arg session "$session" --arg match "$match" \
+            '.actor == $actor and .session == $session and .match == $match' <<<"$record" >/dev/null; then
+            old_hash=$(basename "$file" .json)
+            learned_rules_remove_proposal_locked "$old_hash" replaced "$now" || { learned_rules_unlock; return 2; }
+        fi
+    done < <(find "$LEARNED_RULES_PROPOSALS_DIR" -maxdepth 1 -type f -name '*.json' -print0)
+    count=$(find "$LEARNED_RULES_PROPOSALS_DIR" -maxdepth 1 -type f -name '*.json' | wc -l)
+    (( count < LEARNED_RULE_PROPOSAL_CAP )) || {
+        learned_rules_error 'proposal cap reached'
+        learned_rules_unlock
+        return 2
+    }
+    nonce=$(learned_rules_random_id) || { learned_rules_unlock; return 2; }
+    while IFS= read -r -d '' file; do
+        record=$(learned_rules_read_secure "$file") || { learned_rules_unlock; return 2; }
+        if jq -e --arg nonce "$nonce" '.nonce == $nonce' <<<"$record" >/dev/null 2>&1; then
+            learned_rules_error 'capability entropy reuse detected'
+            learned_rules_unlock
+            return 2
+        fi
+    done < <(find "$LEARNED_RULES_PROPOSALS_DIR" -maxdepth 1 -type f -name '*.json' -print0)
+    record=$(jq -cn \
+        --arg nonce "$nonce" --arg actor "$actor" --arg session "$session" \
+        --arg match "$match" --arg action "$action" --arg confidence "$confidence" \
+        --arg space "$space" --arg action_kind "$action_kind" \
+        --arg generation "$generation" --argjson created "$now" \
+        --argjson expires "$((now + LEARNED_RULE_PROPOSAL_TTL))" \
+        '{nonce:$nonce,actor:$actor,session:$session,space:$space,
+          match:$match,action:$action,action_kind:$action_kind,confidence:($confidence|tonumber),
+          created_at:$created,expires_at:$expires,generation:$generation,status:"pending"}') || {
+        learned_rules_unlock
+        return 2
+    }
+    proposal_id=$(learned_rules_capability_for_record_locked "$record") || { learned_rules_unlock; return 2; }
+    proposal_hash=$(printf '%s' "$proposal_id" | learned_rules_sha256) || { learned_rules_unlock; return 2; }
+    record=$(jq -c --arg hash "$proposal_hash" '.proposal_hash=$hash' <<<"$record") \
+      || { learned_rules_unlock; return 2; }
+    learned_rules_validate_proposal_record_locked "$record" "$proposal_id" "$proposal_hash" \
+      || { learned_rules_unlock; return 2; }
+    path="$LEARNED_RULES_PROPOSALS_DIR/$proposal_hash.json"
+    [[ ! -e "$path" ]] || { learned_rules_unlock; return 2; }
+    learned_rules_atomic_write "$path" "$record" || { learned_rules_unlock; return 2; }
+    learned_rules_unlock
+    printf '%s\n' "$proposal_id"
+    if [[ ${DR_ORCH_TEST_CRASH_POINT:-} = after_proposal_persist ]]; then
+        return 75
+    fi
+}
+
+learned_rules_enqueue_locked() {
+    local proposal_id=$1 proposal_hash path record event event_path event_record count bytes
+    [[ "$proposal_id" =~ ^[0-9a-f]{64}$ ]] || return 2
+    proposal_hash=$(printf '%s' "$proposal_id" | learned_rules_sha256) || return
+    path="$LEARNED_RULES_PROPOSALS_DIR/$proposal_hash.json"
+    [[ -f "$path" && ! -L "$path" ]] || return 2
+    learned_rules_check_owner_mode "$path" 600 file || return
+    record=$(learned_rules_read_secure "$path") || return
+    learned_rules_validate_proposal_record_locked "$record" "$proposal_id" "$proposal_hash" || return
+    event_path="$LEARNED_RULES_DELIVERY_DIR/$proposal_hash.json"
+    [[ ! -L "$event_path" ]] || return 2
+    if [[ -e "$event_path" ]]; then
+        learned_rules_check_owner_mode "$event_path" 600 file || return
+        event_record=$(learned_rules_read_secure "$event_path") || return
+        jq -e --arg id "$proposal_id" '.proposal_id == $id' <<<"$event_record" >/dev/null || return 2
+        return 0
+    fi
+    read -r count bytes < <(learned_rules_dir_stats "$LEARNED_RULES_DELIVERY_DIR") || return
+    (( count < LEARNED_RULE_QUEUE_CAP )) || return 2
+    event=$(jq -cn --arg id "$proposal_id" --argjson expires "$(jq -r '.expires_at' <<<"$record")" \
+        --arg prompt 'Save as rule? [Y/N]' \
+        '{proposal_id:$id,expires_at:$expires,prompt:$prompt}') || return 2
+    (( bytes + ${#event} + 1 <= LEARNED_RULE_QUEUE_BYTES_CAP )) || return 2
+    learned_rules_atomic_write "$event_path" "$event"
+}
+
+learned_rules_enqueue() {
+    local proposal_id=$1 rc
+    learned_rules_lock || return
+    learned_rules_enqueue_locked "$proposal_id"
+    rc=$?
+    learned_rules_unlock
+    return "$rc"
+}
+
+learned_rules_mark_delivered() {
+    local proposal_id=$1 proposal_hash path record updated rc=0
+    [[ "$proposal_id" =~ ^[0-9a-f]{64}$ ]] || return 2
+    proposal_hash=$(printf '%s' "$proposal_id" | learned_rules_sha256) || return
+    learned_rules_lock || return
+    path="$LEARNED_RULES_PROPOSALS_DIR/$proposal_hash.json"
+    if [[ ! -f "$path" || -L "$path" || ! -f "$LEARNED_RULES_DELIVERY_DIR/$proposal_hash.json" ]]; then
+        rc=2
+    else
+        record=$(learned_rules_read_secure "$path") || rc=2
+        if (( rc == 0 )); then
+            learned_rules_validate_proposal_record_locked "$record" "$proposal_id" "$proposal_hash" || rc=2
+        fi
+        if (( rc == 0 )); then
+            updated=$(jq -c '.status = "delivered"' <<<"$record") || rc=2
+        fi
+        if (( rc == 0 )); then
+            learned_rules_atomic_write "$path" "$updated" || rc=2
+        fi
+    fi
+    learned_rules_unlock
+    return "$rc"
+}
+
+learned_rules_finalize_locked() {
+    local proposal_hash=$1 reason=$2 now=$3
+    learned_rules_remove_proposal_locked "$proposal_hash" "$reason" "$now"
+}
+
+learned_rules_consume() {
+    local proposal_id=$1 answer=$2 actor=$3 session=$4
+    local proposal_hash path record now expires status match action expected rules actual existing
+    local new_rules base generation rc=0 current_space
+    [[ "$proposal_id" =~ ^[0-9a-f]{64}$ ]] || return 2
+    [[ "$answer" = Y || "$answer" = N ]] || return 2
+    learned_rules_validate_context "$actor" actor || return
+    learned_rules_validate_context "$session" session || return
+    proposal_hash=$(printf '%s' "$proposal_id" | learned_rules_sha256) || return
+    now=$(learned_rules_now) || return
+    learned_rules_lock || return
+    path="$LEARNED_RULES_PROPOSALS_DIR/$proposal_hash.json"
+    if [[ ! -f "$path" || -L "$path" ]]; then
+        learned_rules_unlock
+        return 3
+    fi
+    learned_rules_check_owner_mode "$path" 600 file || { learned_rules_unlock; return 2; }
+    record=$(learned_rules_read_secure "$path") || {
+        learned_rules_unlock
+        return 2
+    }
+    learned_rules_validate_proposal_record_locked "$record" "$proposal_id" "$proposal_hash" || {
+        learned_rules_unlock
+        return 2
+    }
+    current_space="${DR_ORCH_SPACE_CONTEXT:-${DATARIM_ACTIVE_SPACE:-$session}}"
+    [[ $(jq -r '.actor' <<<"$record") = "$actor" && $(jq -r '.session' <<<"$record") = "$session" \
+       && $(jq -r '.space' <<<"$record") = "$current_space" ]] || {
+        learned_rules_unlock
+        return 3
+    }
+    expires=$(jq -r '.expires_at' <<<"$record")
+    (( now < expires )) || { learned_rules_unlock; return 3; }
+    status=$(jq -r '.status' <<<"$record")
+    [[ "$status" = delivered ]] || { learned_rules_unlock; return 3; }
+    if [[ "$answer" = N ]]; then
+        learned_rules_finalize_locked "$proposal_hash" declined "$now" || rc=2
+        learned_rules_unlock
+        return "$rc"
+    fi
+    match=$(jq -r '.match' <<<"$record")
+    action=$(learned_rules_canonical_action "$(jq -r '.action' <<<"$record")") || {
+        learned_rules_unlock
+        return 2
+    }
+    [[ "$action" = "$(jq -r '.action' <<<"$record")" ]] || { learned_rules_unlock; return 2; }
+    rules=$(learned_rules_load_rules_locked) || { learned_rules_unlock; return 2; }
+    if jq -e --arg hash "$proposal_hash" '.patterns[]? | select(.proposal_hash == $hash)' >/dev/null <<<"$rules"; then
+        learned_rules_audit_once_locked learned_rule_commit "$proposal_hash" || { learned_rules_unlock; return 2; }
+        learned_rules_finalize_locked "$proposal_hash" accepted "$now" || rc=2
+        learned_rules_unlock
+        return "$rc"
+    fi
+    expected=$(jq -r '.generation' <<<"$record")
+    actual=$(learned_rules_current_generation_locked "$rules" "$match") || { learned_rules_unlock; return 2; }
+    [[ "$expected" = "$actual" ]] || { learned_rules_unlock; return 3; }
+    existing=$(jq -c --arg match "$match" '[.patterns[] | select(.match == $match)][0] // null' <<<"$rules") || {
+        learned_rules_unlock
+        return 2
+    }
+    if [[ "$existing" != null ]] && (( now < $(jq -r '.expires_at' <<<"$existing") )); then
+        base=$(jq -c --argjson now "$now" --arg hash "$proposal_hash" \
+            '.last_validated_at=$now | .proposal_hash=$hash | del(.generation)' <<<"$existing") || {
+            learned_rules_unlock
+            return 2
+        }
+    else
+        base=$(jq -cn --arg match "$match" --arg action "$action" \
+            --argjson confidence "$(jq -r '.confidence' <<<"$record")" --argjson now "$now" \
+            --argjson expiry "$((now + LEARNED_RULE_LIFETIME))" --arg hash "$proposal_hash" \
+            '{match:$match,action:$action,confidence:$confidence,created_at:$now,last_validated_at:$now,expires_at:$expiry,proposal_hash:$hash}') || {
+            learned_rules_unlock
+            return 2
+        }
+    fi
+    generation=$(printf '%s' "$(jq -cS '.' <<<"$base")" | learned_rules_sha256) || { learned_rules_unlock; return 2; }
+    base=$(jq -c --arg generation "$generation" '.generation=$generation' <<<"$base") || { learned_rules_unlock; return 2; }
+    new_rules=$(jq -c --arg match "$match" --argjson rule "$base" \
+        '.patterns = ([.patterns[] | select(.match != $match)] + [$rule])' <<<"$rules") || {
+        learned_rules_unlock
+        return 2
+    }
+    jq -e --argjson rule_cap "$LEARNED_RULE_RULE_CAP" '.patterns | length <= $rule_cap' >/dev/null <<<"$new_rules" || { learned_rules_unlock; return 2; }
+    learned_rules_audit_once_locked learned_rule_prepare "$proposal_hash" || { learned_rules_unlock; return 2; }
+    if [[ ${DR_ORCH_TEST_CRASH_POINT:-} = before_rules_rename ]]; then
+        learned_rules_unlock
+        return 75
+    fi
+    learned_rules_atomic_write "$LEARNED_RULES_FILE" "$new_rules" || { learned_rules_unlock; return 2; }
+    learned_rules_sync_file "$LEARNED_RULES_FILE"
+    if [[ ${DR_ORCH_TEST_CRASH_POINT:-} = after_rules_rename ]]; then
+        learned_rules_unlock
+        return 75
+    fi
+    learned_rules_audit_once_locked learned_rule_commit "$proposal_hash" || { learned_rules_unlock; return 2; }
+    learned_rules_finalize_locked "$proposal_hash" accepted "$now" || rc=2
+    learned_rules_unlock
+    return "$rc"
+}
+
+learned_rules_store_maintenance() {
+    local now file record proposal_id proposal_hash updated rc=0
+    now=$(learned_rules_now) || return
+    learned_rules_lock || return
+    learned_rules_purge_locked "$now" || { learned_rules_unlock; return 2; }
+    while IFS= read -r -d '' file; do
+        record=$(learned_rules_read_secure "$file") || { rc=2; break; }
+        proposal_hash=$(basename -- "$file" .json)
+        proposal_id=$(learned_rules_capability_for_record_locked "$record") || { rc=2; break; }
+        learned_rules_validate_proposal_record_locked "$record" "$proposal_id" "$proposal_hash" \
+          || { rc=2; break; }
+        if [[ -e "$LEARNED_RULES_FILE" ]] \
+          && jq -e --arg hash "$(jq -r '.proposal_hash' <<<"$record")" \
+            '.patterns[]? | select(.proposal_hash==$hash)' \
+            <<<"$(learned_rules_load_rules_locked)" >/dev/null 2>&1; then
+            learned_rules_audit_once_locked learned_rule_commit "$(jq -r '.proposal_hash' <<<"$record")" || { rc=2; break; }
+            learned_rules_finalize_locked "$(jq -r '.proposal_hash' <<<"$record")" accepted "$now" || { rc=2; break; }
+            continue
+        fi
+        if [[ $(jq -r '.status // "invalid"' <<<"$record") = pending ]]; then
+            learned_rules_enqueue_locked "$proposal_id" || { rc=2; break; }
+            updated=$(jq -c '.status="delivered"' <<<"$record") || { rc=2; break; }
+            learned_rules_atomic_write "$file" "$updated" || { rc=2; break; }
+        fi
+    done < <(find "$LEARNED_RULES_PROPOSALS_DIR" -maxdepth 1 -type f -name '*.json' -print0)
+    learned_rules_unlock
+    return "$rc"
+}

--- a/plugins/dr-orchestrate/scripts/lib/portable-stat.sh
+++ b/plugins/dr-orchestrate/scripts/lib/portable-stat.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# shellcheck shell=bash
+
+portable_mode() {
+  local path="$1" value
+  if value="$(stat -c %a -- "$path" 2>/dev/null)" && [[ "$value" =~ ^[0-7]{3,4}$ ]]; then
+    printf '%s\n' "${value: -3}"
+    return 0
+  fi
+  if value="$(stat -f %Lp -- "$path" 2>/dev/null)" && [[ "$value" =~ ^[0-7]{3,4}$ ]]; then
+    printf '%s\n' "${value: -3}"
+    return 0
+  fi
+  return 1
+}
+
+portable_mtime() {
+  local path="$1" value
+  if value="$(stat -c %Y -- "$path" 2>/dev/null)" && [[ "$value" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+  if value="$(stat -f %m -- "$path" 2>/dev/null)" && [[ "$value" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+  return 1
+}
+
+portable_uid() {
+  local path="$1" value
+  if value="$(stat -c %u -- "$path" 2>/dev/null)" && [[ "$value" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+  if value="$(stat -f %u -- "$path" 2>/dev/null)" && [[ "$value" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+  return 1
+}
+
+portable_size() {
+  local path="$1" value
+  if value="$(stat -Lc %s -- "$path" 2>/dev/null)" && [[ "$value" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+  if value="$(stat -Lf %z -- "$path" 2>/dev/null)" && [[ "$value" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+  return 1
+}
+
+portable_identity() {
+  local path="$1" value
+  if value="$(stat -Lc '%d:%i' -- "$path" 2>/dev/null)" \
+    && [[ "$value" =~ ^[0-9]+:[0-9]+$ ]]; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+  if value="$(stat -Lf '%d:%i' -- "$path" 2>/dev/null)" \
+    && [[ "$value" =~ ^[0-9]+:[0-9]+$ ]]; then
+    printf '%s\n' "$value"
+    return 0
+  fi
+  return 1
+}

--- a/plugins/dr-orchestrate/scripts/lib/resolver_history.py
+++ b/plugins/dr-orchestrate/scripts/lib/resolver_history.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Deterministic normalization, rotation, and ranking for resolver history."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ACTION_PATTERN = re.compile(r"/dr-[a-z0-9][a-z0-9-]*\Z")
+FORBIDDEN_INTENT_CHARS = set("/\\;&|<>$`\"'()[]{}*?!~")
+
+
+def normalize_intent(value: str) -> str:
+    """Return the canonical exact-match intent or raise ValueError."""
+    if any(
+        (ord(char) <= 0x1F and char != "\t")
+        or 0x7F <= ord(char) <= 0x9F
+        for char in value
+    ):
+        raise ValueError("intent contains a control character")
+    normalized = re.sub(r"[ \t]+", " ", value.strip(" \t"))
+    size = len(normalized.encode("utf-8"))
+    if not 1 <= size <= 256:
+        raise ValueError("intent must contain 1 through 256 UTF-8 bytes")
+    if normalized.startswith("-") or normalized in {".", ".."}:
+        raise ValueError("intent resembles an option or path component")
+    if any(char in FORBIDDEN_INTENT_CHARS for char in normalized):
+        raise ValueError("intent contains a path or shell metacharacter")
+    return normalized
+
+
+def canonical_record(raw: Any) -> dict[str, Any] | None:
+    """Validate and canonicalize one decoded history object."""
+    if not isinstance(raw, dict):
+        return None
+    intent = raw.get("intent")
+    try:
+        normalized = normalize_intent(intent) if isinstance(intent, str) else None
+    except (UnicodeError, ValueError):
+        return None
+    action = raw.get("action")
+    exit_code = raw.get("exit_code")
+    timestamp = raw.get("timestamp")
+    if normalized is None or normalized != intent:
+        return None
+    if not isinstance(action, str) or ACTION_PATTERN.fullmatch(action) is None:
+        return None
+    if isinstance(exit_code, bool) or not isinstance(exit_code, int):
+        return None
+    if not 0 <= exit_code <= 255:
+        return None
+    if isinstance(timestamp, bool) or not isinstance(timestamp, int) or timestamp < 0:
+        return None
+    return {
+        "intent": normalized,
+        "action": action,
+        "exit_code": exit_code,
+        "timestamp": timestamp,
+    }
+
+
+def load_valid_records(path: Path) -> tuple[list[dict[str, Any]], int]:
+    """Load structurally valid records and count ignored corrupt lines."""
+    records: list[dict[str, Any]] = []
+    corrupt = 0
+    if not path.exists():
+        return records, corrupt
+    with path.open("rb") as stream:
+        for line in stream:
+            try:
+                parsed = json.loads(line.decode("utf-8", "strict"))
+            except (UnicodeDecodeError, json.JSONDecodeError):
+                corrupt += 1
+                continue
+            record = canonical_record(parsed)
+            if record is None:
+                corrupt += 1
+            else:
+                records.append(record)
+    return records, corrupt
+
+
+def encode_record(record: dict[str, Any]) -> bytes:
+    return (
+        json.dumps(record, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+        + b"\n"
+    )
+
+
+def bounded_suffix(
+    records: list[dict[str, Any]], max_records: int, max_bytes: int
+) -> list[bytes]:
+    """Return the newest contiguous suffix within both retention bounds."""
+    kept_reversed: list[bytes] = []
+    used = 0
+    for record in reversed(records[-max_records:]):
+        encoded = encode_record(record)
+        if used + len(encoded) > max_bytes:
+            break
+        kept_reversed.append(encoded)
+        used += len(encoded)
+    return list(reversed(kept_reversed))
+
+
+def rotate(arguments: list[str]) -> int:
+    if len(arguments) != 5:
+        return 2
+    source = Path(arguments[0])
+    destination = Path(arguments[1])
+    max_records = int(arguments[2])
+    max_bytes = int(arguments[3])
+    new_record = arguments[4]
+    records, corrupt = load_valid_records(source)
+    if new_record:
+        try:
+            appended = canonical_record(json.loads(new_record))
+        except json.JSONDecodeError:
+            appended = None
+        if appended is None:
+            return 2
+        records.append(appended)
+    with destination.open("wb") as stream:
+        for encoded in bounded_suffix(records, max_records, max_bytes):
+            stream.write(encoded)
+        stream.flush()
+        os.fsync(stream.fileno())
+    print(corrupt)
+    return 0
+
+
+def suggest(arguments: list[str]) -> int:
+    if len(arguments) != 3:
+        return 2
+    history = Path(arguments[0])
+    intent = normalize_intent(arguments[1])
+    trusted_raw = json.loads(arguments[2])
+    trusted = {
+        action
+        for action in trusted_raw
+        if isinstance(action, str) and ACTION_PATTERN.fullmatch(action) is not None
+    }
+    records, _ = load_valid_records(history)
+    counts: dict[str, dict[str, int]] = {}
+    for record in records:
+        if record["intent"] != intent or record["action"] not in trusted:
+            continue
+        stats = counts.setdefault(
+            record["action"], {"success": 0, "failure": 0, "latest_success": -1}
+        )
+        if record["exit_code"] == 0:
+            stats["success"] += 1
+            stats["latest_success"] = max(stats["latest_success"], record["timestamp"])
+        else:
+            stats["failure"] += 1
+    if counts:
+        print(
+            min(
+                counts,
+                key=lambda action: (
+                    -counts[action]["success"],
+                    counts[action]["failure"],
+                    -counts[action]["latest_success"],
+                    action,
+                ),
+            )
+        )
+    return 0
+
+
+def normalize(arguments: list[str]) -> int:
+    if len(arguments) != 1:
+        return 2
+    raw = os.fsencode(arguments[0])
+    try:
+        decoded = raw.decode("utf-8", "strict")
+        normalized = normalize_intent(decoded)
+    except (UnicodeDecodeError, UnicodeError, ValueError):
+        return 2
+    sys.stdout.buffer.write(normalized.encode("utf-8"))
+    return 0
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        return 2
+    command, arguments = sys.argv[1], sys.argv[2:]
+    try:
+        if command == "normalize":
+            return normalize(arguments)
+        if command == "rotate":
+            return rotate(arguments)
+        if command == "suggest":
+            return suggest(arguments)
+    except (OSError, UnicodeError, ValueError, json.JSONDecodeError):
+        return 2
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/dr-orchestrate/scripts/plugin.sh
+++ b/plugins/dr-orchestrate/scripts/plugin.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# plugin.sh — hook dispatcher for dr-orchestrate plugin (Phase 1, TUNE-0164).
+# plugin.sh — hook dispatcher for dr-orchestrate plugin.
 # Pure routing; bash 3.2+ ok. The bash-4 floor lives in cmd_run.sh where the
 # actual cycle work runs (V-AC-15 must answer get_autonomy from any host bash).
 set -euo pipefail
@@ -25,8 +25,13 @@ dispatch() {
       # resolver + escalation chain.
       "$DR_ORCH_DIR/scripts/cmd_run.sh" --unknown-prompt "$@"
       ;;
+    on_callback)
+      # Transport-neutral seam used by Telegram/bot adapters. Live Telegram
+      # HTTP transport remains outside this plugin phase.
+      "$DR_ORCH_DIR/scripts/learned_rules.sh" consume_callback "$@"
+      ;;
     on_tune_complete)
-      echo "dr-orchestrate: on_tune_complete noop (Phase 3 hook)"
+      "$DR_ORCH_DIR/scripts/learned_rules.sh" maintenance
       return 0
       ;;
     *)
@@ -40,7 +45,7 @@ dispatch() {
 # (which delegates to dev-tools/resolve-space-autonomy.sh + space.yml §
 # autonomy.policy). Full-autonomy spaces return "auto" from the gate and run
 # all reversible actions without asking. See README.md § Autonomy Levels.
-get_autonomy() { echo "2"; }
+get_autonomy() { echo "4"; }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   cmd="${1:-}"; shift || true

--- a/plugins/dr-orchestrate/scripts/proposal_backend.sh
+++ b/plugins/dr-orchestrate/scripts/proposal_backend.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Idempotent local delivery queue backend for learned-rule approval callbacks.
+
+set -euo pipefail
+
+PROPOSAL_BACKEND_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+: "${DR_ORCH_DIR:=$(cd "$PROPOSAL_BACKEND_SCRIPT_DIR/.." && pwd)}"
+export DR_ORCH_DIR
+# shellcheck source=/dev/null
+source "$PROPOSAL_BACKEND_SCRIPT_DIR/lib/learned-rules-store.sh"
+
+proposal_backend_main() {
+    local command=${1-}
+    case "$command" in
+        emit)
+            [[ $# -eq 2 ]] || return 2
+            learned_rules_enqueue "$2"
+            ;;
+        *)
+            learned_rules_error 'usage: proposal_backend.sh emit <proposal-id>'
+            return 2
+            ;;
+    esac
+}
+
+proposal_backend_main "$@"

--- a/plugins/dr-orchestrate/scripts/resolver.sh
+++ b/plugins/dr-orchestrate/scripts/resolver.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+# resolver.sh — bounded, trusted resolver-history compatibility CLI.
+set -euo pipefail
+
+umask 077
+
+DR_ORCH_DIR="${DR_ORCH_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+DR_ORCH_STATE_DIR="${DR_ORCH_STATE_DIR:-${STATE_DIR:-$HOME/.local/share/dr-orchestrate/state}}"
+DR_ORCH_RULES_DEFAULT="${DR_ORCH_RULES_DEFAULT:-$DR_ORCH_DIR/rules/default.yaml}"
+DR_ORCH_RULES_USER="${DR_ORCH_RULES_USER:-$HOME/.config/dr-orchestrate/rules/user.yaml}"
+DR_ORCH_AUDIT_FILE="${DR_ORCH_AUDIT_FILE:-$DR_ORCH_STATE_DIR/resolver-audit.jsonl}"
+DR_ORCH_LOCK_TIMEOUT="${DR_ORCH_LOCK_TIMEOUT:-5}"
+
+readonly HISTORY_FILE="$DR_ORCH_STATE_DIR/resolver-history.jsonl"
+readonly LOCK_FILE="$DR_ORCH_STATE_DIR/.resolver-history.lock"
+readonly RESOLVER_HISTORY_LIB="$DR_ORCH_DIR/scripts/lib/resolver_history.py"
+readonly HISTORY_MAX_RECORDS=5000
+readonly HISTORY_MAX_BYTES=1048576
+
+_error() {
+  printf 'resolver: %s\n' "$*" >&2
+}
+
+_usage() {
+  printf '%s\n' \
+    'usage: resolver.sh record <intent> <action> <exit-code>' \
+    '       resolver.sh suggest_alternative <intent>'
+}
+
+_require_dependencies() {
+  local dependency
+  for dependency in flock jq python3 yq; do
+    command -v "$dependency" >/dev/null 2>&1 || {
+      _error "required dependency unavailable: $dependency"
+      return 2
+    }
+  done
+  [[ -f "$RESOLVER_HISTORY_LIB" ]] || {
+    _error "resolver-history library unavailable: $RESOLVER_HISTORY_LIB"
+    return 2
+  }
+}
+
+_validate_state_path() {
+  [[ -n "$DR_ORCH_STATE_DIR" && "$DR_ORCH_STATE_DIR" != "/" ]] || {
+    _error 'DR_ORCH_STATE_DIR must name a dedicated directory'
+    return 2
+  }
+  [[ ! -L "$DR_ORCH_STATE_DIR" ]] || {
+    _error 'state directory must not be a symlink'
+    return 2
+  }
+  if [[ -e "$DR_ORCH_STATE_DIR" && ! -d "$DR_ORCH_STATE_DIR" ]]; then
+    _error 'state path is not a directory'
+    return 2
+  fi
+
+  mkdir -p -- "$DR_ORCH_STATE_DIR"
+  chmod 700 -- "$DR_ORCH_STATE_DIR"
+}
+
+_validate_regular_or_absent() {
+  local path="$1"
+  [[ ! -L "$path" ]] || {
+    _error "refusing symlink path: $path"
+    return 2
+  }
+  if [[ -e "$path" && ! -f "$path" ]]; then
+    _error "path is not a regular file: $path"
+    return 2
+  fi
+}
+
+_normalize_intent() {
+  python3 "$RESOLVER_HISTORY_LIB" normalize "$1"
+}
+
+_registry_source_json() {
+  local source="$1"
+  if [[ ! -f "$source" || ! -s "$source" ]]; then
+    printf '[]\n'
+    return 0
+  fi
+  yq eval -o=json '.patterns // []' -- "$source" 2>/dev/null || printf '[]\n'
+}
+
+_trusted_registry_json() {
+  local bundled user
+  bundled="$(_registry_source_json "$DR_ORCH_RULES_DEFAULT")"
+  user="$(_registry_source_json "$DR_ORCH_RULES_USER")"
+  jq -cn --argjson bundled "$bundled" --argjson user "$user" '
+    [$bundled, $user]
+    | map(if type == "array" then . else [] end)
+    | add
+    | [ .[]?
+        | .action?
+        | strings
+        | select(test("^/dr-[a-z0-9][a-z0-9-]*$")) ]
+    | unique
+    | sort
+  '
+}
+
+_canonical_action() {
+  local registry="$2" candidate="$1"
+  if [[ "$candidate" =~ ^dr-[a-z0-9][a-z0-9-]*$ ]]; then
+    candidate="/$candidate"
+  fi
+  [[ "$candidate" =~ ^/dr-[a-z0-9][a-z0-9-]*$ ]] || return 2
+  jq -e --arg action "$candidate" 'index($action) != null' <<<"$registry" >/dev/null \
+    || return 2
+  printf '%s\n' "$candidate"
+}
+
+_now_epoch() {
+  local now="${DR_ORCH_NOW_EPOCH:-}"
+  if [[ -z "$now" ]]; then
+    now="$(date +%s)"
+  fi
+  [[ "$now" =~ ^[0-9]+$ ]] || return 2
+  printf '%s\n' "$now"
+}
+
+_emit_corrupt_audit_locked() {
+  local corrupt_count="$1" now audit_parent payload
+  [[ "$corrupt_count" =~ ^[1-9][0-9]*$ ]] || return 0
+  now="$(_now_epoch)" || return 2
+  audit_parent="$(dirname "$DR_ORCH_AUDIT_FILE")"
+  [[ ! -L "$audit_parent" ]] || return 2
+  mkdir -p -- "$audit_parent"
+  _validate_regular_or_absent "$DR_ORCH_AUDIT_FILE" || return 2
+  payload="$(jq -nc \
+    --arg event_type resolver_history_corrupt \
+    --argjson timestamp "$now" \
+    --argjson corrupt_count "$corrupt_count" \
+    '{event_type:$event_type,timestamp:$timestamp,corrupt_count:$corrupt_count}')"
+  printf '%s\n' "$payload" >> "$DR_ORCH_AUDIT_FILE"
+  chmod 600 -- "$DR_ORCH_AUDIT_FILE"
+}
+
+# Rebuild a canonical suffix under the already-held lock. Passing a JSON record
+# appends it before count/byte rotation; an empty argument performs maintenance.
+_rotate_history_locked() {
+  local new_record="${1:-}" temporary corrupt_count
+  _validate_regular_or_absent "$HISTORY_FILE" || return 2
+  temporary="$(mktemp "$DR_ORCH_STATE_DIR/.resolver-history.XXXXXX")"
+  chmod 600 -- "$temporary"
+
+  if ! corrupt_count="$(python3 "$RESOLVER_HISTORY_LIB" rotate \
+      "$HISTORY_FILE" "$temporary" "$HISTORY_MAX_RECORDS" "$HISTORY_MAX_BYTES" \
+      "$new_record")"; then
+    rm -f -- "$temporary"
+    return 2
+  fi
+
+  mv -f -- "$temporary" "$HISTORY_FILE"
+  chmod 600 -- "$HISTORY_FILE"
+  _emit_corrupt_audit_locked "$corrupt_count"
+}
+
+_record_locked() {
+  local intent="$1" action="$2" exit_code="$3" timestamp="$4" record
+  record="$(jq -nc \
+    --arg intent "$intent" \
+    --arg action "$action" \
+    --argjson exit_code "$exit_code" \
+    --argjson timestamp "$timestamp" \
+    '{intent:$intent,action:$action,exit_code:$exit_code,timestamp:$timestamp}')"
+  _rotate_history_locked "$record"
+}
+
+_suggest_locked() {
+  local intent="$1" registry="$2"
+  _validate_regular_or_absent "$HISTORY_FILE" || return 2
+  [[ -f "$HISTORY_FILE" ]] || return 0
+  _rotate_history_locked
+  [[ -s "$HISTORY_FILE" ]] || return 0
+
+  python3 "$RESOLVER_HISTORY_LIB" suggest "$HISTORY_FILE" "$intent" "$registry"
+}
+
+_with_lock() (
+  local operation="$1"
+  shift
+  _validate_state_path || exit $?
+  _validate_regular_or_absent "$LOCK_FILE" || exit $?
+  : >> "$LOCK_FILE"
+  chmod 600 -- "$LOCK_FILE"
+  exec 9>> "$LOCK_FILE"
+  flock -w "$DR_ORCH_LOCK_TIMEOUT" 9 || {
+    _error 'timed out acquiring resolver-history lock'
+    exit 2
+  }
+  "$operation" "$@"
+)
+
+record() {
+  [[ $# -eq 3 ]] || { _usage >&2; return 2; }
+  local normalized registry canonical exit_code="$3" timestamp
+  if ! normalized="$(_normalize_intent "$1")"; then
+    _error 'invalid intent'
+    return 2
+  fi
+  [[ "$exit_code" =~ ^[0-9]+$ && "$exit_code" -le 255 ]] || {
+    _error 'exit code must be an integer from 0 through 255'
+    return 2
+  }
+  registry="$(_trusted_registry_json)"
+  if ! canonical="$(_canonical_action "$2" "$registry")"; then
+    _error 'action is not present in the trusted default/user registry'
+    return 2
+  fi
+  timestamp="$(_now_epoch)" || {
+    _error 'invalid DR_ORCH_NOW_EPOCH'
+    return 2
+  }
+  _with_lock _record_locked "$normalized" "$canonical" "$exit_code" "$timestamp"
+}
+
+suggest_alternative() {
+  [[ $# -eq 1 ]] || { _usage >&2; return 2; }
+  local normalized registry
+  if ! normalized="$(_normalize_intent "$1")"; then
+    _error 'invalid intent'
+    return 2
+  fi
+  registry="$(_trusted_registry_json)"
+  _with_lock _suggest_locked "$normalized" "$registry"
+}
+
+main() {
+  _require_dependencies || return $?
+  [[ "$DR_ORCH_LOCK_TIMEOUT" =~ ^[0-9]+([.][0-9]+)?$ ]] || {
+    _error 'DR_ORCH_LOCK_TIMEOUT must be a non-negative number'
+    return 2
+  }
+  local command="${1:-}"
+  [[ -n "$command" ]] || { _usage >&2; return 2; }
+  shift
+  case "$command" in
+    record) record "$@" ;;
+    suggest_alternative) suggest_alternative "$@" ;;
+    -h|--help) _usage ;;
+    *) _error "unknown command: $command"; _usage >&2; return 2 ;;
+  esac
+}
+
+main "$@"

--- a/plugins/dr-orchestrate/scripts/rules_loader.sh
+++ b/plugins/dr-orchestrate/scripts/rules_loader.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # rules_loader.sh — 3-source prompt-pattern rules merge (default → user → learned).
-# Read-only loader; Phase C auto-learn write path deferred.
-# Output: JSON array of {match, action, confidence} on stdout, deduped by
+# Output: JSON array of rules on stdout, deduped by
 # match-key with last-write-wins (learned beats user beats default).
 #
 # The four load_fb_* functions are thin shims that delegate to the core
@@ -12,7 +11,8 @@ set -euo pipefail
 : "${DR_ORCH_DIR:=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
 : "${DR_ORCH_RULES_DEFAULT:=$DR_ORCH_DIR/rules/default.yaml}"
 : "${DR_ORCH_RULES_USER:=$HOME/.config/dr-orchestrate/rules/user.yaml}"
-: "${DR_ORCH_RULES_LEARNED:=${STATE_DIR:-$HOME/.local/share/dr-orchestrate/state}/learned-rules.yaml}"
+: "${DR_ORCH_STATE_DIR:=${STATE_DIR:-$HOME/.local/share/dr-orchestrate/state}}"
+: "${DR_ORCH_RULES_LEARNED:=$DR_ORCH_STATE_DIR/learned-rules.yaml}"
 
 # Resolve the core policy loader. Prefer the core path; fall back to a local
 # copy (deprecation shim) when the core path is absent (e.g. copy-mode installs
@@ -43,21 +43,68 @@ else
 fi
 
 _extract() {
-  local src="$1"
+  local src="$1" provenance="$2"
   [[ -f "$src" && -s "$src" ]] || { echo '[]'; return 0; }
-  yq eval -o=json '.patterns // []' "$src" 2>/dev/null || echo '[]'
+  yq eval -o=json '.patterns // []' "$src" 2>/dev/null \
+    | jq -c --arg provenance "$provenance" 'map(. + {provenance:$provenance})' \
+    || echo '[]'
+}
+
+_extract_learned() {
+  [[ -f "$DR_ORCH_RULES_LEARNED" && -s "$DR_ORCH_RULES_LEARNED" ]] \
+    || { echo '[]'; return 0; }
+  local now="${DR_ORCH_NOW_EPOCH:-$(date +%s)}"
+  [[ "$now" =~ ^[0-9]+$ ]] || { echo '[]'; return 0; }
+  yq eval -o=json '.patterns // []' "$DR_ORCH_RULES_LEARNED" 2>/dev/null \
+    | jq -c --argjson now "$now" '
+        def epoch: type=="number" and floor==. and .>=0 and .<=253402300799;
+        map(select(
+          (.match|type)=="string" and (.match|utf8bytelength)>=1 and (.match|utf8bytelength)<=256 and
+          (.match|startswith("-")|not) and (.match|test("[[:cntrl:]]")|not) and
+          (.match|contains("\t")|not) and (.match|startswith(" ")|not) and (.match|endswith(" ")|not) and
+          (.match|contains("  ")|not) and (.match|contains("..")|not) and
+          (.match|test("[/\\\\;&|<>$`(){}*?!]|\\[|\\]")|not) and
+          (.action|type)=="string" and (.action|length)>0 and
+          (.confidence|type)=="number" and .confidence>=0 and .confidence<=1 and
+          (.created_at|epoch) and (.last_validated_at|epoch) and (.expires_at|epoch) and
+          .last_validated_at>=.created_at and .last_validated_at<=.expires_at and
+          .expires_at==(.created_at + 604800) and
+          (.proposal_hash|type)=="string" and (.proposal_hash|test("^[0-9a-f]{64}$")) and
+          (.generation|type)=="string" and (.generation|test("^[0-9a-f]{64}$")) and
+          $now < .expires_at and $now < (.last_validated_at + 86400)
+        )) | map(. + {provenance:"learned"})' \
+    || echo '[]'
 }
 
 load() {
   local d u l
-  d="$(_extract "$DR_ORCH_RULES_DEFAULT")"
-  u="$(_extract "$DR_ORCH_RULES_USER")"
-  l="$(_extract "$DR_ORCH_RULES_LEARNED")"
+  d="$(_extract "$DR_ORCH_RULES_DEFAULT" bundled)"
+  u="$(_extract "$DR_ORCH_RULES_USER" user)"
+  l="$(_extract_learned)"
   jq -c -s '
     .[0] + .[1] + .[2]
     | reduce .[] as $x ({}; .[$x.match] = $x)
     | [.[]]
   ' <(echo "$d") <(echo "$u") <(echo "$l")
+}
+
+# Trusted actions deliberately exclude learned rules. This is the capability
+# registry used before every learned dispatch and proposal acceptance.
+load_trusted_actions() {
+  jq -c -s '[.[0][], .[1][]] | map(.action) | unique' \
+    <(_extract "$DR_ORCH_RULES_DEFAULT" bundled) \
+    <(_extract "$DR_ORCH_RULES_USER" user)
+}
+
+load_inactive_learned() {
+  [[ -f "$DR_ORCH_RULES_LEARNED" && -s "$DR_ORCH_RULES_LEARNED" ]] \
+    || { echo '[]'; return 0; }
+  local now="${DR_ORCH_NOW_EPOCH:-$(date +%s)}"
+  yq eval -o=json '.patterns // []' "$DR_ORCH_RULES_LEARNED" 2>/dev/null \
+    | jq -c --argjson now "$now" 'map(select(
+        (.last_validated_at|type)=="number" and (.expires_at|type)=="number" and
+        ($now >= .expires_at or $now >= (.last_validated_at + 86400))))' \
+    || echo '[]'
 }
 
 # load_fb_* shims — delegate to the core loader when available; otherwise

--- a/plugins/dr-orchestrate/scripts/secrets_backend.sh
+++ b/plugins/dr-orchestrate/scripts/secrets_backend.sh
@@ -3,13 +3,17 @@
 # V-AC: 9 (YAML get + mode 0600 enforcement).
 set -euo pipefail
 
+_SECRETS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/portable-stat.sh
+source "$_SECRETS_DIR/lib/portable-stat.sh"
+
 # yaml_get <file> <key> — print value of top-level scalar key. Mode MUST be 0600.
 # Exit codes: 0 ok, 1 file missing, 2 mode wrong, 3 key missing.
 yaml_get() {
   local file="$1"; local key="$2"
   [[ -f "$file" ]] || { echo "ERR: $file missing" >&2; return 1; }
   local mode
-  mode="$(stat -f %Lp "$file" 2>/dev/null || stat -c %a "$file" 2>/dev/null)"
+  mode="$(portable_mode "$file" 2>/dev/null || true)"
   [[ -n "$mode" ]] || { echo "ERR: cannot stat $file" >&2; return 1; }
   if [[ "$mode" != "600" ]]; then
     echo "ERR: $file mode $mode (need 600)" >&2

--- a/plugins/dr-orchestrate/scripts/security.sh
+++ b/plugins/dr-orchestrate/scripts/security.sh
@@ -4,6 +4,10 @@
 # 8 (5 violations/hour → 1h pane block). Fail-closed by design.
 set -euo pipefail
 
+_SECURITY_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/portable-stat.sh
+source "$_SECURITY_DIR/lib/portable-stat.sh"
+
 : "${STATE_DIR:=/tmp/dr-orchestrate-state}"
 mkdir -p "$STATE_DIR"
 
@@ -119,7 +123,7 @@ is_pane_blocked() {
   local b="$STATE_DIR/${safe_pane}.blocked"
   [[ -f "$b" ]] || return 1
   local mtime
-  mtime="$(stat -f %m "$b" 2>/dev/null || stat -c %Y "$b" 2>/dev/null)"
+  mtime="$(portable_mtime "$b" 2>/dev/null || printf '0')"
   [[ -n "$mtime" ]] || return 1
   if (( $(date -u +%s) - mtime >= 3600 )); then
     rm -f "$b"

--- a/plugins/dr-orchestrate/scripts/semantic_parser.sh
+++ b/plugins/dr-orchestrate/scripts/semantic_parser.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # semantic_parser.sh — rule-based first-pass classifier.
 # Reads merged ruleset from rules_loader.sh (default + user + learned).
-# Hit  → confidence from matched rule, source=rule_phase1_stub.
+# Hit  → confidence and selected trusted action with rule provenance.
 # Miss → confidence 0, source=rule_phase2_miss (subagent_resolver.sh handles
 # the fallback inference in TUNE-0165 M6).
 # V-AC: 14 (rule-based confidence > 0 for known commands).
@@ -15,27 +15,33 @@ source "$DR_ORCH_DIR/scripts/rules_loader.sh"
 parse() {
   local input="${1:-}"
   local conf=0
-  local source="rule_phase2_miss"
+  local source="rule_phase2_miss" selected_action="" provenance=""
 
   local rules
   rules="$(load 2>/dev/null || echo '[]')"
 
-  local match rule_conf
-  while IFS=$'\t' read -r match rule_conf; do
+  local match action rule_conf rule_provenance
+  while IFS=$'\t' read -r match action rule_conf rule_provenance; do
     [[ -z "$match" ]] && continue
-    if [[ "$input" == *"$match"* ]]; then
+    if { [[ "$rule_provenance" == "learned" ]] && [[ "$input" == "$match" ]]; } \
+      || { [[ "$rule_provenance" != "learned" ]] && [[ "$input" == *"$match"* ]]; }; then
       if awk -v a="$rule_conf" -v b="$conf" 'BEGIN{exit !(a>b)}'; then
         conf="$rule_conf"
         source="rule_phase1_stub"
+        selected_action="$action"
+        provenance="$rule_provenance"
       fi
     fi
-  done < <(printf '%s' "$rules" | jq -r '.[] | [.match, (.confidence|tostring)] | @tsv')
+  done < <(printf '%s' "$rules" | jq -r '.[] | [.match, .action, (.confidence|tostring), .provenance] | @tsv')
 
   jq -n -c \
     --arg cmd "$input" \
     --argjson conf "$conf" \
     --arg src "$source" \
-    '{command:$cmd, confidence:$conf, source:$src}'
+    --arg action "$selected_action" \
+    --arg provenance "$provenance" \
+    '{command:$cmd, confidence:$conf, source:$src,
+      action:$action, provenance:$provenance}'
 }
 
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then

--- a/plugins/dr-orchestrate/scripts/tmux_manager.sh
+++ b/plugins/dr-orchestrate/scripts/tmux_manager.sh
@@ -16,6 +16,18 @@ session_init() {
   tmux new-session -d -s "$s"
 }
 
+# Restore a missing session or a dead primary pane without replaying commands.
+session_recover() {
+  local s="${1:-datarim}"
+  if ! tmux has-session -t "$s" 2>/dev/null; then
+    session_init "$s"
+    return 0
+  fi
+  if [[ "$(tmux display-message -p -t "$s:0.0" '#{pane_dead}' 2>/dev/null || echo 1)" == "1" ]]; then
+    tmux respawn-pane -k -t "$s:0.0"
+  fi
+}
+
 pane_split() {
   local s="$1"
   tmux split-window -t "$s"

--- a/plugins/dr-orchestrate/tests/helpers/phase3-env.bash
+++ b/plugins/dr-orchestrate/tests/helpers/phase3-env.bash
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# Hermetic Phase 3 acceptance environment. Source this file, then call
+# phase3_env_setup; phase3_env_cleanup removes only the generated fixture.
+
+phase3_env_repo_root() {
+  cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd -P
+}
+
+phase3_env_write_space() {
+  cat >"$DATARIM_SPACES_ROOT/phase3-test/space.yml" <<'YAML'
+space:
+  name: phase3-test
+autonomy:
+  schema_version: 1
+  policy:
+    cross_project_write: auto
+    verify: auto
+YAML
+}
+
+phase3_env_write_network_stubs() {
+  local tool
+  for tool in curl wget nc ncat ssh scp; do
+    printf '%s\n' '#!/usr/bin/env bash' \
+      'printf "%s\\n" "$(basename "$0") $*" >> "${PHASE3_NETWORK_LOG:?}"' \
+      'exit 97' >"$PHASE3_ENV_ROOT/bin/$tool"
+    chmod 700 "$PHASE3_ENV_ROOT/bin/$tool"
+  done
+}
+
+phase3_env_setup() {
+  local parent="${BATS_TEST_TMPDIR:-${TMPDIR:-/tmp}}"
+  PHASE3_REPO_ROOT="${PHASE3_REPO_ROOT:-$(phase3_env_repo_root)}"
+  PHASE3_PLUGIN_ROOT="${PHASE3_PLUGIN_ROOT:-$PHASE3_REPO_ROOT/plugins/dr-orchestrate}"
+  PHASE3_ENV_ROOT="$(mktemp -d "$parent/dr-orchestrate-phase3.XXXXXX")"
+  export PHASE3_REPO_ROOT PHASE3_PLUGIN_ROOT PHASE3_ENV_ROOT
+
+  export HOME="$PHASE3_ENV_ROOT/home"
+  export XDG_CONFIG_HOME="$PHASE3_ENV_ROOT/config"
+  export DATARIM_RUNTIME="$PHASE3_REPO_ROOT"
+  export DR_ORCH_DIR="$PHASE3_PLUGIN_ROOT"
+  export AUDIT_DIR="$PHASE3_ENV_ROOT/audit"
+  export DR_ORCH_STATE_DIR="$PHASE3_ENV_ROOT/state"
+  export STATE_DIR="$DR_ORCH_STATE_DIR"
+  export DR_ORCH_RULES_DEFAULT="$PHASE3_PLUGIN_ROOT/rules/default.yaml"
+  export DR_ORCH_RULES_USER="$XDG_CONFIG_HOME/dr-orchestrate/rules/user.yaml"
+  export DR_ORCH_RULES_LEARNED="$DR_ORCH_STATE_DIR/learned-rules.yaml"
+  DR_ORCH_AUDIT_FILE="$AUDIT_DIR/audit-$(date -u +%Y-%m-%d).jsonl"
+  export DR_ORCH_AUDIT_FILE
+  export DR_ORCH_PROPOSALS_DIR="$DR_ORCH_STATE_DIR/learned-rule-proposals"
+  export DR_ORCH_TOMBSTONES_DIR="$DR_ORCH_STATE_DIR/learned-rule-tombstones"
+  export DR_ORCH_DELIVERY_DIR="$DR_ORCH_STATE_DIR/learned-rule-delivery"
+  export DR_ORCH_LEARNED_AUDIT="$DR_ORCH_AUDIT_FILE"
+  export DR_ORCH_PROPOSAL_MOCK_LOG="$DR_ORCH_STATE_DIR/proposals.jsonl"
+  export DR_ORCH_PROPOSAL_QUEUE="$DR_ORCH_STATE_DIR/proposal-queue.jsonl"
+  export DR_ORCH_ACTION_EXECUTOR_LOG="$DR_ORCH_STATE_DIR/executor.log"
+  export DR_ORCH_AUTONOMY_AUDIT="$DR_ORCH_STATE_DIR/autonomy.jsonl"
+  export DR_AUTONOMY_AUDIT="$DR_ORCH_AUTONOMY_AUDIT"
+  export DATARIM_SPACES_ROOT="$PHASE3_ENV_ROOT/spaces"
+  export DATARIM_ACTIVE_SPACE=phase3-test
+  export DR_ORCH_FB_RULES="$PHASE3_ENV_ROOT/autonomy/fb-rules.yaml"
+  export DR_AUTONOMY_RULES="$DR_ORCH_FB_RULES"
+  export DR_ORCH_USER_CONFIG="$XDG_CONFIG_HOME/dr-orchestrate/user-config.yaml"
+  export DR_ORCH_ACTOR=phase3-actor
+  export DR_ORCH_SESSION_CONTEXT=phase3-session
+  export SESSION_NAME=phase3-session
+  export DR_ORCH_NOW_EPOCH="${DR_ORCH_NOW_EPOCH:-2000000000}"
+  export DR_ORCH_PROPOSAL_BACKEND=mock
+  export DR_ORCH_OUTBOUND_BACKEND=mock
+  export TMUX_TMPDIR="$PHASE3_ENV_ROOT/tmux"
+  export PHASE3_NETWORK_LOG="$PHASE3_ENV_ROOT/network.log"
+  unset TMUX
+
+  mkdir -p "$HOME" "$AUDIT_DIR" "$DR_ORCH_STATE_DIR" "$TMUX_TMPDIR" \
+    "$(dirname "$DR_ORCH_RULES_USER")" "$(dirname "$DR_ORCH_USER_CONFIG")" \
+    "$DATARIM_SPACES_ROOT/phase3-test" "$PHASE3_ENV_ROOT/autonomy" \
+    "$PHASE3_ENV_ROOT/bin"
+  chmod 700 "$HOME" "$AUDIT_DIR" "$DR_ORCH_STATE_DIR" "$TMUX_TMPDIR"
+  printf 'patterns: []\n' >"$DR_ORCH_RULES_USER"
+  printf '{}\n' >"$DR_ORCH_USER_CONFIG"
+  cp "$PHASE3_REPO_ROOT/dev-tools/rules/fb-rules.yaml" "$DR_ORCH_FB_RULES"
+  phase3_env_write_space
+  : >"$PHASE3_NETWORK_LOG"
+  : >"$DR_ORCH_ACTION_EXECUTOR_LOG"
+  phase3_env_write_network_stubs
+  export PATH="$PHASE3_ENV_ROOT/bin:$PATH"
+}
+
+phase3_env_cleanup() {
+  if [[ -n "${PHASE3_ENV_ROOT:-}" && -d "$PHASE3_ENV_ROOT" ]]; then
+    tmux kill-server >/dev/null 2>&1 || true
+    rm -rf -- "$PHASE3_ENV_ROOT"
+  fi
+}

--- a/plugins/dr-orchestrate/tests/test_action_gate.bats
+++ b/plugins/dr-orchestrate/tests/test_action_gate.bats
@@ -16,10 +16,12 @@ autonomy:
   schema_version: 1
   policy:
     merge_main: auto
+    cross_project_write: auto
 YAML
   cat > "$DR_AUTONOMY_RULES" <<'YAML'
 always_gated_floor: [finance_action]
 action_autonomy_map:
+  framework_command: cross_project_write
   merge_main: merge_main
 YAML
 }
@@ -30,6 +32,13 @@ YAML
   [ "$status" -eq 0 ] \
     && [ -s "$DR_ORCH_AUTONOMY_AUDIT" ] \
     && [ "$(jq -r '.decision' "$DR_ORCH_AUTONOMY_AUDIT")" = auto ]
+}
+
+@test "V-AC-26: framework command maps through cross-project write policy" {
+  run env DATARIM_ACTIVE_SPACE=arcanada \
+    "$PLUGIN_ROOT/scripts/action_gate.sh" gate --action framework_command
+  [ "$status" -eq 0 ] \
+    && [ "$(jq -r '.policy_key' "$DR_ORCH_AUTONOMY_AUDIT")" = cross_project_write ]
 }
 
 @test "action gate blocks floor action even in permissive space" {

--- a/plugins/dr-orchestrate/tests/test_learned_rules.bats
+++ b/plugins/dr-orchestrate/tests/test_learned_rules.bats
@@ -1,0 +1,547 @@
+#!/usr/bin/env bats
+
+setup() {
+    PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    chmod 700 "$BATS_TEST_TMPDIR"
+    export DR_ORCH_STATE_DIR="$BATS_TEST_TMPDIR/state"
+    export DR_ORCH_RULES_DEFAULT="$BATS_TEST_TMPDIR/default.yaml"
+    export DR_ORCH_RULES_USER="$BATS_TEST_TMPDIR/user.yaml"
+    export DR_ORCH_RULES_LEARNED="$DR_ORCH_STATE_DIR/learned-rules.yaml"
+    export DR_ORCH_LEARNED_AUDIT="$DR_ORCH_STATE_DIR/learned-rule-audit.jsonl"
+    export DR_ORCH_NOW_EPOCH=100
+    cat > "$DR_ORCH_RULES_DEFAULT" <<'YAML'
+patterns:
+  - match: /dr-plan
+    action: /dr-plan
+    confidence: 0.95
+  - match: /dr-qa
+    action: /dr-qa
+    confidence: 0.95
+YAML
+    printf 'patterns: []\n' > "$DR_ORCH_RULES_USER"
+}
+
+lr() {
+    bash "$PLUGIN_ROOT/scripts/learned_rules.sh" "$@"
+}
+
+backend() {
+    bash "$PLUGIN_ROOT/scripts/proposal_backend.sh" "$@"
+}
+
+proposal_count() {
+    find "$DR_ORCH_STATE_DIR/learned-rule-proposals" -type f -name '*.json' 2>/dev/null | wc -l
+}
+
+queue_count() {
+    find "$DR_ORCH_STATE_DIR/learned-rule-delivery" -type f -name '*.json' 2>/dev/null | wc -l
+}
+
+rule_value() {
+    jq -r ".patterns[0].$1" "$DR_ORCH_RULES_LEARNED"
+}
+
+@test "normalization is exact and preserves case and UTF-8" {
+    run bash -c 'source "$1/scripts/lib/learned-rules-common.sh"; learned_rules_normalize_match "$2"' _ "$PLUGIN_ROOT" $'  Run\t  Ångström  '
+    [ "$status" -eq 0 ]
+    [ "$output" = "Run Ångström" ]
+}
+
+@test "normalization rejects controls, path syntax, metacharacters, leading options, and overlength" {
+    for bad in $'bad\nvalue' '../plan' 'run;plan' '--dr-plan' "$(printf 'x%.0s' {1..257})"; do
+        run bash -c 'source "$1/scripts/lib/learned-rules-common.sh"; learned_rules_normalize_match "$2"' _ "$PLUGIN_ROOT" "$bad"
+        [ "$status" -ne 0 ]
+    done
+}
+
+@test "proposal is an opaque capability and delivery leaks only callback fields" {
+    run lr propose $'  Run\t plan ' dr-plan 0.91 alice s-1
+    [ "$status" -eq 0 ]
+    id="$output"
+    [[ "$id" =~ ^[0-9a-f]{64}$ ]]
+    [ "$(proposal_count)" -eq 1 ]
+    [ "$(queue_count)" -eq 1 ]
+    proposal="$(find "$DR_ORCH_STATE_DIR/learned-rule-proposals" -name '*.json')"
+    event="$(find "$DR_ORCH_STATE_DIR/learned-rule-delivery" -name '*.json')"
+    run grep -Fq "$id" "$proposal"
+    [ "$status" -ne 0 ]
+    jq -e --arg id "$id" '.proposal_id == $id and .expires_at == 1000 and .prompt == "Save as rule? [Y/N]" and (keys | sort == ["expires_at","prompt","proposal_id"])' "$event"
+    run grep -Fq 'Run plan' "$event"
+    [ "$status" -ne 0 ]
+    run grep -Fq '/dr-plan' "$event"
+    [ "$status" -ne 0 ]
+    [ "$(stat -c %a "$DR_ORCH_STATE_DIR")" = 700 ]
+    [ "$(stat -c %a "$proposal")" = 600 ]
+    [ "$(stat -c %a "$event")" = 600 ]
+}
+
+@test "pending proposal is not consumable and maintenance completes delivery exactly once" {
+    export DR_ORCH_TEST_CRASH_POINT=after_proposal_persist
+    run lr propose 'run plan' /dr-plan 0.9 alice s-1
+    [ "$status" -eq 75 ]
+    id="$(printf '%s\n' "$output" | tail -n1)"
+    unset DR_ORCH_TEST_CRASH_POINT
+    run lr consume_callback "$id" Y alice s-1
+    [ "$status" -ne 0 ]
+    run lr maintenance
+    [ "$status" -eq 0 ]
+    run lr maintenance
+    [ "$status" -eq 0 ]
+    [ "$(queue_count)" -eq 1 ]
+    run lr consume_callback "$id" Y alice s-1
+    [ "$status" -eq 0 ]
+}
+
+@test "Y callback persists a bounded immutable-expiry learned rule" {
+    id="$(lr propose 'run plan' /dr-plan 0.9 alice s-1)"
+    run lr consume_callback "$id" Y alice s-1
+    [ "$status" -eq 0 ]
+    [ "$(rule_value match)" = 'run plan' ]
+    [ "$(rule_value action)" = '/dr-plan' ]
+    [ "$(rule_value created_at)" = 100 ]
+    [ "$(rule_value last_validated_at)" = 100 ]
+    [ "$(rule_value expires_at)" = 604900 ]
+    [ "$(jq '.patterns | length' "$DR_ORCH_RULES_LEARNED")" -eq 1 ]
+}
+
+@test "wrong actor, wrong session, malformed id, and expiry equality leave rules byte-identical" {
+    id="$(lr propose 'run plan' /dr-plan 0.9 alice s-1)"
+    mkdir -p "$DR_ORCH_STATE_DIR"
+    chmod 700 "$DR_ORCH_STATE_DIR"
+    printf '{"patterns":[]}\n' > "$DR_ORCH_RULES_LEARNED"
+    before="$(sha256sum "$DR_ORCH_RULES_LEARNED")"
+    run lr consume_callback "$id" Y mallory s-1
+    [ "$status" -ne 0 ]
+    run lr consume_callback "$id" Y alice wrong
+    [ "$status" -ne 0 ]
+    run lr consume_callback 'not-a-capability' Y alice s-1
+    [ "$status" -ne 0 ]
+    export DR_ORCH_NOW_EPOCH=1000
+    run lr consume_callback "$id" Y alice s-1
+    [ "$status" -ne 0 ]
+    [ "$(sha256sum "$DR_ORCH_RULES_LEARNED")" = "$before" ]
+}
+
+@test "N tombstones once and never mutates rules" {
+    id="$(lr propose 'run plan' /dr-plan 0.9 alice s-1)"
+    run lr consume_callback "$id" N alice s-1
+    [ "$status" -eq 0 ]
+    [ ! -e "$DR_ORCH_RULES_LEARNED" ]
+    [ "$(find "$DR_ORCH_STATE_DIR/learned-rule-tombstones" -name '*.json' | wc -l)" -eq 1 ]
+    run lr consume_callback "$id" N alice s-1
+    [ "$status" -ne 0 ]
+}
+
+@test "learned actions never extend the trusted action registry" {
+    mkdir -p "$DR_ORCH_STATE_DIR"
+    chmod 700 "$DR_ORCH_STATE_DIR"
+    cat > "$DR_ORCH_RULES_LEARNED" <<'JSON'
+{"patterns":[{"match":"poison","action":"/dr-evil","confidence":1,"created_at":1,"last_validated_at":1,"expires_at":604801,"proposal_hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","generation":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}]}
+JSON
+    chmod 600 "$DR_ORCH_RULES_LEARNED"
+    run lr propose 'do evil' /dr-evil 0.9 alice s-1
+    [ "$status" -ne 0 ]
+    run lr propose 'run qa' dr-qa 0.9 alice s-1
+    [ "$status" -eq 0 ]
+}
+
+@test "same actor session and intent replaces the older outstanding proposal" {
+    first="$(lr propose 'run plan' /dr-plan 0.8 alice s-1)"
+    second="$(lr propose ' run   plan ' /dr-plan 0.9 alice s-1)"
+    [ "$first" != "$second" ]
+    [ "$(proposal_count)" -eq 1 ]
+    run lr consume_callback "$first" Y alice s-1
+    [ "$status" -ne 0 ]
+    run lr consume_callback "$second" Y alice s-1
+    [ "$status" -eq 0 ]
+}
+
+@test "delivery backend enqueue is idempotent by capability hash" {
+    export DR_ORCH_TEST_CRASH_POINT=after_proposal_persist
+    run lr propose 'run plan' /dr-plan 0.9 alice s-1
+    [ "$status" -eq 75 ]
+    id="$(printf '%s\n' "$output" | tail -n1)"
+    unset DR_ORCH_TEST_CRASH_POINT
+    run backend emit "$id"
+    [ "$status" -eq 0 ]
+    run backend emit "$id"
+    [ "$status" -eq 0 ]
+    [ "$(queue_count)" -eq 1 ]
+}
+
+@test "prepare is durable before rename and pre-rename crash is retryable" {
+    id="$(lr propose 'run plan' /dr-plan 0.9 alice s-1)"
+    export DR_ORCH_TEST_CRASH_POINT=before_rules_rename
+    run lr consume_callback "$id" Y alice s-1
+    [ "$status" -eq 75 ]
+    [ ! -e "$DR_ORCH_RULES_LEARNED" ]
+    [ "$(jq -r 'select(.event == "learned_rule_prepare") | .proposal_hash' "$DR_ORCH_LEARNED_AUDIT" | wc -l)" -eq 1 ]
+    unset DR_ORCH_TEST_CRASH_POINT
+    run lr consume_callback "$id" Y alice s-1
+    [ "$status" -eq 0 ]
+    [ "$(jq -r 'select(.event == "learned_rule_commit") | .proposal_hash' "$DR_ORCH_LEARNED_AUDIT" | wc -l)" -eq 1 ]
+}
+
+@test "post-rename crash reconciles one commit without duplicate rule" {
+    id="$(lr propose 'run plan' /dr-plan 0.9 alice s-1)"
+    export DR_ORCH_TEST_CRASH_POINT=after_rules_rename
+    run lr consume_callback "$id" Y alice s-1
+    [ "$status" -eq 75 ]
+    [ "$(jq '.patterns | length' "$DR_ORCH_RULES_LEARNED")" -eq 1 ]
+    unset DR_ORCH_TEST_CRASH_POINT
+    run lr consume_callback "$id" Y alice s-1
+    [ "$status" -eq 0 ]
+    [ "$(jq '.patterns | length' "$DR_ORCH_RULES_LEARNED")" -eq 1 ]
+    [ "$(jq -r 'select(.event == "learned_rule_commit") | .proposal_hash' "$DR_ORCH_LEARNED_AUDIT" | wc -l)" -eq 1 ]
+}
+
+@test "renewal changes validation time but not immutable creation or expiry" {
+    first="$(lr propose 'run plan' /dr-plan 0.9 alice s-1)"
+    lr consume_callback "$first" Y alice s-1
+    export DR_ORCH_NOW_EPOCH=86500
+    second="$(lr propose 'run plan' /dr-plan 0.9 alice s-2)"
+    lr consume_callback "$second" Y alice s-2
+    [ "$(rule_value created_at)" = 100 ]
+    [ "$(rule_value last_validated_at)" = 86500 ]
+    [ "$(rule_value expires_at)" = 604900 ]
+}
+
+@test "expired rule requires a fresh creation window" {
+    first="$(lr propose 'run plan' /dr-plan 0.9 alice s-1)"
+    lr consume_callback "$first" Y alice s-1
+    export DR_ORCH_NOW_EPOCH=604900
+    second="$(lr propose 'run plan' /dr-plan 0.9 alice s-2)"
+    lr consume_callback "$second" Y alice s-2
+    [ "$(rule_value created_at)" = 604900 ]
+    [ "$(rule_value expires_at)" = 1209700 ]
+}
+
+@test "maintenance preserves due rules and atomically purges expiry equality" {
+    id="$(lr propose 'run plan' /dr-plan 0.9 alice s-1)"
+    lr consume_callback "$id" Y alice s-1
+    export DR_ORCH_NOW_EPOCH=86500
+    lr maintenance
+    [ "$(jq '.patterns | length' "$DR_ORCH_RULES_LEARNED")" -eq 1 ]
+    export DR_ORCH_NOW_EPOCH=604900
+    lr maintenance
+    [ "$(jq '.patterns | length' "$DR_ORCH_RULES_LEARNED")" -eq 0 ]
+    [ "$(stat -c %a "$DR_ORCH_RULES_LEARNED")" = 600 ]
+}
+
+@test "stale same-match proposal loses after another proposal commits" {
+    first="$(lr propose 'run plan' /dr-plan 0.9 alice s-1)"
+    second="$(lr propose 'run plan' /dr-plan 0.8 bob s-2)"
+    lr consume_callback "$first" Y alice s-1
+    before="$(sha256sum "$DR_ORCH_RULES_LEARNED")"
+    run lr consume_callback "$second" Y bob s-2
+    [ "$status" -ne 0 ]
+    [ "$(sha256sum "$DR_ORCH_RULES_LEARNED")" = "$before" ]
+}
+
+@test "symlinked state targets fail closed" {
+    mkdir -p "$BATS_TEST_TMPDIR/real-state"
+    ln -s "$BATS_TEST_TMPDIR/real-state" "$DR_ORCH_STATE_DIR"
+    run lr propose 'run plan' /dr-plan 0.9 alice s-1
+    [ "$status" -ne 0 ]
+    [ -z "$(find "$BATS_TEST_TMPDIR/real-state" -mindepth 1 -print -quit)" ]
+}
+
+@test "maintenance purges proposals and tombstones at inclusive boundaries" {
+    id="$(lr propose 'run plan' /dr-plan 0.9 alice s-1)"
+    export DR_ORCH_NOW_EPOCH=1000
+    lr maintenance
+    run lr consume_callback "$id" Y alice s-1
+    [ "$status" -ne 0 ]
+
+    export DR_ORCH_NOW_EPOCH=1100
+    id2="$(lr propose 'run qa' /dr-qa 0.9 alice s-2)"
+    lr consume_callback "$id2" N alice s-2
+    export DR_ORCH_NOW_EPOCH=605900
+    lr maintenance
+    [ -z "$(find "$DR_ORCH_STATE_DIR/learned-rule-tombstones" -name '*.json' -print -quit)" ]
+}
+
+@test "entropy failure and capability reuse fail closed" {
+    export DR_ORCH_TEST_ENTROPY_FAIL=1
+    run lr propose 'run plan' /dr-plan 0.9 alice s-1
+    [ "$status" -ne 0 ]
+    unset DR_ORCH_TEST_ENTROPY_FAIL
+    DR_ORCH_TEST_ENTROPY_HEX="$(printf 'a%.0s' {1..64})"
+    export DR_ORCH_TEST_ENTROPY_HEX
+    run lr propose 'run plan' /dr-plan 0.9 alice s-1
+    [ "$status" -eq 0 ]
+    run lr propose 'run qa' /dr-qa 0.9 bob s-2
+    [ "$status" -ne 0 ]
+}
+
+@test "callback capability rejects tampered bound proposal fields" {
+    id="$(lr propose 'run plan' /dr-plan 0.9 alice s-1)"
+    proposal="$(find "$DR_ORCH_STATE_DIR/learned-rule-proposals" -name '*.json')"
+    jq -c '.match="run qa"' "$proposal" >"$proposal.tmp"
+    mv "$proposal.tmp" "$proposal"
+    chmod 600 "$proposal"
+    run lr consume_callback "$id" Y alice s-1
+    [ "$status" -ne 0 ]
+    [ ! -e "$DR_ORCH_RULES_LEARNED" ]
+}
+
+@test "corrupted learned YAML fails closed without replacement" {
+    mkdir -p "$DR_ORCH_STATE_DIR"
+    chmod 700 "$DR_ORCH_STATE_DIR"
+    printf 'patterns: [not-valid\n' >"$DR_ORCH_RULES_LEARNED"
+    chmod 600 "$DR_ORCH_RULES_LEARNED"
+    before="$(sha256sum "$DR_ORCH_RULES_LEARNED")"
+    run lr propose 'run plan' /dr-plan 0.9 alice s-1
+    [ "$status" -ne 0 ]
+    [ "$(sha256sum "$DR_ORCH_RULES_LEARNED")" = "$before" ]
+}
+
+@test "manual extended TTL and fractional lifecycle state is rejected" {
+    mkdir -p "$DR_ORCH_STATE_DIR"
+    chmod 700 "$DR_ORCH_STATE_DIR"
+    cat >"$DR_ORCH_RULES_LEARNED" <<'JSON'
+{"patterns":[{"match":"run plan","action":"/dr-plan","confidence":0.9,"created_at":1.5,"last_validated_at":2,"expires_at":9999999999,"proposal_hash":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","generation":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"}]}
+JSON
+    chmod 600 "$DR_ORCH_RULES_LEARNED"
+    before="$(sha256sum "$DR_ORCH_RULES_LEARNED")"
+    run lr maintenance
+    [ "$status" -ne 0 ]
+    [ "$(sha256sum "$DR_ORCH_RULES_LEARNED")" = "$before" ]
+}
+
+@test "distinct callbacks commit concurrently without lost updates" {
+    first="$(lr propose 'run plan' /dr-plan 0.9 alice s-1)"
+    second="$(lr propose 'run qa' /dr-qa 0.9 bob s-2)"
+    lr consume_callback "$first" Y alice s-1 >"$BATS_TEST_TMPDIR/first.out" 2>&1 & p1=$!
+    lr consume_callback "$second" Y bob s-2 >"$BATS_TEST_TMPDIR/second.out" 2>&1 & p2=$!
+    wait "$p1"; r1=$?; wait "$p2"; r2=$?
+    [ "$r1" -eq 0 ] && [ "$r2" -eq 0 ]
+    [ "$(jq -r '[.patterns[].match] | sort | join(",")' "$DR_ORCH_RULES_LEARNED")" = 'run plan,run qa' ]
+}
+
+@test "same callback has exactly one concurrent consumer" {
+    id="$(lr propose 'run plan' /dr-plan 0.9 alice s-1)"
+    set +e
+    lr consume_callback "$id" Y alice s-1 >/dev/null 2>&1 & p1=$!
+    lr consume_callback "$id" Y alice s-1 >/dev/null 2>&1 & p2=$!
+    wait "$p1"; r1=$?; wait "$p2"; r2=$?
+    set -e
+    [ $(( (r1 == 0) + (r2 == 0) )) -eq 1 ]
+    [ "$(jq '.patterns | length' "$DR_ORCH_RULES_LEARNED")" -eq 1 ]
+}
+
+@test "lifecycle constants ignore environment overrides" {
+    export LEARNED_RULE_PROPOSAL_TTL=9999 LEARNED_RULE_LIFETIME=9999
+    export LEARNED_RULE_REVALIDATE_AFTER=9999 LEARNED_RULE_PROPOSAL_CAP=1
+    id="$(lr propose 'run plan' /dr-plan 0.9 alice s-1)"
+    proposal="$(find "$DR_ORCH_STATE_DIR/learned-rule-proposals" -name '*.json')"
+    [ "$(jq -r '.expires_at' "$proposal")" -eq 1000 ]
+    lr consume_callback "$id" Y alice s-1
+    [ "$(jq -r '.patterns[0].expires_at' "$DR_ORCH_RULES_LEARNED")" -eq 604900 ]
+}
+
+@test "proposal and rule caps fail closed at immutable boundaries" {
+    mkdir -p "$DR_ORCH_STATE_DIR/learned-rule-proposals"
+    chmod 700 "$DR_ORCH_STATE_DIR" "$DR_ORCH_STATE_DIR/learned-rule-proposals"
+    for n in $(seq 1 128); do
+        printf '{"expires_at":1000}\n' >"$DR_ORCH_STATE_DIR/learned-rule-proposals/$n.json"
+        chmod 600 "$DR_ORCH_STATE_DIR/learned-rule-proposals/$n.json"
+    done
+    run lr propose 'run plan three' /dr-plan 0.9 carol s-3
+    [ "$status" -ne 0 ]
+
+    rm -rf "$DR_ORCH_STATE_DIR"
+    second="$(lr propose 'run qa' /dr-qa 0.9 bob s-2)"
+    mkdir -p "$DR_ORCH_STATE_DIR"
+    jq -cn '[range(0;256) | {match:("seed " + tostring),action:"/dr-plan",confidence:0.9,
+      created_at:100,last_validated_at:100,expires_at:604900,
+      proposal_hash:("a"*64),generation:("b"*64)}] | {patterns:.}' \
+      >"$DR_ORCH_RULES_LEARNED"
+    chmod 600 "$DR_ORCH_RULES_LEARNED"
+    run lr consume_callback "$second" Y bob s-2
+    [ "$status" -ne 0 ]
+    [ "$(jq '.patterns | length' "$DR_ORCH_RULES_LEARNED")" -eq 256 ]
+}
+
+@test "delivery and tombstone byte caps fail closed" {
+    mkdir -p "$DR_ORCH_STATE_DIR/learned-rule-delivery"
+    chmod 700 "$DR_ORCH_STATE_DIR" "$DR_ORCH_STATE_DIR/learned-rule-delivery"
+    printf '%65536s' x >"$DR_ORCH_STATE_DIR/learned-rule-delivery/full.json"
+    chmod 600 "$DR_ORCH_STATE_DIR/learned-rule-delivery/full.json"
+    run lr propose 'run plan' /dr-plan 0.9 alice s-1
+    [ "$status" -ne 0 ]
+    [ "$(proposal_count)" -eq 1 ]
+
+    rm -rf "$DR_ORCH_STATE_DIR"
+    id="$(lr propose 'run plan' /dr-plan 0.9 alice s-1)"
+    mkdir -p "$DR_ORCH_STATE_DIR/learned-rule-tombstones"
+    printf '{"consumed_at":100,"padding":"' \
+      >"$DR_ORCH_STATE_DIR/learned-rule-tombstones/full.json"
+    head -c 1048576 /dev/zero | tr '\0' x \
+      >>"$DR_ORCH_STATE_DIR/learned-rule-tombstones/full.json"
+    printf '"}\n' >>"$DR_ORCH_STATE_DIR/learned-rule-tombstones/full.json"
+    chmod 600 "$DR_ORCH_STATE_DIR/learned-rule-tombstones/full.json"
+    run lr consume_callback "$id" N alice s-1
+    [ "$status" -ne 0 ]
+    [ "$(proposal_count)" -eq 1 ]
+}
+
+@test "proposal directory and learned target symlinks are rejected" {
+    mkdir -p "$DR_ORCH_STATE_DIR" "$BATS_TEST_TMPDIR/elsewhere"
+    chmod 700 "$DR_ORCH_STATE_DIR" "$BATS_TEST_TMPDIR/elsewhere"
+    ln -s "$BATS_TEST_TMPDIR/elsewhere" "$DR_ORCH_STATE_DIR/learned-rule-proposals"
+    run lr propose 'run plan' /dr-plan 0.9 alice s-1
+    [ "$status" -ne 0 ]
+    rm "$DR_ORCH_STATE_DIR/learned-rule-proposals"
+    printf 'victim\n' >"$BATS_TEST_TMPDIR/victim"
+    ln -s "$BATS_TEST_TMPDIR/victim" "$DR_ORCH_RULES_LEARNED"
+    run lr propose 'run plan' /dr-plan 0.9 alice s-1
+    [ "$status" -ne 0 ]
+    [ "$(cat "$BATS_TEST_TMPDIR/victim")" = victim ]
+}
+
+@test "proposal-file and intermediate symlinks plus unsafe modes fail closed" {
+    mkdir -p "$DR_ORCH_STATE_DIR/learned-rule-proposals"
+    chmod 700 "$DR_ORCH_STATE_DIR" "$DR_ORCH_STATE_DIR/learned-rule-proposals"
+    printf 'victim\n' >"$BATS_TEST_TMPDIR/proposal-victim"
+    ln -s "$BATS_TEST_TMPDIR/proposal-victim" \
+      "$DR_ORCH_STATE_DIR/learned-rule-proposals/unsafe.json"
+    run lr maintenance
+    [ "$status" -ne 0 ]
+    [ "$(cat "$BATS_TEST_TMPDIR/proposal-victim")" = victim ]
+
+    rm -rf "$DR_ORCH_STATE_DIR"
+    mkdir -p "$DR_ORCH_STATE_DIR" "$BATS_TEST_TMPDIR/elsewhere"
+    chmod 700 "$DR_ORCH_STATE_DIR" "$BATS_TEST_TMPDIR/elsewhere"
+    ln -s "$BATS_TEST_TMPDIR/elsewhere" "$DR_ORCH_STATE_DIR/intermediate"
+    export DR_ORCH_PROPOSALS_DIR="$DR_ORCH_STATE_DIR/intermediate/proposals"
+    run lr propose 'run plan' /dr-plan 0.9 alice s-1
+    [ "$status" -ne 0 ]
+
+    unset DR_ORCH_PROPOSALS_DIR
+    rm -rf "$DR_ORCH_STATE_DIR"
+    mkdir -p "$DR_ORCH_STATE_DIR/learned-rule-proposals"
+    chmod 700 "$DR_ORCH_STATE_DIR" "$DR_ORCH_STATE_DIR/learned-rule-proposals"
+    printf '{}\n' >"$DR_ORCH_STATE_DIR/learned-rule-proposals/unsafe.json"
+    chmod 644 "$DR_ORCH_STATE_DIR/learned-rule-proposals/unsafe.json"
+    run lr maintenance
+    [ "$status" -ne 0 ]
+}
+
+@test "configured state path escape is rejected" {
+    export DR_ORCH_PROPOSALS_DIR="$BATS_TEST_TMPDIR/outside"
+    run lr propose 'run plan' /dr-plan 0.9 alice s-1
+    [ "$status" -ne 0 ]
+    [ ! -e "$BATS_TEST_TMPDIR/outside" ]
+}
+
+@test "configured state ancestor symlink is rejected" {
+    mkdir -p "$BATS_TEST_TMPDIR/real"
+    ln -s "$BATS_TEST_TMPDIR/real" "$BATS_TEST_TMPDIR/link"
+    export DR_ORCH_STATE_DIR="$BATS_TEST_TMPDIR/link/state"
+    unset DR_ORCH_RULES_LEARNED DR_ORCH_PROPOSALS_DIR DR_ORCH_TOMBSTONES_DIR DR_ORCH_DELIVERY_DIR
+    run lr propose 'run plan' /dr-plan 0.9 alice s-1
+    [ "$status" -ne 0 ]
+    [ ! -e "$BATS_TEST_TMPDIR/real/state" ]
+}
+
+@test "secure state read rejects replacement between validation and use" {
+    target="$BATS_TEST_TMPDIR/replace.json"
+    printf 'trusted\n' >"$target"
+    chmod 600 "$target"
+    run bash -c '
+      source "$1/scripts/lib/learned-rules-common.sh"
+      portable_identity() {
+        if [[ "$1" != /dev/fd/* ]]; then
+          mv "$1" "$1.original"
+          printf "replaced\\n" >"$1"
+          chmod 600 "$1"
+        fi
+        stat -Lc "%d:%i" -- "$1"
+      }
+      learned_rules_read_secure "$2"
+    ' _ "$PLUGIN_ROOT" "$target"
+    [ "$status" -ne 0 ]
+    [[ "$output" != *replaced* ]]
+}
+
+@test "shared lock symlink is rejected without victim mutation" {
+    mkdir -p "$DR_ORCH_STATE_DIR"
+    chmod 700 "$DR_ORCH_STATE_DIR"
+    printf 'LOCK-VICTIM' >"$BATS_TEST_TMPDIR/lock-victim"
+    ln -s "$BATS_TEST_TMPDIR/lock-victim" "$DR_ORCH_STATE_DIR/.learned-rules.lock"
+    run lr propose 'run plan' /dr-plan 0.9 alice s-1
+    [ "$status" -ne 0 ]
+    [ "$(cat "$BATS_TEST_TMPDIR/lock-victim")" = LOCK-VICTIM ]
+}
+
+@test "shared lock contention is bounded" {
+    lr maintenance
+    flock -x "$DR_ORCH_STATE_DIR/.learned-rules.lock" -c 'sleep 2' & holder=$!
+    sleep 0.1
+    export DR_ORCH_LOCK_TIMEOUT_S=1
+    run lr propose 'run plan' /dr-plan 0.9 alice s-1
+    [ "$status" -ne 0 ]
+    wait "$holder"
+}
+
+@test "prepare audit failure prevents mutation and commit failure reconciles once" {
+    id="$(lr propose 'run plan' /dr-plan 0.9 alice s-1)"
+    export DR_ORCH_TEST_AUDIT_FAIL_EVENT=learned_rule_prepare
+    run lr consume_callback "$id" Y alice s-1
+    [ "$status" -ne 0 ] && [ ! -e "$DR_ORCH_RULES_LEARNED" ]
+    unset DR_ORCH_TEST_AUDIT_FAIL_EVENT
+
+    export DR_ORCH_TEST_AUDIT_FAIL_EVENT=learned_rule_commit
+    run lr consume_callback "$id" Y alice s-1
+    [ "$status" -ne 0 ] && [ -s "$DR_ORCH_RULES_LEARNED" ]
+    unset DR_ORCH_TEST_AUDIT_FAIL_EVENT
+    run lr maintenance
+    [ "$status" -eq 0 ]
+    [ "$(jq -r 'select(.event=="learned_rule_commit") | .proposal_hash' "$DR_ORCH_LEARNED_AUDIT" | wc -l)" -eq 1 ]
+    ! grep -Fq "$id" "$DR_ORCH_LEARNED_AUDIT"
+}
+
+@test "day-rotated maintenance does not duplicate a prior commit" {
+    mkdir -p "$BATS_TEST_TMPDIR/audit"
+    chmod 700 "$BATS_TEST_TMPDIR/audit"
+    export DR_ORCH_LEARNED_AUDIT="$BATS_TEST_TMPDIR/audit/audit-2026-07-17.jsonl"
+    id="$(lr propose 'run plan' /dr-plan 0.9 alice s-1)"
+    proposal_hash="$(basename "$(find "$DR_ORCH_STATE_DIR/learned-rule-proposals" -name '*.json')" .json)"
+    export DR_ORCH_TEST_ATOMIC_FAIL_BASENAME="$proposal_hash.json"
+    run lr consume_callback "$id" Y alice s-1
+    [ "$status" -ne 0 ]
+    [ "$(jq -s '[.[]|select(.event=="learned_rule_commit")]|length' "$DR_ORCH_LEARNED_AUDIT")" -eq 1 ]
+    unset DR_ORCH_TEST_ATOMIC_FAIL_BASENAME
+    export DR_ORCH_LEARNED_AUDIT="$BATS_TEST_TMPDIR/audit/audit-2026-07-18.jsonl"
+    run lr maintenance
+    [ "$status" -eq 0 ]
+    [ "$(jq -s '[.[]|select(.event=="learned_rule_commit")]|length' \
+      "$BATS_TEST_TMPDIR"/audit/audit-*.jsonl)" -eq 1 ]
+}
+
+@test "standalone callback writes the canonical daily audit ledger" {
+    unset DR_ORCH_LEARNED_AUDIT DR_ORCH_AUDIT_FILE
+    export AUDIT_DIR="$BATS_TEST_TMPDIR/canonical-audit"
+    id="$(lr propose 'run plan' /dr-plan 0.9 alice s-1)"
+    run "$PLUGIN_ROOT/scripts/plugin.sh" dispatch on_callback "$id" Y alice s-1
+    [ "$status" -eq 0 ]
+    audit="$AUDIT_DIR/audit-$(date -u +%Y-%m-%d).jsonl"
+    [ -s "$audit" ]
+    jq -s -e 'any(.[]; .event=="learned_rule_prepare") and
+      any(.[]; .event=="learned_rule_commit")' "$audit"
+    [ ! -e "$DR_ORCH_STATE_DIR/learned-rule-audit.jsonl" ]
+}
+
+@test "callback binds space and persists non-overridable framework action kind" {
+    export DATARIM_ACTIVE_SPACE=space-a
+    id="$(lr propose 'run plan' /dr-plan 0.9 alice s-1)"
+    proposal="$(find "$DR_ORCH_STATE_DIR/learned-rule-proposals" -name '*.json')"
+    jq -e '.space=="space-a" and .action_kind=="framework_command"' "$proposal"
+    export DATARIM_ACTIVE_SPACE=space-b
+    run lr consume_callback "$id" Y alice s-1
+    [ "$status" -ne 0 ]
+    export DATARIM_ACTIVE_SPACE=space-a
+    run lr consume_callback "$id" Y alice s-1
+    [ "$status" -eq 0 ]
+}

--- a/plugins/dr-orchestrate/tests/test_phase3_audit_recovery.bats
+++ b/plugins/dr-orchestrate/tests/test_phase3_audit_recovery.bats
@@ -1,0 +1,102 @@
+#!/usr/bin/env bats
+
+setup() {
+  PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  chmod 700 "$BATS_TEST_TMPDIR"
+  AUDIT_FILE="$BATS_TEST_TMPDIR/audit.jsonl"
+}
+
+@test "V-AC-25: trailing prepare is marked interrupted exactly once" {
+  run bash -c '
+    source "$1/scripts/audit_sink.sh"
+    emit "$2" "$(make_cycle_checkpoint prepare cycle-1 session-a %1 /dr-plan pending)"
+    recover_cycle_checkpoint "$2" session-a %1
+    recover_cycle_checkpoint "$2" session-a %1
+    jq -s -e '\''[.[] | select(.phase=="recovery" and .outcome=="recovered_interrupted")] | length == 1'\'' "$2"
+  ' _ "$PLUGIN_ROOT" "$AUDIT_FILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "V-AC-25: terminal checkpoint prevents recovery" {
+  run bash -c '
+    source "$1/scripts/audit_sink.sh"
+    emit "$2" "$(make_cycle_checkpoint prepare cycle-2 session-a %1 /dr-plan pending)"
+    emit "$2" "$(make_cycle_checkpoint terminal cycle-2 session-a %1 /dr-plan delivered exit_0)"
+    recover_cycle_checkpoint "$2" session-a %1
+    jq -s -e '\''[.[] | select(.phase=="recovery")] | length == 0'\'' "$2"
+  ' _ "$PLUGIN_ROOT" "$AUDIT_FILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "V-AC-25: recovery never invokes an executor seam" {
+  executor="$BATS_TEST_TMPDIR/executor.log"
+  run env DR_ORCH_ACTION_EXECUTOR_LOG="$executor" bash -c '
+    source "$1/scripts/audit_sink.sh"
+    emit "$2" "$(make_cycle_checkpoint prepare cycle-3 session-a %1 /dr-plan pending)"
+    recover_cycle_checkpoint "$2" session-a %1
+    test ! -e "$DR_ORCH_ACTION_EXECUTOR_LOG"
+  ' _ "$PLUGIN_ROOT" "$AUDIT_FILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "V-AC-29: audit lock symlink is rejected without victim mutation" {
+  victim="$BATS_TEST_TMPDIR/victim"
+  printf 'DO-NOT-TRUNCATE' >"$victim"
+  ln -s "$victim" "$AUDIT_FILE.lock"
+  run bash "$PLUGIN_ROOT/scripts/audit_sink.sh" emit "$AUDIT_FILE" '{}'
+  [ "$status" -ne 0 ]
+  [ "$(cat "$victim")" = DO-NOT-TRUNCATE ]
+}
+
+@test "V-AC-25: concurrent recovery emits exactly one marker" {
+  run bash -c '
+    source "$1/scripts/audit_sink.sh"
+    emit "$2" "$(make_cycle_checkpoint prepare cycle-race session-a %1 /dr-plan pending)"
+    pids=()
+    for _ in $(seq 1 16); do recover_cycle_checkpoint "$2" session-a %1 & pids+=("$!"); done
+    for pid in "${pids[@]}"; do wait "$pid"; done
+    test "$(jq -s '\''[.[] | select(.phase=="recovery")] | length'\'' "$2")" -eq 1
+  ' _ "$PLUGIN_ROOT" "$AUDIT_FILE"
+  [ "$status" -eq 0 ]
+}
+
+@test "V-AC-25: recovery crosses a UTC day rotation" {
+  old="$BATS_TEST_TMPDIR/audit-2026-07-17.jsonl"
+  current="$BATS_TEST_TMPDIR/audit-2026-07-18.jsonl"
+  run bash -c '
+    source "$1/scripts/audit_sink.sh"
+    emit "$2" "$(make_cycle_checkpoint prepare cycle-midnight session-a %1 /dr-plan pending)"
+    pids=()
+    for _ in $(seq 1 16); do
+      recover_latest_cycle_checkpoint "$(dirname "$2")" "$3" session-a %1 & pids+=("$!")
+    done
+    for pid in "${pids[@]}"; do wait "$pid"; done
+    test "$(jq -s '\''[.[] | select(.phase=="recovery" and .cycle_id=="cycle-midnight")] | length'\'' "$3")" -eq 1
+  ' _ "$PLUGIN_ROOT" "$old" "$current"
+  [ "$status" -eq 0 ]
+}
+
+@test "legacy owner-controlled 0644 audit migrates to private mode" {
+  printf '{}\n' >"$AUDIT_FILE"
+  chmod 0644 "$AUDIT_FILE"
+  run bash "$PLUGIN_ROOT/scripts/audit_sink.sh" emit "$AUDIT_FILE" '{}'
+  [ "$status" -eq 0 ]
+  [ "$(bash -c 'source "$1/scripts/lib/portable-stat.sh"; portable_mode "$2"' \
+    _ "$PLUGIN_ROOT" "$AUDIT_FILE")" = 600 ]
+  [ "$(wc -l <"$AUDIT_FILE")" -eq 2 ]
+}
+
+@test "descriptor validation is portable and does not depend on procfs" {
+  run grep -R -Fq '/proc/' "$PLUGIN_ROOT/scripts/audit_sink.sh" \
+    "$PLUGIN_ROOT/scripts/lib/learned-rules-store.sh"
+  [ "$status" -ne 0 ]
+  grep -qF 'portable_identity "/dev/fd/' "$PLUGIN_ROOT/scripts/audit_sink.sh"
+  grep -qF 'portable_identity /dev/fd/9' "$PLUGIN_ROOT/scripts/lib/learned-rules-store.sh"
+}
+
+@test "group-writable audit parent is rejected" {
+  chmod 0777 "$BATS_TEST_TMPDIR"
+  run bash "$PLUGIN_ROOT/scripts/audit_sink.sh" emit "$AUDIT_FILE" '{}'
+  [ "$status" -ne 0 ]
+  [ ! -e "$AUDIT_FILE" ]
+}

--- a/plugins/dr-orchestrate/tests/test_plugin_register.bats
+++ b/plugins/dr-orchestrate/tests/test_plugin_register.bats
@@ -4,6 +4,8 @@
 setup() {
     PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
     export DR_ORCH_DIR="$PLUGIN_ROOT"
+    export DR_ORCH_STATE_DIR="$BATS_TEST_TMPDIR/state"
+    export AUDIT_DIR="$BATS_TEST_TMPDIR/audit"
 }
 
 @test "V-AC-1: plugin.yaml registers id dr-orchestrate" {
@@ -27,10 +29,10 @@ setup() {
     [ "$status" -eq 0 ]
 }
 
-@test "V-AC-15: get_autonomy returns 2 (TUNE-0165 bumps L1→L2)" {
+@test "V-AC-28: get_autonomy returns 4 for Phase 3" {
     run bash "$DR_ORCH_DIR/scripts/plugin.sh" get_autonomy
     [ "$status" -eq 0 ]
-    [ "$output" = "2" ]
+    [ "$output" = "4" ]
 }
 
 @test "V-AC-16: dispatch on_unknown_prompt routes to cmd_run.sh" {
@@ -50,4 +52,10 @@ setup() {
     # Structural check independent of bash version: the dispatch case exists.
     run grep -E '^[[:space:]]*on_unknown_prompt\)' "$DR_ORCH_DIR/scripts/plugin.sh"
     [ "$status" -eq 0 ]
+}
+
+@test "V-AC-28: transport-neutral callback hook is wired to learned lifecycle" {
+    run grep -E '^[[:space:]]*on_callback\)' "$DR_ORCH_DIR/scripts/plugin.sh"
+    [ "$status" -eq 0 ]
+    grep -qF 'learned_rules.sh" consume_callback' "$DR_ORCH_DIR/scripts/plugin.sh"
 }

--- a/plugins/dr-orchestrate/tests/test_resolver_history.bats
+++ b/plugins/dr-orchestrate/tests/test_resolver_history.bats
@@ -1,0 +1,270 @@
+#!/usr/bin/env bats
+
+setup() {
+  PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  RESOLVER="$PLUGIN_ROOT/scripts/resolver.sh"
+  export HOME="$BATS_TEST_TMPDIR/home"
+  export DR_ORCH_STATE_DIR="$BATS_TEST_TMPDIR/state"
+  export STATE_DIR="$DR_ORCH_STATE_DIR"
+  export DR_ORCH_RULES_DEFAULT="$BATS_TEST_TMPDIR/default.yaml"
+  export DR_ORCH_RULES_USER="$BATS_TEST_TMPDIR/user.yaml"
+  export DR_ORCH_RULES_LEARNED="$BATS_TEST_TMPDIR/learned.yaml"
+  export DR_ORCH_AUDIT_FILE="$BATS_TEST_TMPDIR/audit.jsonl"
+  mkdir -p "$HOME"
+
+  cat > "$DR_ORCH_RULES_DEFAULT" <<'YAML'
+patterns:
+  - match: plan
+    action: "/dr-plan"
+    confidence: 0.95
+  - match: do
+    action: "/dr-do"
+    confidence: 0.95
+  - match: qa
+    action: "/dr-qa"
+    confidence: 0.95
+  - match: status
+    action: "/dr-status"
+    confidence: 0.95
+YAML
+  printf 'patterns: []\n' > "$DR_ORCH_RULES_USER"
+  printf 'patterns: []\n' > "$DR_ORCH_RULES_LEARNED"
+}
+
+run_resolver() {
+  run "$RESOLVER" "$@"
+}
+
+history_file() {
+  printf '%s/resolver-history.jsonl\n' "$DR_ORCH_STATE_DIR"
+}
+
+@test "record normalizes intent, canonicalizes trusted dr action, and hardens state" {
+  run_resolver record $'  tune\t  request  ' dr-plan 1
+  [ "$status" -eq 0 ] || { printf '%s\n' "$output"; return 1; }
+
+  local history
+  history="$(history_file)"
+  [ "$(jq -r '.intent' "$history")" = "tune request" ] \
+    && [ "$(jq -r '.action' "$history")" = "/dr-plan" ] \
+    && [ "$(jq -r '.exit_code' "$history")" = "1" ] \
+    && [ "$(stat -c '%a' "$DR_ORCH_STATE_DIR")" = "700" ] \
+    && [ "$(stat -c '%a' "$history")" = "600" ] \
+    && [ "$(stat -c '%a' "$DR_ORCH_STATE_DIR/.resolver-history.lock")" = "600" ]
+}
+
+@test "record accepts a trusted explicit user action" {
+  cat > "$DR_ORCH_RULES_USER" <<'YAML'
+patterns:
+  - match: custom
+    action: "/dr-custom"
+    confidence: 0.90
+YAML
+
+  run_resolver record tune dr-custom 0
+  [ "$status" -eq 0 ] \
+    && [ "$(jq -r '.action' "$(history_file)")" = "/dr-custom" ]
+}
+
+@test "record rejects actions absent from the default and user registry" {
+  run_resolver record tune dr-unknown 0
+  [ "$status" -ne 0 ] \
+    && [ ! -e "$(history_file)" ]
+}
+
+@test "learned rules never extend the trusted registry" {
+  cat > "$DR_ORCH_RULES_LEARNED" <<'YAML'
+patterns:
+  - match: learned
+    action: "/dr-learned-only"
+    confidence: 1.0
+YAML
+
+  run_resolver record tune dr-learned-only 0
+  [ "$status" -ne 0 ] \
+    && [ ! -e "$(history_file)" ]
+}
+
+@test "invalid intents and exit codes are rejected without mutation" {
+  local candidate
+  for candidate in "" "-option" "../escape" "path/component" 'x;touch-canary' $'line\nbreak' $'bad\xFF'; do
+    run_resolver record "$candidate" dr-plan 0
+    [ "$status" -ne 0 ] || return 1
+  done
+  run_resolver record tune dr-plan not-an-integer
+  [ "$status" -ne 0 ] || return 1
+  run_resolver record tune dr-plan 256
+  [ "$status" -ne 0 ] \
+    && [ ! -e "$(history_file)" ]
+}
+
+@test "shell metacharacter input is inert as well as rejected" {
+  local canary="$BATS_TEST_TMPDIR/injection-canary"
+  run_resolver record '$(touch '"$canary"')' dr-plan 0
+  [ "$status" -ne 0 ] \
+    && [ ! -e "$canary" ] \
+    && [ ! -e "$(history_file)" ]
+}
+
+@test "suggest returns the sole trusted failed action for compatibility" {
+  run_resolver record tune dr-plan 1
+  [ "$status" -eq 0 ] || return 1
+  run_resolver suggest_alternative tune
+  [ "$status" -eq 0 ] \
+    && [ "$output" = "/dr-plan" ]
+}
+
+@test "ranking prefers success count descending" {
+  run_resolver record tune dr-plan 0
+  run_resolver record tune dr-do 0
+  run_resolver record tune dr-do 0
+  run_resolver suggest_alternative tune
+  [ "$status" -eq 0 ] \
+    && [ "$output" = "/dr-do" ]
+}
+
+@test "a successful distinct alternative outranks a repeatedly failed action" {
+  run_resolver record tune dr-plan 1
+  run_resolver record tune dr-plan 2
+  run_resolver record tune dr-plan 3
+  run_resolver record tune dr-do 0
+  run_resolver suggest_alternative tune
+  [ "$status" -eq 0 ] \
+    && [ "$output" = "/dr-do" ]
+}
+
+@test "ranking prefers failure count ascending after equal success count" {
+  run_resolver record tune dr-plan 0
+  run_resolver record tune dr-plan 1
+  run_resolver record tune dr-do 0
+  run_resolver suggest_alternative tune
+  [ "$status" -eq 0 ] \
+    && [ "$output" = "/dr-do" ]
+}
+
+@test "ranking prefers latest success descending after equal counts" {
+  DR_ORCH_NOW_EPOCH=100 run_resolver record tune dr-plan 0
+  DR_ORCH_NOW_EPOCH=200 run_resolver record tune dr-do 0
+  run_resolver suggest_alternative tune
+  [ "$status" -eq 0 ] \
+    && [ "$output" = "/dr-do" ]
+}
+
+@test "ranking uses lexical action as the deterministic final tie-break" {
+  DR_ORCH_NOW_EPOCH=100 run_resolver record tune dr-plan 0
+  DR_ORCH_NOW_EPOCH=100 run_resolver record tune dr-do 0
+  run_resolver suggest_alternative tune
+  [ "$status" -eq 0 ] \
+    && [ "$output" = "/dr-do" ]
+}
+
+@test "suggest normalizes whitespace but preserves case distinctions" {
+  run_resolver record $' tune\trequest ' dr-plan 0
+  run_resolver record "Tune request" dr-do 0
+  run_resolver suggest_alternative "  tune   request"
+  [ "$status" -eq 0 ] \
+    && [ "$output" = "/dr-plan" ]
+}
+
+@test "corrupt history is ignored and produces an audit event" {
+  mkdir -p "$DR_ORCH_STATE_DIR"
+  chmod 700 "$DR_ORCH_STATE_DIR"
+  {
+    printf '%s\n' '{broken-json'
+    jq -nc '{intent:"tune",action:"/dr-plan",exit_code:0,timestamp:100}'
+  } > "$(history_file)"
+  chmod 600 "$(history_file)"
+
+  run_resolver suggest_alternative tune
+  [ "$status" -eq 0 ] \
+    && [ "$output" = "/dr-plan" ] \
+    && [ "$(stat -c '%a' "$DR_ORCH_AUDIT_FILE")" = "600" ] \
+    && jq -e 'select(.event_type == "resolver_history_corrupt" and .corrupt_count == 1)' \
+      "$DR_ORCH_AUDIT_FILE" >/dev/null
+}
+
+@test "manually injected untrusted actions are never suggested" {
+  mkdir -p "$DR_ORCH_STATE_DIR"
+  chmod 700 "$DR_ORCH_STATE_DIR"
+  jq -nc '{intent:"tune",action:"/dr-untrusted",exit_code:0,timestamp:100}' \
+    > "$(history_file)"
+  chmod 600 "$(history_file)"
+
+  run_resolver suggest_alternative tune
+  [ "$status" -eq 0 ] \
+    && [ -z "$output" ]
+}
+
+@test "rotation retains exactly the newest 5000 valid records" {
+  mkdir -p "$DR_ORCH_STATE_DIR"
+  chmod 700 "$DR_ORCH_STATE_DIR"
+  local i
+  for i in $(seq 1 5001); do
+    jq -nc --argjson ts "$i" \
+      '{intent:"tune",action:"/dr-plan",exit_code:0,timestamp:$ts}'
+  done > "$(history_file)"
+  chmod 600 "$(history_file)"
+
+  DR_ORCH_NOW_EPOCH=6000 run_resolver record tune dr-do 0
+  [ "$status" -eq 0 ] \
+    && [ "$(wc -l < "$(history_file)")" -eq 5000 ] \
+    && [ "$(head -1 "$(history_file)" | jq -r '.timestamp')" -eq 3 ] \
+    && [ "$(tail -1 "$(history_file)" | jq -r '.timestamp')" -eq 6000 ]
+}
+
+@test "rotation caps valid history at one MiB while retaining the newest suffix" {
+  mkdir -p "$DR_ORCH_STATE_DIR"
+  chmod 700 "$DR_ORCH_STATE_DIR"
+  python3 - "$(history_file)" <<'PY'
+import json
+import sys
+
+path = sys.argv[1]
+intent = "x" * 240
+with open(path, "w", encoding="utf-8") as stream:
+    for stamp in range(1, 4001):
+        stream.write(json.dumps({
+            "intent": intent,
+            "action": "/dr-plan",
+            "exit_code": 0,
+            "timestamp": stamp,
+        }, separators=(",", ":")) + "\n")
+PY
+  chmod 600 "$(history_file)"
+
+  DR_ORCH_NOW_EPOCH=5000 run_resolver record tune dr-do 0
+  [ "$status" -eq 0 ] \
+    && [ "$(wc -c < "$(history_file)")" -le 1048576 ] \
+    && [ "$(tail -1 "$(history_file)" | jq -r '.timestamp')" -eq 5000 ] \
+    && [ "$(head -1 "$(history_file)" | jq -r '.timestamp')" -gt 1 ]
+}
+
+@test "concurrent records all survive the shared history lock" {
+  run bash -c '
+    set -euo pipefail
+    resolver="$1"
+    for i in $(seq 1 40); do
+      DR_ORCH_NOW_EPOCH="$i" "$resolver" record tune dr-plan 0 &
+    done
+    wait
+  ' _ "$RESOLVER"
+  [ "$status" -eq 0 ] \
+    && [ "$(wc -l < "$(history_file)")" -eq 40 ] \
+    && [ "$(jq -s 'map(.timestamp) | unique | length' "$(history_file)")" -eq 40 ]
+}
+
+@test "symlinked state and history paths fail closed" {
+  local outside="$BATS_TEST_TMPDIR/outside"
+  mkdir -p "$outside"
+  ln -s "$outside" "$DR_ORCH_STATE_DIR"
+  run_resolver record tune dr-plan 0
+  [ "$status" -ne 0 ] || return 1
+
+  rm -f "$DR_ORCH_STATE_DIR"
+  mkdir -p "$DR_ORCH_STATE_DIR"
+  chmod 700 "$DR_ORCH_STATE_DIR"
+  ln -s "$outside/history" "$(history_file)"
+  run_resolver record tune dr-plan 0
+  [ "$status" -ne 0 ] \
+    && [ ! -e "$outside/history" ]
+}

--- a/plugins/dr-orchestrate/tests/test_rules_loader.bats
+++ b/plugins/dr-orchestrate/tests/test_rules_loader.bats
@@ -55,20 +55,62 @@ YAML
 @test "M1: learned override wins over user for same match key" {
     cat > "$DR_ORCH_RULES_USER" <<'YAML'
 patterns:
-  - match: "/dr-plan"
+  - match: "run plan"
     action: "/dr-plan"
     confidence: 0.85
 YAML
     cat > "$DR_ORCH_RULES_LEARNED" <<'YAML'
 patterns:
-  - match: "/dr-plan"
+  - match: "run plan"
     action: "/dr-plan"
     confidence: 0.70
+    created_at: 100
+    last_validated_at: 100
+    expires_at: 604900
+    proposal_hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    generation: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 YAML
+    export DR_ORCH_NOW_EPOCH=101
     run bash "$DR_ORCH_DIR/scripts/rules_loader.sh" load
     [ "$status" -eq 0 ]
-    conf=$(echo "$output" | jq '.[] | select(.match == "/dr-plan") | .confidence')
+    conf=$(echo "$output" | jq '.[] | select(.match == "run plan") | .confidence')
     [ "$conf" = "0.7" ]
+}
+
+@test "V-AC-24: due learned rules fail closed" {
+    cat > "$DR_ORCH_RULES_LEARNED" <<'YAML'
+patterns:
+  - match: "run plan"
+    action: "/dr-plan"
+    confidence: 0.90
+    created_at: 100
+    last_validated_at: 100
+    expires_at: 604900
+    proposal_hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    generation: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+YAML
+    export DR_ORCH_NOW_EPOCH=86500
+    run bash "$DR_ORCH_DIR/scripts/rules_loader.sh" load
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq '[.[] | select(.match == "run plan")] | length')" -eq 0 ]
+}
+
+@test "V-AC-29: malformed match, fractional epoch, and extended TTL fail closed" {
+    cat > "$DR_ORCH_RULES_LEARNED" <<'YAML'
+patterns:
+  - match: "bad;match"
+    action: "/dr-plan"
+    confidence: 0.9
+    created_at: 1.5
+    last_validated_at: 2
+    expires_at: 9999999999
+    proposal_hash: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+    generation: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+YAML
+    export DR_ORCH_NOW_EPOCH=3
+    run bash "$DR_ORCH_DIR/scripts/rules_loader.sh" load
+    [ "$status" -eq 0 ]
+    [ "$(echo "$output" | jq '[.[] | select(.provenance=="learned")] | length')" -eq 0 ]
 }
 
 @test "M1: missing user/learned files do not fail" {

--- a/plugins/dr-orchestrate/tests/test_semantic_parser.bats
+++ b/plugins/dr-orchestrate/tests/test_semantic_parser.bats
@@ -56,3 +56,9 @@ setup() {
     conf=$(echo "$out" | jq -r '.confidence')
     awk -v c="$conf" 'BEGIN{exit !(c==0.95)}'
 }
+
+@test "V-AC-28: parser returns the selected action and provenance" {
+    out=$(bash "$DR_ORCH_DIR/scripts/semantic_parser.sh" parse "/dr-plan TUNE-0166")
+    [ "$(echo "$out" | jq -r '.action')" = "/dr-plan" ]
+    [ "$(echo "$out" | jq -r '.provenance')" = "bundled" ]
+}

--- a/plugins/dr-orchestrate/tests/test_tmux_manager.bats
+++ b/plugins/dr-orchestrate/tests/test_tmux_manager.bats
@@ -48,7 +48,7 @@ teardown() {
     run pane_send "$target" "echo orchestrate-marker"
     [ "$status" -eq 0 ]
     sleep 0.3
-    run tmux capture-pane -p -t "$target"
+    run tmux capture-pane -J -p -t "$target"
     echo "$output" | grep -q 'orchestrate-marker'
 }
 
@@ -73,7 +73,7 @@ teardown() {
     run pane_send_content "$target" "$brief"
     [ "$status" -eq 0 ]
     sleep 0.3
-    run tmux capture-pane -p -t "$target"
+    run tmux capture-pane -J -p -t "$target"
     echo "$output" | grep -q 'Второй месяц'
 }
 


### PR DESCRIPTION
Relands **TUNE-0166**, which the TUNE-0541 sweep found in the brief's "ten that DID land" column while all 18 files its commit adds were absent from `main`. Verdict: **GENUINELY-LOST-WORK-EXISTS**.

It carries **six of the twenty orphaned enforcement gates** — `check-auto-restart.sh`, `check-escape-false-positives.sh`, `check-orchestrate-docs.sh`, `check-orchestrate-regression.sh`, `check-rule-ttl.sh`, `e2e-test-orchestrate.sh` — the single largest block of the twenty. The earlier triage credited them to `tune-0141`; that branch only *contains* them, this commit *adds* them.

**From the re-rooted history.** No merge-base with `main`, so this is a cherry-pick of the task's own commit, de-stacked: conflict resolution kept only this task's work and dropped residue from unlanded predecessors (0166's `/dr-plugin` row cited TUNE-0103/0105 toggles that are not in `main`; main's row was kept verbatim).

**A stale pinned baseline had to be fixed, not worked around.** `check-orchestrate-docs.sh` pinned `BASE` to a hard-coded sha from the pre-re-root history. That commit is unreachable from `main`, so all three of its checks failed for *any* correct tree. The baseline is now derived from `merge-base HEAD origin/main`, preserving each check's intent. Mutation-proven not weaker — changing `VERSION`, bumping the plugin manifest version, adding a new release claim, and removing a Phase 3 contract term are each still caught.

**Wired, not inert.** The six gates were reachable only from their own acceptance suite, which CI did not run: `dev-tools-lint.yml` enumerates dev-tools tests explicitly and `bats.yml` covers only `tests/`. This PR adds `orchestrate-phase3-acceptance.bats` to that enumeration, following the file's existing pattern, so the gates execute on every PR. Landing them unwired would have repeated the defect this programme exists to end.

Verified: **249/249 bats green**, `shellcheck --severity=warning` clean, `task-id-gate` clean on all four shipped scopes, docs helper `PASS: phase3_docs=6`.