### PR TITLE
fix(tune-0550): the closure gate must actually run — CI wiring + /dr-quick bypass

### DIFF
--- a/.github/workflows/dev-tools-lint.yml
+++ b/.github/workflows/dev-tools-lint.yml
@@ -42,6 +42,7 @@ jobs:
           bats dev-tools/tests/check-github-actions-execution.bats
           bats dev-tools/tests/rename-task-prefix.bats
           bats dev-tools/tests/cross-kb-evolution-digest.bats
+          bats dev-tools/tests/closure-gate.bats
           bats dev-tools/tests/orchestrate-phase3-acceptance.bats
 
   linter-run:

--- a/commands/dr-quick.md
+++ b/commands/dr-quick.md
@@ -56,7 +56,17 @@ After Step 2's probe completes and the task ID is known, emit `**{TASK-ID} · {t
 3. Append a thin one-liner task line to `tasks.md` and mirror it into `activeContext.md` § Active Tasks. Short English title. `status in_progress`, `priority P3`, `complexity L1` by convention (the fast-lane is for L1-sized work; if the work turns out larger, STOP and recommend `/dr-init` for the full pipeline).
 4. Quick KB scan for context: spawn ONE subagent via the Agent tool, using the runtime's CHEAPEST / WEAKEST reasoning tier (vendor-neutral — each runtime resolves its own cheap tier). The subagent does a fast, shallow read of the knowledge base / codebase to locate where the change belongs (or to find what was asked). It returns only the relevant files/context, not a full analysis. This keeps the main (strong) context free and avoids the multi-hour full-analysis path.
 5. Apply the fix (for a fix task) or report the located item (for a search task). The actual edit runs in the main context.
-6. Write a SHORT archive: `documentation/archive/quick/archive-QCK-XXXX.md` — what was done (1-3 sentences) + files touched + a diff/commit reference. NO reflection, NO evolution proposals, NO compliance report. Flip the `tasks.md` one-liner to status `done`.
+6. **CLOSURE REACHABILITY GATE** (MANDATORY before Step 7, for every git repository this QCK changed; skip only for a READ-ONLY QCK, which touches no repository). The fast-lane skips PRD, plan, QA and compliance — it does NOT skip the check that the work exists where consumers can reach it. A QCK that edits files on a branch, writes its archive and flips `done` while the branch never lands produces exactly the defect the slow lane's `/dr-archive` Step 0.13 exists to prevent, and produces it faster.
+
+   ```bash
+   "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/closure-gate.sh" \
+       --root <repo-path> --branch <task-branch> --task QCK-XXXX
+   ```
+
+   Exit `0` = the branch's content is present in `origin/main`; proceed to Step 7.
+   Exit `1` = the work is absent. Do NOT write the archive and do NOT flip the status: land the change (open the pull request, merge it, re-run the gate), or record a cancellation. Exit `2` = usage or environment error; the gate fails **closed**, so an unresolvable base ref is never read as "everything landed". Rationale, and the reason this asserts content reachability rather than commit ancestry: `commands/dr-archive.md` § 0.13.2.
+
+7. Write a SHORT archive: `documentation/archive/quick/archive-QCK-XXXX.md` — what was done (1-3 sentences) + files touched + a diff/commit reference. NO reflection, NO evolution proposals, NO compliance report. Flip the `tasks.md` one-liner to status `done`.
 
 ## When to use / When not to use
 

--- a/dev-tools/tests/closure-gate.bats
+++ b/dev-tools/tests/closure-gate.bats
@@ -193,3 +193,29 @@ advance_main() {
   [ "$status" -eq 2 ]
   [[ "$output" == *"origin/main"* ]]
 }
+
+@test "wiring: CI enumerates this suite, and every route to done invokes the gate" {
+  # Measured 2026-07-30: deleting closure-gate.sh AND this suite outright left
+  # `bats tests/ (full)` (2492/2492), `bats self-tests`, `doc-refs` and
+  # `dr-auto reassert-wiring` all green. A gate nothing runs is a paragraph,
+  # not a gate. The assertions below are the anti-decay wiring.
+  ROOT="$(cd "$BATS_TEST_DIRNAME/../.." && pwd)"
+
+  # 1. dev-tools/tests/*.bats is NOT swept by `bats tests/` — the CI job
+  #    enumerates files, so an unlisted suite runs nowhere at all.
+  WF="$ROOT/.github/workflows/dev-tools-lint.yml"
+  [ -f "$WF" ]
+  run grep -c 'bats dev-tools/tests/closure-gate.bats' "$WF"
+  [ "$status" -eq 0 ]
+
+  # 2. Every command that may flip a task to `done` must invoke the gate first.
+  #    `/dr-archive` was wired at birth; `/dr-quick` writes a short archive and
+  #    flips `tasks.md` to `done` on its own authority, so an unwired fast-lane
+  #    is a complete bypass of the slow lane's gate.
+  for cmd in dr-archive dr-quick; do
+    DOC="$ROOT/commands/$cmd.md"
+    [ -f "$DOC" ]
+    run grep -c 'dev-tools/closure-gate.sh' "$DOC"
+    [ "$status" -eq 0 ]
+  done
+}


### PR DESCRIPTION
TUNE-0541 shipped a correct closure gate (#278). Nothing invoked it.

## Evidence the gate was unwired

Deleted `dev-tools/closure-gate.sh` **and** `dev-tools/tests/closure-gate.bats` outright against main `07d72d4`, then ran every blocking job:

| CI job | result with the gate deleted |
|---|---|
| `bats tests/ (full)` | green — 2492/2492 |
| `bats self-tests (blocking)` | green |
| `doc-refs` self-dogfood | green — 206 files scanned, did not notice the dangling ref at `commands/dr-archive.md:179` |
| `dr-auto reassert-wiring` | green |

Removing the entire gate changed nothing observable.

## Two causes, both fixed

1. **`dev-tools/tests/*.bats` is not swept by `bats tests/`.** `dev-tools-lint.yml` enumerates suites by name and `closure-gate.bats` was not listed — the gate's own tests ran in no CI job. (23 of 28 suites in that directory are still unlisted; tracked separately.)
2. **`/dr-quick` was a complete bypass.** Step 6 flipped `tasks.md` to `done` on its own authority with no closure check. The fast-lane skips PRD/plan/QA/compliance by design; it must not also skip the check that the work reached `origin/main`.

## Mutation-tested

The new wiring test asserts all three attachment points, and each is independently load-bearing — removing the CI line, the `/dr-quick` invocation, or the `/dr-archive` invocation turns it red on its own. With the fix in place, deleting `closure-gate.sh` fails 9/10 tests instead of shipping green.

## The gate's own logic is sound and unchanged

Verified before touching anything: neutering it to `exit 0` reds 6/9 existing tests; disabling only the modified-line detector reds tests 2–4; disabling only the added-file detector reds test 1. Behavioural both-direction probes — refuse a branch whose content is absent from `origin/main`, allow a genuinely squash-merged branch — pass on every node carrying the runtime. The ancestry assertion originally proposed for this gate was confirmed wrong by measurement: it fails on correctly squash-merged branches, so TUNE-0541's content-reachability choice stands.

## Pre-existing red, not from this change

`check-body-english` fails on `skills/expectations-checklist/SKILL.md`, which this PR does not touch. Inherited from main.