### PR TITLE
fix(TUNE-0545): route the collision skill to the reserving allocator

### DIFF
--- a/skills/dr-init-id-collision-window/SKILL.md
+++ b/skills/dr-init-id-collision-window/SKILL.md
@@ -57,7 +57,7 @@ NEW_ID="$(dev-tools/next-free-id.sh TUNE "$DATARIM_ROOT")"   # probes AND reserv
 ```
 
 The allocator reserves the selected ID with an atomic `mkdir` mutex under
-`datarim/.id-reservations/{ID}` (TUNE-0285). `mkdir` is atomic on every POSIX
+`datarim/.id-reservations/{ID}`. `mkdir` is atomic on every POSIX
 filesystem, so of two sessions computing the same candidate exactly one wins and
 the loser gets `EEXIST` and bumps. The reservation is reversible three ways, so
 a crashed session can never permanently burn an ID:
@@ -84,11 +84,12 @@ are the collisions that actually happen:
 | `datarim/*` under `.gitignore` | `rg`/`grep` honour `.gitignore`, so a taken ID reads as free unless `--no-ignore` is passed |
 | archive subdirectories | the ID is retired, not free |
 
-Measured provenance: `TUNE-0543` and `TUNE-0544` were both free at 12:30 and
-claimed by other sessions by 12:50 — with task files and worktree branches but
-**zero** presence in `backlog.md`, `tasks.md`, the archive, or `git log --all`.
-On 2026-07-31 three separate collisions (`TUNE-0545`, `INFRA-0379`, and an
-earlier pair) all traced to sessions that probed by hand instead of reserving.
+Measured provenance: two consecutive IDs were both free at 12:30 and claimed by
+other sessions by 12:50 — with task files and worktree branches but **zero**
+presence in `backlog.md`, `tasks.md`, the archive, or `git log --all`. Three
+separate collisions in a single day, in two different prefixes, all traced to
+sessions that probed by hand instead of reserving. One of them was committed by
+an agent following the fallback procedure in this very file.
 
 ## Detection — manual probe scope (fallback / verification only)
 

--- a/skills/dr-init-id-collision-window/SKILL.md
+++ b/skills/dr-init-id-collision-window/SKILL.md
@@ -44,12 +44,66 @@ This skill is invoked by:
   conversation context but is actually already filed in `backlog.md` as a
   follow-up from a sibling task.
 
-## Detection — probe scope
+## Allocation — reserve, do not merely probe
+
+**Use `dev-tools/next-free-id.sh <PREFIX> <DATARIM_ROOT>`. It is the only
+allocator that both probes and *reserves*.** A hand-rolled `grep`/`ls` probe
+tells you an ID was free a moment ago; it does not stop the session next to you
+from taking it while you write your first artifact. That gap is the entire
+subject of this skill.
+
+```sh
+NEW_ID="$(dev-tools/next-free-id.sh TUNE "$DATARIM_ROOT")"   # probes AND reserves
+```
+
+The allocator reserves the selected ID with an atomic `mkdir` mutex under
+`datarim/.id-reservations/{ID}` (TUNE-0285). `mkdir` is atomic on every POSIX
+filesystem, so of two sessions computing the same candidate exactly one wins and
+the loser gets `EEXIST` and bumps. The reservation is reversible three ways, so
+a crashed session can never permanently burn an ID:
+
+1. **TTL self-expiry** — a marker older than `DATARIM_ID_RESERVATION_TTL`
+   seconds (default `1800`) is reclaimed automatically.
+2. **Explicit release** — `dev-tools/next-free-id.sh --release <ID> <ROOT>`.
+   Call this **after your first artifact is written** (the artifact itself is
+   then the claim), or immediately if you probed an ID you did not use.
+3. **Manual** — `rm -rf datarim/.id-reservations/<ID>`.
+
+`datarim/.id-reservations/` is gitignored; it is host-local coordination state,
+never committed.
+
+### Why the manual probe below is a fallback, not the default
+
+The allocator already searches surfaces an ad-hoc probe misses, and the misses
+are the collisions that actually happen:
+
+| Surface | Why a naive probe misses it |
+|---|---|
+| live `tmux` session names | a batch-spawned orchestrator reserves its ID in the session name before any file exists |
+| `git worktree list` branch names | a sibling checkout holds the claim with zero presence in the main checkout |
+| `datarim/*` under `.gitignore` | `rg`/`grep` honour `.gitignore`, so a taken ID reads as free unless `--no-ignore` is passed |
+| archive subdirectories | the ID is retired, not free |
+
+Measured provenance: `TUNE-0543` and `TUNE-0544` were both free at 12:30 and
+claimed by other sessions by 12:50 — with task files and worktree branches but
+**zero** presence in `backlog.md`, `tasks.md`, the archive, or `git log --all`.
+On 2026-07-31 three separate collisions (`TUNE-0545`, `INFRA-0379`, and an
+earlier pair) all traced to sessions that probed by hand instead of reserving.
+
+## Detection — manual probe scope (fallback / verification only)
+
+Use this to *verify* an allocator result, or when the allocator is unavailable.
+It does not reserve, so treat any result as provisional until an artifact
+exists.
 
 Run from the workspace root (the dir containing `datarim/` and
 `documentation/`):
 
 ```sh
+# 0. gitignore trap: datarim/* is gitignored — a ripgrep probe without
+#    --no-ignore reports a TAKEN id as free. Always pass it.
+rg --no-ignore -n "${TASK_ID}" datarim/ documentation/ 2>/dev/null
+
 # 1. probe active state
 grep -E "^- ${TASK_ID} " datarim/tasks.md datarim/backlog.md
 grep "^${TASK_ID}\b" datarim/activeContext.md
@@ -68,9 +122,20 @@ ls datarim/tasks/${TASK_ID}-*.md \
 ls documentation/archive/*/archive-${TASK_ID}.md \
    documentation/archive/*/snapshots/${TASK_ID}-final-stage.md \
    2>/dev/null
+
+# 4. host-global surfaces no file scan can see
+tmux list-sessions -F '#{session_name}' 2>/dev/null | grep -F "${TASK_ID}"
+git worktree list --porcelain 2>/dev/null | grep -F "${TASK_ID}"
+
+# 5. task FILENAMES in every worktree, and commit subjects on every branch —
+#    both invisible to a search rooted at the main checkout
+for wt in $(git worktree list --porcelain | awk '/^worktree /{print $2}'); do
+    find "$wt/datarim" -maxdepth 2 -name "${TASK_ID}*" 2>/dev/null
+done
+git log --all --format='%s%n%b' 2>/dev/null | grep -F "${TASK_ID}"
 ```
 
-Any hit in step 2 or 3 outside the calling session's own scope = collision.
+Any hit in steps 2-5 outside the calling session's own scope = collision.
 Distinguish «my own forgotten earlier session» from «parallel session» via
 frontmatter `operator:` / `captured_at:` / commit author, not by file presence
 alone.
@@ -107,9 +172,11 @@ shipped script.
 The losing session (lower commit-time or operator-assigned) renames its task
 ID. Procedure:
 
-1. **Choose new ID.** Pick the next free `TASK-PREFIX-NNNN` per
-   `skills/datarim-system/SKILL.md` § Unified Task Numbering — confirm via the same
-   probe in detection step 1–3 with the new ID.
+1. **Choose new ID.** Allocate with `dev-tools/next-free-id.sh <PREFIX> <ROOT>`
+   so the replacement ID is *reserved*, not merely probed — renaming into a
+   second collision is a real outcome when parallel sessions are active.
+   Confirm with the § Detection probe, and re-probe immediately before you
+   write: free-at-start is not free-at-end.
 
 2. **sed-batch rename across artifact bodies.** All artifact files reference
    the old ID in frontmatter (`task_id:`), headings, cross-links, and audit log

--- a/tests/tune-0545-collision-skill-routing.bats
+++ b/tests/tune-0545-collision-skill-routing.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+# TUNE-0545 — the collision-window skill must route agents to the RESERVING
+# allocator. TUNE-0285 shipped an atomic mkdir mutex that works (its own suite
+# proves it), but the skill agents read when picking an ID never mentioned it
+# and prescribed a hand-rolled probe blind to tmux, worktrees, gitignore and
+# git log --all. A sound mutex wired to nothing still produces collisions:
+# three occurred on 2026-07-31 alone. These assertions keep the wiring.
+
+SKILL="${BATS_TEST_DIRNAME}/../skills/dr-init-id-collision-window/SKILL.md"
+
+@test "S01: skill names the reserving allocator" {
+    grep -q 'next-free-id\.sh' "$SKILL"
+}
+
+@test "S02: skill states the allocator reserves, not merely probes" {
+    grep -qiE 'probes AND reserves|both probes and .*reserve' "$SKILL"
+}
+
+@test "S03: skill documents the atomic mkdir reservation mutex" {
+    grep -q 'id-reservations' "$SKILL"
+    grep -qi 'mkdir' "$SKILL"
+}
+
+@test "S04: skill documents all three reversibility paths" {
+    grep -qi 'TTL' "$SKILL"
+    grep -q -- '--release' "$SKILL"
+    grep -qi 'rm -rf datarim/\.id-reservations' "$SKILL"
+}
+
+@test "S05: skill documents release-after-first-artifact semantics" {
+    grep -qiE 'after your first artifact|first artifact is written' "$SKILL"
+}
+
+@test "S06: skill warns about the gitignore trap with the actual flag" {
+    grep -q -- '--no-ignore' "$SKILL"
+}
+
+@test "S07: skill covers host-global surfaces a file scan cannot see" {
+    grep -q 'tmux' "$SKILL"
+    grep -q 'worktree' "$SKILL"
+}
+
+@test "S08: skill covers per-worktree task filenames and all-branch subjects" {
+    grep -q 'git log --all' "$SKILL"
+    # shellcheck disable=SC2016  # matching the LITERAL "$wt" the skill prints, not expanding it
+    grep -qE 'find .*\$wt/datarim|for wt in' "$SKILL"
+}
+
+@test "S09: the rename path also allocates via the reserving allocator" {
+    sed -n '/^## Resolution/,$p' "$SKILL" | grep -q 'next-free-id\.sh'
+}
+
+@test "S10: the allocator the skill names actually exists and is executable" {
+    [ -x "${BATS_TEST_DIRNAME}/../dev-tools/next-free-id.sh" ]
+}
+
+@test "S11: that allocator really implements the reservation the skill promises" {
+    grep -q 'id-reservations' "${BATS_TEST_DIRNAME}/../dev-tools/next-free-id.sh"
+    grep -q -- '--release' "${BATS_TEST_DIRNAME}/../dev-tools/next-free-id.sh"
+}


### PR DESCRIPTION
## The premise was wrong, and that is the finding

TUNE-0285's atomic reservation mutex is **not missing**. Verified before touching anything:

- merged in **#283** (`99c5da5`), present on `main` today
- the installed runtime copy is **byte-identical** to `main` (`24c2191fb226`, 18811 bytes)
- its suite passes **11/11**, and it demonstrably works against the live workspace — a call reserved `INFRA-0381` and `--release` freed it

`mkdir` mutex under `datarim/.id-reservations/{ID}`, TTL stale-GC, `--release`, concurrent-contender and crash-expiry coverage. All shipped.

## But it is wired to nothing on the path agents walk

`skills/dr-init-id-collision-window/SKILL.md` is what an agent reads when it needs an ID. Before this commit:

| Reference | Hits |
|---|---|
| `next-free-id.sh` | **0** |
| `id-reservations` / `mkdir` / `--release` / TUNE-0285 | **0** |
| `tmux`, `worktree`, `git log --all`, `--no-ignore` | **0** |

What it *did* prescribe was a hand-rolled `grep`/`ls` probe blind to every one of those surfaces.

**A probe tells you an ID was free a moment ago. It does not stop the session next to you taking it while you write your first artifact.** That gap is the entire subject of this skill — and the skill was teaching the losing move.

Three collisions on 2026-07-31 (`TUNE-0545`, `INFRA-0379`, and an earlier pair) all trace to sessions that probed by hand instead of reserving. **I collided on `INFRA-0379` by following this exact procedure**, which is how the defect surfaced.

## Changes

- **Allocation** is now a reserve-not-probe step naming `next-free-id.sh`, with the `mkdir` mechanism, all three reversibility paths, and release-after-first-artifact semantics.
- **The manual probe is demoted** to fallback/verification and extended with the gitignore trap, `tmux`, `worktree`, per-worktree task filenames and all-branch commit subjects — each with a short why-a-naive-probe-misses-it note, plus the measured `TUNE-0543/0544` provenance.
- **The rename path** in Resolution now allocates through the allocator too; renaming into a *second* collision is a real outcome with parallel sessions active.

## Tests — mutation-tested

11 new assertions, and they can actually fail:

| Mutation | Failures |
|---|---|
| strip the allocator reference | **2** |
| strip `--no-ignore` | **1** |
| strip the host-global surfaces | **2** |

`S10`/`S11` additionally assert the named allocator **exists** and **really implements** the reservation the skill promises, so doc and script cannot drift apart silently — which is precisely how this defect survived.

TUNE-0285's own suite still passes. No behavioural change to any script; `shellcheck` clean (one intentional `SC2016` annotated, since the pattern matches a literal `$wt`).

Commit signed (ED25519).

## Ownership

Executed under **TUNE-0545**, which already states *"the fix belongs in the agent-facing contract (dr-init Step 4 / the id-collision skill), not in the script. Do not 'fix' a bug the script does not have."* No new task ID allocated — that would have been a fourth collision risk for no benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165v6R7gmFBYVAQSq1YfNAt