### PR TITLE
feat(TUNE-0545): read the two claim surfaces the allocator was blind to

### DIFF
--- a/dev-tools/next-free-id.sh
+++ b/dev-tools/next-free-id.sh
@@ -287,6 +287,63 @@ elif command -v git >/dev/null 2>&1; then
     git -C "$DATARIM_ROOT" branch -a --format='%(refname:short)' 2>/dev/null >> "$LIVE_FILE" || true
 fi
 
+# ── surface 3b (PROBE ONLY): task FILENAMES inside every worktree ────────────
+#
+# Surface 1 sweeps datarim/ and documentation/archive/ — but only under
+# DATARIM_ROOT, i.e. the checkout the caller happens to be standing in. A
+# sibling worktree that already wrote `datarim/tasks/{ID}-task-description.md`
+# is invisible to it, and that is not hypothetical: two consecutive IDs were
+# handed out while exactly those files sat in sibling checkouts, with zero
+# presence in tasks.md, backlog.md, the archive or any commit.
+#
+# Filenames only, never bodies — same rule as surface 1, and for the same
+# reason: task documents cite illustrative IDs in prose.
+#
+# PROBE ONLY. A foreign checkout may sit on a stale branch, a reverted
+# experiment or a fixture tree, so a hit is good enough to REFUSE an ID and not
+# good enough to define the watermark. Feeding it to MAX_NUM would rebuild the
+# fixture-poison defect on a new surface.
+#
+# Test seam: DATARIM_ID_WORKTREE_PATHS (newline-separated) replaces the live
+# `git worktree list`, so a spec is hermetic on a host with dozens of trees.
+_scan_worktree_task_names() {
+    local wt="$1"
+    [[ -n "$wt" && -d "$wt" ]] || return 0
+    find "$wt/datarim/tasks" -maxdepth 1 2>/dev/null | sed 's|.*/||' >> "$LIVE_FILE" || true
+}
+
+if [[ -n "${DATARIM_ID_WORKTREE_PATHS+set}" ]]; then
+    while IFS= read -r _wt; do
+        _scan_worktree_task_names "$_wt"
+    done <<< "$DATARIM_ID_WORKTREE_PATHS"
+elif command -v git >/dev/null 2>&1; then
+    while IFS= read -r _wt; do
+        _scan_worktree_task_names "$_wt"
+    done < <(git -C "$DATARIM_ROOT" worktree list --porcelain 2>/dev/null \
+             | awk '/^worktree /{print substr($0, 10)}')
+fi
+
+# ── surface 3c (PROBE ONLY): commit subjects on EVERY ref ────────────────────
+#
+# A claim can exist as nothing but a commit on a branch that is not checked
+# out. `git branch -a` above catches the case where the ID is in the branch
+# NAME; it says nothing about a conventional-commit subject like
+# `feat(PREFIX-NNNN): ...` on an otherwise unremarkable branch name.
+#
+# PROBE ONLY, emphatically. Commit subjects are free prose and routinely cite
+# IDs they do not claim — a renumber commit names both the old and the new ID.
+# Refusing both is the conservative and correct outcome for a mutex: the cost
+# is skipping an ID, which is recoverable, against handing out a live one,
+# which is not.
+#
+# Test seam: DATARIM_ID_GIT_LOG (newline-separated subjects) replaces the live
+# `git log`.
+if [[ -n "${DATARIM_ID_GIT_LOG+set}" ]]; then
+    printf '%s\n' "$DATARIM_ID_GIT_LOG" >> "$LIVE_FILE"
+elif command -v git >/dev/null 2>&1; then
+    git -C "$DATARIM_ROOT" log --all --format='%s' 2>/dev/null >> "$LIVE_FILE" || true
+fi
+
 # ── surface 4 (ceiling + probe): in-flight init-lock markers ─────────────────
 #
 # `datarim/.locks/<ID>.init-lock` is the mkdir-based atomic claim a concurrent

--- a/tests/tune-0545-claim-surfaces.bats
+++ b/tests/tune-0545-claim-surfaces.bats
@@ -1,0 +1,216 @@
+#!/usr/bin/env bats
+# tune-0545-claim-surfaces.bats
+#
+# TUNE-0545 items (1) and (2) — the two claim surfaces next-free-id.sh does not
+# yet read.
+#
+# Both are surfaces that demonstrably hid live claims in the field: two
+# consecutive IDs were handed out while task files sat in sibling worktrees and
+# the only other trace was a commit subject on a branch that was not checked
+# out. A search rooted at the main checkout is structurally blind to both.
+#
+# Group W — per-worktree datarim/tasks/ FILENAMES (item 1).
+# Group L — commit subjects across ALL refs (item 2).
+# Group P — both surfaces are PROBE-ONLY and must never lift the ceiling.
+#
+# Group G — the same two surfaces driven through REAL git, no seam.
+#
+# Groups W/L/P are hermetic: the live probes are replaced through the documented
+# env seams, so they pass identically on a host running dozens of sessions.
+# Group G deliberately is not — a seam-only suite leaves the actual git
+# invocations untested, and mutating `git log --all` to `git log -1` broke
+# nothing until G01 existed.
+
+HELPER="${BATS_TEST_DIRNAME}/../dev-tools/next-free-id.sh"
+
+setup() {
+    FIXTURE_DIR="$(mktemp -d)"
+    mkdir -p "${FIXTURE_DIR}/datarim/tasks"
+    mkdir -p "${FIXTURE_DIR}/documentation/archive/framework"
+    # Neutralise the pre-existing live surfaces so only the surface under test
+    # can influence the result.
+    export DATARIM_ID_TMUX_SESSIONS=""
+    export DATARIM_ID_GIT_REFS=""
+    export DATARIM_ID_GIT_LOG=""
+    export DATARIM_ID_WORKTREE_PATHS=""
+}
+
+teardown() {
+    rm -rf "${FIXTURE_DIR}" "${SIBLING_DIR:-/nonexistent-xyz}"
+    unset DATARIM_ID_TMUX_SESSIONS DATARIM_ID_GIT_REFS \
+          DATARIM_ID_GIT_LOG DATARIM_ID_WORKTREE_PATHS
+}
+
+# Seed the main checkout so the ceiling is a known value.
+seed_main_ceiling() {
+    printf -- '- TUNE-0100 · pending · P2 · L1 · seed\n' \
+        > "${FIXTURE_DIR}/datarim/backlog.md"
+}
+
+# ── Group W — per-worktree task FILENAMES (item 1) ────────────────────────────
+
+# W01: the defect, minimally. A sibling worktree holds a task-description file
+# for an ID with ZERO presence in the main checkout. The allocator must not
+# hand that ID out.
+@test "W01: an ID claimed only by a task file in a sibling worktree is refused" {
+    seed_main_ceiling
+    SIBLING_DIR="$(mktemp -d)"
+    mkdir -p "${SIBLING_DIR}/datarim/tasks"
+    : > "${SIBLING_DIR}/datarim/tasks/TUNE-0101-task-description.md"
+
+    export DATARIM_ID_WORKTREE_PATHS="${SIBLING_DIR}"
+    run bash "${HELPER}" "TUNE" "${FIXTURE_DIR}"
+    [ "$status" -eq 0 ]
+    # ceiling is 0100, so the naive answer is 0101 — which the sibling holds
+    [ "$output" != "TUNE-0101" ]
+}
+
+# W02: the scan must cover every worktree in the list, not just the first.
+@test "W02: every worktree path is scanned, not only the first" {
+    seed_main_ceiling
+    SIB_A="$(mktemp -d)"; SIB_B="$(mktemp -d)"
+    mkdir -p "${SIB_A}/datarim/tasks" "${SIB_B}/datarim/tasks"
+    : > "${SIB_A}/datarim/tasks/TUNE-0101-task-description.md"
+    : > "${SIB_B}/datarim/tasks/TUNE-0102-init-task.md"
+
+    export DATARIM_ID_WORKTREE_PATHS="${SIB_A}
+${SIB_B}"
+    run bash "${HELPER}" "TUNE" "${FIXTURE_DIR}"
+    [ "$status" -eq 0 ]
+    [ "$output" != "TUNE-0101" ]
+    [ "$output" != "TUNE-0102" ]
+    rm -rf "${SIB_A}" "${SIB_B}"
+}
+
+# W03: a missing or unreadable worktree path must not break allocation.
+# Worktree lists routinely contain stale entries for deleted directories.
+@test "W03: a stale worktree path is tolerated, not fatal" {
+    seed_main_ceiling
+    export DATARIM_ID_WORKTREE_PATHS="/nonexistent/worktree/path"
+    run bash "${HELPER}" "TUNE" "${FIXTURE_DIR}"
+    [ "$status" -eq 0 ]
+    [ "$output" = "TUNE-0101" ]
+}
+
+# ── Group L — commit subjects across all refs (item 2) ───────────────────────
+
+# L01: the defect. An ID whose only trace is a commit subject on some branch
+# must not be handed out.
+@test "L01: an ID appearing only in a commit subject is refused" {
+    seed_main_ceiling
+    export DATARIM_ID_GIT_LOG="feat(TUNE-0101): something already in flight"
+    run bash "${HELPER}" "TUNE" "${FIXTURE_DIR}"
+    [ "$status" -eq 0 ]
+    [ "$output" != "TUNE-0101" ]
+}
+
+# L02: multi-line log output — every subject line counts, not just the first.
+@test "L02: all log lines are scanned" {
+    seed_main_ceiling
+    export DATARIM_ID_GIT_LOG="chore: unrelated
+feat(TUNE-0101): first
+fix(TUNE-0102): second"
+    run bash "${HELPER}" "TUNE" "${FIXTURE_DIR}"
+    [ "$status" -eq 0 ]
+    [ "$output" != "TUNE-0101" ]
+    [ "$output" != "TUNE-0102" ]
+}
+
+# L03: an empty log seam must not refuse anything.
+@test "L03: empty commit-log surface leaves allocation unchanged" {
+    seed_main_ceiling
+    export DATARIM_ID_GIT_LOG=""
+    run bash "${HELPER}" "TUNE" "${FIXTURE_DIR}"
+    [ "$status" -eq 0 ]
+    [ "$output" = "TUNE-0101" ]
+}
+
+# ── Group P — probe-only discipline ──────────────────────────────────────────
+#
+# Both new surfaces are free-form prose or foreign-checkout state. A hit is
+# good enough to REFUSE an ID; it must NOT define the watermark. Trusting
+# either for the ceiling rebuilds the fixture-poison defect on a new surface —
+# a commit subject saying "renumbered TUNE-9000" would otherwise push every
+# future ID past 9000.
+
+@test "P01: a high ID in a commit subject does not lift the ceiling" {
+    seed_main_ceiling
+    export DATARIM_ID_GIT_LOG="docs: renumbered away from TUNE-9000"
+    run bash "${HELPER}" "TUNE" "${FIXTURE_DIR}"
+    [ "$status" -eq 0 ]
+    # must stay just above the real ceiling, NOT jump to 9001
+    [ "$output" = "TUNE-0101" ]
+}
+
+@test "P02: a high ID in a worktree task file does not lift the ceiling" {
+    seed_main_ceiling
+    SIBLING_DIR="$(mktemp -d)"
+    mkdir -p "${SIBLING_DIR}/datarim/tasks"
+    : > "${SIBLING_DIR}/datarim/tasks/TUNE-9000-task-description.md"
+    export DATARIM_ID_WORKTREE_PATHS="${SIBLING_DIR}"
+    run bash "${HELPER}" "TUNE" "${FIXTURE_DIR}"
+    [ "$status" -eq 0 ]
+    [ "$output" = "TUNE-0101" ]
+}
+
+# ── Group D — the surfaces are documented ────────────────────────────────────
+
+@test "D01: the script documents the per-worktree filename surface" {
+    grep -qiE 'worktree' "${HELPER}"
+    grep -q 'DATARIM_ID_WORKTREE_PATHS' "${HELPER}"
+}
+
+@test "D02: the script documents the all-refs commit-subject surface" {
+    grep -q 'DATARIM_ID_GIT_LOG' "${HELPER}"
+}
+
+# ── Group G — the REAL git paths, no seam ────────────────────────────────────
+#
+# Groups W and L drive the surfaces through their env seams, which keeps them
+# hermetic but leaves the actual git invocations unexercised. That is a real
+# blind spot: mutating `git log --all` to `git log -1` broke nothing in the
+# seam-driven tests. These two build a genuine repository so the discovery
+# commands themselves are under test.
+
+@test "G01: real git — an ID on a NON-checked-out branch is refused (exercises --all)" {
+    unset DATARIM_ID_GIT_LOG          # force the live git path
+    export DATARIM_ID_GIT_REFS=""     # keep branch NAMES out of it
+    REPO="$(mktemp -d)"
+    git -C "$REPO" init -q
+    git -C "$REPO" config user.email t@t; git -C "$REPO" config user.name t
+    git -C "$REPO" config commit.gpgsign false
+    mkdir -p "$REPO/datarim"
+    printf -- '- TUNE-0100 · pending · P2 · L1 · seed\n' > "$REPO/datarim/backlog.md"
+    git -C "$REPO" add -A; git -C "$REPO" commit -qm "chore: seed"
+    # a claim that exists ONLY as a commit subject on another branch
+    git -C "$REPO" checkout -q -b sidebranch
+    git -C "$REPO" commit -q --allow-empty -m "feat(TUNE-0101): in flight elsewhere"
+    git -C "$REPO" checkout -q -
+
+    run bash "${HELPER}" "TUNE" "$REPO"
+    [ "$status" -eq 0 ]
+    [ "$output" != "TUNE-0101" ]
+    rm -rf "$REPO"
+}
+
+@test "G02: real git — a task file in a linked worktree is refused (exercises worktree list)" {
+    unset DATARIM_ID_WORKTREE_PATHS   # force the live git path
+    export DATARIM_ID_GIT_REFS=""
+    export DATARIM_ID_GIT_LOG=""
+    REPO="$(mktemp -d)"; LINKED="$(mktemp -d)"; rmdir "$LINKED"
+    git -C "$REPO" init -q
+    git -C "$REPO" config user.email t@t; git -C "$REPO" config user.name t
+    git -C "$REPO" config commit.gpgsign false
+    mkdir -p "$REPO/datarim"
+    printf -- '- TUNE-0100 · pending · P2 · L1 · seed\n' > "$REPO/datarim/backlog.md"
+    git -C "$REPO" add -A; git -C "$REPO" commit -qm "chore: seed"
+    git -C "$REPO" worktree add -q -b wt "$LINKED"
+    mkdir -p "$LINKED/datarim/tasks"
+    : > "$LINKED/datarim/tasks/TUNE-0101-task-description.md"
+
+    run bash "${HELPER}" "TUNE" "$REPO"
+    [ "$status" -eq 0 ]
+    [ "$output" != "TUNE-0101" ]
+    git -C "$REPO" worktree remove --force "$LINKED" 2>/dev/null || true
+    rm -rf "$REPO" "$LINKED"
+}


### PR DESCRIPTION
Items **(1)** and **(2)** of TUNE-0545 — the surfaces `next-free-id.sh` did not read. Follows #314, which fixed the *routing* to the allocator; this fixes what the allocator can *see*.

Both demonstrably hid live claims: two consecutive IDs were handed out while task files sat in sibling worktrees and the only other trace was a commit subject on a branch nobody had checked out.

## What was added

**Surface 3b — task FILENAMES inside every worktree.** Surface 1 already sweeps `datarim/` and `documentation/archive/`, but only under `DATARIM_ROOT` — whichever checkout the caller happens to stand in. A sibling worktree that already wrote `datarim/tasks/{ID}-task-description.md` was invisible. Filenames only, never bodies, matching surface 1's existing rule.

**Surface 3c — commit subjects on every ref.** `git branch -a` catches an ID in a branch *name*; it says nothing about `feat(PREFIX-NNNN): …` on an otherwise unremarkable branch.

## Both are PROBE-ONLY, deliberately

They feed `is_claimed()` and **never** `MAX_NUM`. Commit subjects are free prose and routinely cite IDs they don't claim — a renumber commit names both old and new. Refusing both is the conservative, correct outcome for a mutex: skipping an ID is recoverable, handing out a live one is not.

Trusting either for the ceiling would rebuild the fixture-poison defect on new ground, so `P01`/`P02` pin that: a `TUNE-9000` in a commit subject or a worktree task file must **not** push the next ID past 9000.

## Red-first

**6 of the 10 initial assertions failed** against the unmodified script. The 4 that passed were the negative controls that had to *keep* passing — stale worktree path tolerated, empty log surface inert, and neither surface lifting the ceiling.

## Group G exists because mutation testing found a hole in my own suite

The env seams that make W/L hermetic also meant the real git invocations were never executed — mutating `git log --all` → `git log -1` **broke nothing**. `G01`/`G02` build a genuine repository with a real side branch and a real linked worktree. That mutation now fails a test.

| Mutation | Failures |
|---|---|
| break the worktree `find` | 2 |
| break the log flag (`--all` → `-1`) | **1** (was 0 before Group G) |
| route both surfaces to `/dev/null` | 4 |

## Verification

- 12/12 new; **TUNE-0285 race 11/11**, collision-skill routing 11/11 — no regressions
- `shellcheck` clean at CI severity (`--severity=warning`); `task-id-gate` clean on `skills/`, `commands/`, `agents/`, `templates/`
- Live differential against the real workspace: installed and candidate agree, no reservation leaked

## Observed, deliberately not fixed

A live branch named `tune-0551-0553-filing` encodes a *range*. It contains `0553` but no `TUNE-0553` token, so no substring matcher will treat it as a claim — and my own earlier ad-hoc probe over-counted it as one, which is its own argument for using the allocator. Range-encoded branch names are a separate surface, outside items (1) and (2), and guessing at range semantics would be speculative. Recorded rather than silently handled.

Signed (ED25519). Per instruction, **not merging until required checks are green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165v6R7gmFBYVAQSq1YfNAt