### PR TITLE
fix(TUNE-0545): use the runtime-prefixed dev-tools path in the collision skill

### DIFF
--- a/skills/dr-init-id-collision-window/SKILL.md
+++ b/skills/dr-init-id-collision-window/SKILL.md
@@ -46,14 +46,15 @@ This skill is invoked by:
 
 ## Allocation — reserve, do not merely probe
 
-**Use `dev-tools/next-free-id.sh <PREFIX> <DATARIM_ROOT>`. It is the only
+**Use `${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/next-free-id.sh <PREFIX> <DATARIM_ROOT>`.
+It is the only
 allocator that both probes and *reserves*.** A hand-rolled `grep`/`ls` probe
 tells you an ID was free a moment ago; it does not stop the session next to you
 from taking it while you write your first artifact. That gap is the entire
 subject of this skill.
 
 ```sh
-NEW_ID="$(dev-tools/next-free-id.sh TUNE "$DATARIM_ROOT")"   # probes AND reserves
+NEW_ID="$("${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/next-free-id.sh" TUNE "$DATARIM_ROOT")"
 ```
 
 The allocator reserves the selected ID with an atomic `mkdir` mutex under
@@ -64,7 +65,7 @@ a crashed session can never permanently burn an ID:
 
 1. **TTL self-expiry** — a marker older than `DATARIM_ID_RESERVATION_TTL`
    seconds (default `1800`) is reclaimed automatically.
-2. **Explicit release** — `dev-tools/next-free-id.sh --release <ID> <ROOT>`.
+2. **Explicit release** — `${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/next-free-id.sh --release <ID> <ROOT>`.
    Call this **after your first artifact is written** (the artifact itself is
    then the claim), or immediately if you probed an ID you did not use.
 3. **Manual** — `rm -rf datarim/.id-reservations/<ID>`.
@@ -173,7 +174,7 @@ shipped script.
 The losing session (lower commit-time or operator-assigned) renames its task
 ID. Procedure:
 
-1. **Choose new ID.** Allocate with `dev-tools/next-free-id.sh <PREFIX> <ROOT>`
+1. **Choose new ID.** Allocate with `${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/next-free-id.sh <PREFIX> <ROOT>`
    so the replacement ID is *reserved*, not merely probed — renaming into a
    second collision is a real outcome when parallel sessions are active.
    Confirm with the § Detection probe, and re-probe immediately before you


### PR DESCRIPTION
**Repairs a regression I introduced in #314** — `bats` has been red on `main` since `6d28d640`, and #315 inherited it.

I merged #314 while `bats tests/ (full)` was still pending, having checked only that the six *required* contexts were green. That was my error, and the fact that the same workflow is not a required context is why it went unnoticed rather than being caught at the gate.

## The defect

`check-dev-tools-path-convention` flagged four bare-relative `dev-tools/next-free-id.sh` references I added.

The convention exists to prevent precisely the bug they would have caused: an agent reading this skill with its cwd in a **consumer workspace** resolves a bare `dev-tools/...` against that workspace, finds nothing, and falls back to the manual procedure — which in this very file is the hand-rolled probe the whole change exists to steer agents away from.

**The gate was protecting the change from defeating itself.** Worth stating plainly, because a bare path that works in the framework repo and silently fails everywhere else is the same shape as the "sound but wired to nothing" defects this task has been chasing all along.

## Fix

All four now use `${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/next-free-id.sh`, which resolves through the installed symlink from any cwd.

| Suite | Result |
|---|---|
| `check-dev-tools-path-convention` | **13/13** |
| `tune-0545-collision-skill-routing` | 11/11 — incl. `S10`, which asserts the named allocator exists and is executable, so the rename is *verified*, not assumed |
| `tune-0545-claim-surfaces` | 12/12 |
| `tune-0285-id-reservation-race` | 11/11 |
| `task-id-gate` (4 scopes) | clean |

Signed. **I will wait for `bats tests/ (full)` specifically — not just the required contexts — before merging this one.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0165v6R7gmFBYVAQSq1YfNAt