### PR TITLE
test(snapshot): cover wrapper separator and size boundary

### DIFF
--- a/tests/stage-snapshot-e2e.bats
+++ b/tests/stage-snapshot-e2e.bats
@@ -223,22 +223,23 @@ EOB
         --captured-by agent --recommended-next /dr-qa \
         --options-file "${huge_options}" --body-file "${BODY_TMP}"
 
-    [ "$status" -eq 1 ]
-    [[ "$output" == *"exceeds 8192-byte cap"* ]]
-    [ ! -e "${FAKE_ROOT}/datarim/snapshots/${TASK_ID}.snapshot.md" ]
+    [ "$status" -eq 1 ] &&
+    [[ "$output" == *"exceeds 8192-byte cap"* ]] &&
+    [ ! -e "${FAKE_ROOT}/datarim/snapshots/${TASK_ID}.snapshot.md" ] &&
     [ ! -d "${FAKE_ROOT}/datarim/snapshots/.lock.${TASK_ID}" ]
 }
 
 @test "E2E — I/O failure cleanup treats root as data and removes the acquired lock" {
     local canary="${BATS_TEST_TMPDIR}/TUNE0546_CANARY"
+    local cp_invoked="${BATS_TEST_TMPDIR}/cp-invoked"
     local literal_payload='$(touch${IFS}TUNE0546_CANARY)'
     local hostile_root="${BATS_TEST_TMPDIR}/root-${literal_payload}"
     local fake_bin="${BATS_TEST_TMPDIR}/fake-bin"
     mkdir -p "${hostile_root}/datarim/snapshots" "${fake_bin}"
-    printf '#!/usr/bin/env bash\nexit 74\n' > "${fake_bin}/cp"
+    printf '#!/usr/bin/env bash\n: > "${SNAPSHOT_TEST_CP_INVOKED}"\nexit 74\n' > "${fake_bin}/cp"
     chmod +x "${fake_bin}/cp"
 
-    run env PATH="${fake_bin}:${PATH}" bash -c '
+    run env PATH="${fake_bin}:${PATH}" SNAPSHOT_TEST_CP_INVOKED="${cp_invoked}" bash -c '
         cd "$1"
         shift
         exec "$@"
@@ -247,8 +248,9 @@ EOB
         --captured-by agent --recommended-next /dr-qa \
         --options-file "${OPTIONS_TMP}" --body-file "${BODY_TMP}"
 
-    [ "$status" -ne 0 ]
-    [ ! -e "${canary}" ]
-    [ ! -d "${hostile_root}/datarim/snapshots/.lock.${TASK_ID}" ]
+    [ "$status" -ne 0 ] &&
+    [ -e "${cp_invoked}" ] &&
+    [ ! -e "${canary}" ] &&
+    [ ! -d "${hostile_root}/datarim/snapshots/.lock.${TASK_ID}" ] &&
     [ ! -e "${hostile_root}/datarim/snapshots/${TASK_ID}.snapshot.md" ]
 }

--- a/tests/stage-snapshot-e2e.bats
+++ b/tests/stage-snapshot-e2e.bats
@@ -107,6 +107,21 @@ EOB
     grep -q '^Implementation TUNE-0259' "${snapshot}"
 }
 
+@test "E2E wrapper — ordinary body without a leading newline stays unglued" {
+    local ordinary_body="${BATS_TEST_TMPDIR}/ordinary-body.txt"
+    printf '%s' 'Implementation TUNE-0259 ordinary first line' > "${ordinary_body}"
+
+    run bash "${WRITER_WRAPPER}" \
+        --root "${FAKE_ROOT}" --task "${TASK_ID}" --stage do --command /dr-do \
+        --captured-by agent --recommended-next /dr-qa \
+        --options-file "${OPTIONS_TMP}" --body-file "${ordinary_body}"
+    [ "$status" -eq 0 ]
+
+    local snapshot="${FAKE_ROOT}/datarim/snapshots/${TASK_ID}.snapshot.md"
+    run grep -F -q -- '---Implementation TUNE-0259 ordinary first line' "${snapshot}"
+    [ "$status" -eq 1 ]
+}
+
 @test "E2E — declared size_bytes equals exact snapshot bytes" {
     run bash "${WRITER_WRAPPER}" \
         --root "${FAKE_ROOT}" --task "${TASK_ID}" --stage do --command /dr-do \
@@ -137,6 +152,40 @@ EOB
     actual="$(wc -c < "${snapshot}" | tr -d ' ')"
     [ "${actual}" -ge 1000 ]
     [ "${declared}" -eq "${actual}" ]
+}
+
+@test "E2E wrapper — declared size converges across the 999-to-1000 boundary" {
+    local captured_at="2026-07-30T00:00:00Z"
+    local probe="${BATS_TEST_TMPDIR}/boundary-frontmatter.md"
+    local boundary_body="${BATS_TEST_TMPDIR}/boundary-body.txt"
+
+    # The cap-width probe is four digits. Choosing the body so the pre-fix
+    # command-substitution path declared 999 forces the 3→4 digit transition.
+    # shellcheck source=/dev/null
+    source "${WRITER_LIB}"
+    _snapshot_render_frontmatter \
+        "${TASK_ID}" do /dr-do "${captured_at}" agent /dr-qa \
+        "${OPTIONS_TMP}" 8192 true > "${probe}"
+    local probe_bytes body_bytes
+    probe_bytes="$(wc -c < "${probe}" | tr -d ' ')"
+    body_bytes=$((1002 - probe_bytes))
+    [ "${body_bytes}" -gt 0 ]
+    python3 -c "print('X' * ${body_bytes}, end='')" > "${boundary_body}"
+    [ "$(wc -c < "${boundary_body}" | tr -d ' ')" -eq "${body_bytes}" ]
+
+    run bash "${WRITER_WRAPPER}" \
+        --root "${FAKE_ROOT}" --task "${TASK_ID}" --stage do --command /dr-do \
+        --captured-by agent --recommended-next /dr-qa \
+        --options-file "${OPTIONS_TMP}" --body-file "${boundary_body}" \
+        --captured-at "${captured_at}"
+    [ "$status" -eq 0 ]
+
+    local snapshot="${FAKE_ROOT}/datarim/snapshots/${TASK_ID}.snapshot.md"
+    local declared actual
+    declared="$(sed -n 's/^size_bytes: //p' "${snapshot}")"
+    actual="$(wc -c < "${snapshot}" | tr -d ' ')"
+    [ "${declared}" -eq "${actual}" ]
+    [ "${actual}" -ge 1000 ]
 }
 
 @test "E2E — exact-size renderer converges across the 9999 to 10000 decimal-width boundary" {

--- a/tests/stage-snapshot-size-cap.bats
+++ b/tests/stage-snapshot-size-cap.bats
@@ -13,6 +13,13 @@ setup() {
     # shellcheck source=/dev/null
     . "$WRITER_LIB"
 }
+assert_declared_size_matches() {
+    local file="$1"
+    local declared actual
+    declared="$(sed -n 's/^size_bytes: //p' "$file")"
+    actual="$(wc -c < "$file")"
+    [ "$declared" -eq "$actual" ]
+}
 
 @test "body under 8192 bytes → no truncation marker" {
     local body="$BATS_TEST_TMPDIR/small.txt"
@@ -24,6 +31,7 @@ setup() {
     local snap="$TMPROOT/datarim/snapshots/TUNE-0254.snapshot.md"
     ! grep -q 'snapshot-truncated' "$snap"
     grep -q '^truncated: false$' "$snap"
+    assert_declared_size_matches "$snap"
 }
 
 @test "body over 8192 bytes → marker present + file ≤ 8192 + truncated: true" {
@@ -39,4 +47,5 @@ setup() {
     [ "$size" -le 8192 ]
     grep -q 'snapshot-truncated' "$snap"
     grep -q '^truncated: true$' "$snap"
+    assert_declared_size_matches "$snap"
 }

--- a/tests/stage-snapshot-utf8-truncation.bats
+++ b/tests/stage-snapshot-utf8-truncation.bats
@@ -23,6 +23,13 @@ setup() {
     # shellcheck source=/dev/null
     . "$WRITER_LIB"
 }
+assert_declared_size_matches() {
+    local file="$1"
+    local declared actual
+    declared="$(sed -n 's/^size_bytes: //p' "$file")"
+    actual="$(wc -c < "$file")"
+    [ "$declared" -eq "$actual" ]
+}
 
 assert_valid_utf8() {
     local file="$1"
@@ -52,6 +59,7 @@ assert_valid_utf8() {
     [ "$size" -le 8192 ]
     assert_valid_utf8 "$snap"
     grep -q 'snapshot-truncated' "$snap"
+    assert_declared_size_matches "$snap"
 }
 
 @test "f5b emoji body truncated to valid utf8" {
@@ -70,6 +78,7 @@ assert_valid_utf8() {
     [ "$size" -le 8192 ]
     assert_valid_utf8 "$snap"
     grep -q 'snapshot-truncated' "$snap"
+    assert_declared_size_matches "$snap"
 }
 
 @test "f5c ascii body still passes regression guard" {
@@ -86,4 +95,5 @@ assert_valid_utf8() {
     size="$(wc -c < "$snap" | tr -d ' ')"
     [ "$size" -le 8192 ]
     assert_valid_utf8 "$snap"
+    assert_declared_size_matches "$snap"
 }


### PR DESCRIPTION
## Summary

- Add a wrapper-level regression for ordinary bodies without a leading newline, preventing YAML/body separator gluing.
- Add a wrapper-level regression that crosses the 999-to-1000 decimal-width boundary and requires exact declared byte size.

## Verification

- Focused Bats: 2/2 passed.
- Snapshot/replay Bats family: 67/67 passed.
- ShellCheck: clean for writer, wrapper, and validator.
- Bash syntax checks: clean.
- Bounded whitespace scan: clean.

## Scope

Tests only. No release, deployment, or merge is included in this PR.