### PR TITLE
fix(snapshot-writer): head -c 0 is GNU-only, aborting the cap guard on macOS

### DIFF
--- a/scripts/lib/snapshot-writer.sh
+++ b/scripts/lib/snapshot-writer.sh
@@ -287,7 +287,18 @@ write_stage_snapshot() {
         # macOS libiconv exits 1 + writes a stderr warning on incomplete
         # trailing sequences (the very case we are normalising), so we
         # absorb the exit code with `|| true` and silence stderr.
-        head -c "$max_body" "$body_file" > "$raw_chunk"
+        # `head -c 0` is NOT portable: GNU coreutils accepts it and emits
+        # nothing, BSD/macOS head rejects it with "illegal byte count -- 0"
+        # and exits 1. max_body is legitimately clamped to 0 above when the
+        # frontmatter alone consumes the whole cap (oversized --options-file),
+        # so this path IS reachable — and on macOS it aborted the writer
+        # before the cap check could fail closed, turning a hard guard into a
+        # silent pass. Linux-only CI never saw it.
+        if [ "$max_body" -eq 0 ]; then
+            : > "$raw_chunk"
+        else
+            head -c "$max_body" "$body_file" > "$raw_chunk"
+        fi
         iconv -c -f UTF-8 -t UTF-8 "$raw_chunk" > "$body_tmp" 2>/dev/null || true
         rm -f "$raw_chunk"
         printf '\n%s\n' "$SNAPSHOT_TRUNCATION_MARKER" >> "$body_tmp"

--- a/tests/stage-snapshot-size-cap.bats
+++ b/tests/stage-snapshot-size-cap.bats
@@ -40,3 +40,25 @@ setup() {
     grep -q 'snapshot-truncated' "$snap"
     grep -q '^truncated: true$' "$snap"
 }
+
+@test "zero-width body budget does not abort the writer on BSD head (portability)" {
+    # When an oversized --options-file makes the frontmatter alone consume the
+    # whole cap, max_body is clamped to 0 and the truncation path runs with a
+    # zero byte count. `head -c 0` is a GNU-only spelling: BSD/macOS head exits
+    # 1 with "illegal byte count -- 0". That aborted the writer BEFORE the cap
+    # check could fail closed, converting a hard guard into a silent pass on
+    # macOS while Linux-only CI stayed green.
+    local huge_options="$BATS_TEST_TMPDIR/huge-options.txt"
+    local body="$BATS_TEST_TMPDIR/zero-budget-body.txt"
+    python3 -c 'print("/dr-qa TUNE-0254 | " + "X" * 9000)' > "$huge_options"
+    printf 'ordinary body\n' > "$body"
+
+    run write_stage_snapshot \
+        --root "$TMPROOT" --task TUNE-0254 --stage do --command /dr-do \
+        --captured-by agent --recommended-next /dr-qa \
+        --options-file "$huge_options" --body-file "$body"
+
+    # The cap guard must fire, not a BSD "illegal byte count" abort.
+    [ "$status" -eq 1 ]
+    [[ "$output" != *"illegal byte count"* ]]
+}


### PR DESCRIPTION
## The bug

An oversized `--options-file` makes the frontmatter alone consume the whole 8192-byte cap, so `max_body` is deliberately clamped to `0` and the truncation path runs with a zero byte count.

`head -c 0` is **not portable**:

| Platform | Behaviour |
|---|---|
| GNU coreutils (Linux, CI) | accepts, emits nothing |
| BSD / macOS | `illegal byte count -- 0`, exit 1 |

Under `set -e` that aborted the writer **before the cap check could fail closed** — converting a hard guard into a silent pass on macOS.

## Why it survived

CI is Linux-only. `tests/stage-snapshot-e2e.bats` → *"oversized options fail closed before publishing any snapshot"* was **already failing on clean main** on macOS, and nothing surfaced it. This is the second defect in this family found only by running the full suite on a developer machine.

## The fix

Guard the zero case with an explicit truncate rather than shelling out to `head`.

## Verification

- Snapshot family: **16/16 passing**, 0 failures
- `shellcheck -S warning`: clean
- New regression test is **mutation-verified** — restoring the bare `head -c` makes it fail