### PR TITLE
fix(snapshot): reland TUNE-0334 TASK-ID regex — slug-suffix FU IDs

### DIFF
--- a/scripts/lib/snapshot-writer.sh
+++ b/scripts/lib/snapshot-writer.sh
@@ -16,7 +16,7 @@ SNAPSHOT_WRITER_LIB_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=resolve-datarim-root.sh
 . "${SNAPSHOT_WRITER_LIB_DIR}/resolve-datarim-root.sh"
 
-readonly SNAPSHOT_TASK_ID_RE='^[A-Z][A-Z0-9-]+-[0-9]{4,5}$'
+readonly SNAPSHOT_TASK_ID_RE='^[A-Z]{2,10}-[0-9]{4}(-[A-Za-z0-9]+)*$'
 readonly SNAPSHOT_STAGE_RE='^(init|prd|plan|design|do|qa|verify|compliance|archive|edit|publish|write|dream|doctor|optimize|auto)$'
 readonly SNAPSHOT_MAX_BYTES=8192
 readonly SNAPSHOT_TRUNCATION_MARKER='<!-- snapshot-truncated, full ответ см. session jsonl -->'

--- a/skills/stage-snapshot-writer/SKILL.md
+++ b/skills/stage-snapshot-writer/SKILL.md
@@ -32,7 +32,7 @@ All arguments are named (`--flag value`) and forwarded verbatim by the wrapper:
 ```bash
 bash "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/snapshot-writer-wrapper.sh" \
     --root <DATARIM_ROOT> \             # absolute path to repo root
-    --task <TASK-ID> \                  # ^[A-Z][A-Z0-9-]+-[0-9]{4,5}$
+    --task <TASK-ID> \                  # ^[A-Z]{2,10}-[0-9]{4}(-[A-Za-z0-9]+)*$
     --stage <plan|prd|do|qa|verify|auto|...> \
     --command </dr-name> \              # literal "/dr-<name>"
     --captured-by <agent|operator> \
@@ -95,7 +95,7 @@ truncated: false
 
 ## Security controls (Appendix A cross-link)
 
-- **T-1 path traversal:** TASK-ID validated against `^[A-Z][A-Z0-9-]+-[0-9]{4,5}$`; reject otherwise.
+- **T-1 path traversal:** TASK-ID validated against `^[A-Z]{2,10}-[0-9]{4}(-[A-Za-z0-9]+)*$`; reject otherwise.
 - **T-2 shell injection:** body read via `--body-file` (no shell expansion); frontmatter via quoted heredoc (Security Mandate S1).
 - **T-3 concurrent writers:** mkdir lock, write-temp-rename (atomic on POSIX).
 - **T-5 secret leak:** `chmod 600` on snapshot file; `.gitignore` covers `datarim/snapshots/`.

--- a/tests/stage-snapshot-id-regex.bats
+++ b/tests/stage-snapshot-id-regex.bats
@@ -1,0 +1,214 @@
+#!/usr/bin/env bats
+#
+# Regression tests for the TASK-ID regex in snapshot-writer.sh.
+#
+# Verifies:
+#   - Slug-suffix IDs (e.g. DEV-1438-FU-engage-generator-perf) are accepted.
+#   - Canonical short IDs (e.g. TUNE-0334) continue to be accepted.
+#   - Path-traversal and malformed IDs are still rejected (T-1 security control).
+#
+# Canonical regex: ^[A-Z]{2,10}-[0-9]{4}(-[A-Za-z0-9]+)*$
+
+REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+WRITER_LIB="${REPO_ROOT}/scripts/lib/snapshot-writer.sh"
+
+setup() {
+    export TMPROOT="$BATS_TEST_TMPDIR/fake-repo"
+    mkdir -p "$TMPROOT/datarim"
+    export OPTIONS="$BATS_TEST_TMPDIR/options.txt"
+    printf '/dr-qa TUNE-0334 | verify\n' > "$OPTIONS"
+    export BODY="$BATS_TEST_TMPDIR/body.txt"
+    printf 'snapshot body for regex regression test\n' > "$BODY"
+    # shellcheck source=/dev/null
+    . "$WRITER_LIB"
+}
+
+# ---------------------------------------------------------------------------
+# Accepted IDs
+# ---------------------------------------------------------------------------
+
+@test "canonical 4-digit ID (TUNE-0334) is accepted" {
+    run write_stage_snapshot \
+        --root "$TMPROOT" \
+        --task TUNE-0334 \
+        --stage 'do' \
+        --command /dr-do \
+        --captured-by agent \
+        --recommended-next /dr-qa \
+        --options-file "$OPTIONS" \
+        --body-file "$BODY"
+    [ "$status" -eq 0 ]
+    [ -f "$TMPROOT/datarim/snapshots/TUNE-0334.snapshot.md" ]
+}
+
+@test "slug-suffix FU ID (DEV-1438-FU-engage-generator-perf) is accepted" {
+    run write_stage_snapshot \
+        --root "$TMPROOT" \
+        --task DEV-1438-FU-engage-generator-perf \
+        --stage 'do' \
+        --command /dr-do \
+        --captured-by agent \
+        --recommended-next /dr-qa \
+        --options-file "$OPTIONS" \
+        --body-file "$BODY"
+    [ "$status" -eq 0 ]
+    [ -f "$TMPROOT/datarim/snapshots/DEV-1438-FU-engage-generator-perf.snapshot.md" ]
+}
+
+@test "multi-segment suffix ID (INFRA-0042-hotfix-db) is accepted" {
+    run write_stage_snapshot \
+        --root "$TMPROOT" \
+        --task INFRA-0042-hotfix-db \
+        --stage plan \
+        --command /dr-plan \
+        --captured-by agent \
+        --recommended-next /dr-do \
+        --options-file "$OPTIONS" \
+        --body-file "$BODY"
+    [ "$status" -eq 0 ]
+    [ -f "$TMPROOT/datarim/snapshots/INFRA-0042-hotfix-db.snapshot.md" ]
+}
+
+@test "10-char prefix ID (ABCDEFGHIJ-0001) is accepted (max prefix length)" {
+    run write_stage_snapshot \
+        --root "$TMPROOT" \
+        --task ABCDEFGHIJ-0001 \
+        --stage 'do' \
+        --command /dr-do \
+        --captured-by agent \
+        --recommended-next /dr-qa \
+        --options-file "$OPTIONS" \
+        --body-file "$BODY"
+    [ "$status" -eq 0 ]
+    [ -f "$TMPROOT/datarim/snapshots/ABCDEFGHIJ-0001.snapshot.md" ]
+}
+
+# ---------------------------------------------------------------------------
+# Rejected IDs — T-1 path-traversal + malformed (security control)
+# ---------------------------------------------------------------------------
+
+@test "path-traversal ../etc/passwd is rejected (T-1)" {
+    run write_stage_snapshot \
+        --root "$TMPROOT" \
+        --task '../etc/passwd' \
+        --stage 'do' \
+        --command /dr-do \
+        --captured-by agent \
+        --recommended-next /dr-qa \
+        --options-file "$OPTIONS" \
+        --body-file "$BODY"
+    [ "$status" -eq 1 ]
+    [ ! -f "$TMPROOT/datarim/snapshots/../etc/passwd.snapshot.md" ]
+}
+
+@test "ID with slash (FOO/../bar) is rejected (T-1)" {
+    run write_stage_snapshot \
+        --root "$TMPROOT" \
+        --task 'FOO/../bar' \
+        --stage 'do' \
+        --command /dr-do \
+        --captured-by agent \
+        --recommended-next /dr-qa \
+        --options-file "$OPTIONS" \
+        --body-file "$BODY"
+    [ "$status" -eq 1 ]
+}
+
+@test "too-short prefix (AB-1234) is rejected — prefix requires 2+ uppercase chars (already 2; only 1-char prefix rejected)" {
+    # AB has 2 chars which satisfies {2,10} — so AB-1234 MUST be accepted.
+    # This test documents that 1-char prefix single-letter IDs like A-1234 are rejected.
+    run write_stage_snapshot \
+        --root "$TMPROOT" \
+        --task 'A-1234' \
+        --stage 'do' \
+        --command /dr-do \
+        --captured-by agent \
+        --recommended-next /dr-qa \
+        --options-file "$OPTIONS" \
+        --body-file "$BODY"
+    [ "$status" -eq 1 ]
+}
+
+@test "lowercase prefix (lowercase-0001) is rejected" {
+    run write_stage_snapshot \
+        --root "$TMPROOT" \
+        --task 'lowercase-0001' \
+        --stage 'do' \
+        --command /dr-do \
+        --captured-by agent \
+        --recommended-next /dr-qa \
+        --options-file "$OPTIONS" \
+        --body-file "$BODY"
+    [ "$status" -eq 1 ]
+}
+
+@test "3-digit number (TUNE-034) is rejected — requires 4 digits" {
+    run write_stage_snapshot \
+        --root "$TMPROOT" \
+        --task 'TUNE-034' \
+        --stage 'do' \
+        --command /dr-do \
+        --captured-by agent \
+        --recommended-next /dr-qa \
+        --options-file "$OPTIONS" \
+        --body-file "$BODY"
+    [ "$status" -eq 1 ]
+}
+
+@test "ID with dot (TUNE-0334.bak) is rejected — dots not in suffix charclass" {
+    run write_stage_snapshot \
+        --root "$TMPROOT" \
+        --task 'TUNE-0334.bak' \
+        --stage 'do' \
+        --command /dr-do \
+        --captured-by agent \
+        --recommended-next /dr-qa \
+        --options-file "$OPTIONS" \
+        --body-file "$BODY"
+    [ "$status" -eq 1 ]
+}
+
+@test "ID with space (TUNE 0334) is rejected" {
+    run write_stage_snapshot \
+        --root "$TMPROOT" \
+        --task 'TUNE 0334' \
+        --stage 'do' \
+        --command /dr-do \
+        --captured-by agent \
+        --recommended-next /dr-qa \
+        --options-file "$OPTIONS" \
+        --body-file "$BODY"
+    [ "$status" -eq 1 ]
+}
+
+@test "prefix longer than 10 chars (ABCDEFGHIJK-0001) is rejected" {
+    run write_stage_snapshot \
+        --root "$TMPROOT" \
+        --task 'ABCDEFGHIJK-0001' \
+        --stage 'do' \
+        --command /dr-do \
+        --captured-by agent \
+        --recommended-next /dr-qa \
+        --options-file "$OPTIONS" \
+        --body-file "$BODY"
+    [ "$status" -eq 1 ]
+}
+
+# ---------------------------------------------------------------------------
+# Snapshot content sanity for slug-suffix IDs
+# ---------------------------------------------------------------------------
+
+@test "snapshot written for slug-suffix ID has correct task_id in frontmatter" {
+    write_stage_snapshot \
+        --root "$TMPROOT" \
+        --task DEV-1438-FU-engage-generator-perf \
+        --stage 'do' \
+        --command /dr-do \
+        --captured-by agent \
+        --recommended-next /dr-qa \
+        --options-file "$OPTIONS" \
+        --body-file "$BODY"
+    local snap="$TMPROOT/datarim/snapshots/DEV-1438-FU-engage-generator-perf.snapshot.md"
+    grep -q '^task_id: DEV-1438-FU-engage-generator-perf$' "$snap"
+    grep -q '^artifact: stage-snapshot$' "$snap"
+}


### PR DESCRIPTION
## What

Relands `TUNE-0334`, archived 2026-06-18 as complete but **never merged**.

## Why this is a real defect, not bookkeeping

The archive records the fix, a version bump to 2.40.1, and a 13-case regression suite. None of it is in the shipped tree. The branch was tagged `zz-archived/feat/tune-0334-snapshot-id-regex` and dropped; the work survived only as unreferenced commit `e67efcc`.

Consequence: `snapshot-writer.sh` kept the strict `^[A-Z][A-Z0-9-]+-[0-9]{4,5}$`, which anchors immediately after the digits. Every slug-suffix follow-up ID was rejected, so **stage-snapshot and `/dr-next` resume were silently unavailable** for those tasks — for six weeks after the archive said otherwise. Same `documented-but-unwired` class this closure programme exists to catch, with an extra twist: here the *archive itself* was the false evidence.

## Trap avoided

Checking the old branch out wholesale reverted `snapshot-writer.sh` by 165 lines to its June state — silently dropping the **v2.60.1 `head -c 0` cap-guard portability fix**. Only the regex constant and the two `SKILL.md` mentions are carried over; the guard is verified still present.

## Verification

- 13/13 new cases pass
- **Mutation-tested** — restoring the old regex fails 4 cases, so the suite is load-bearing
- Full suite **2583 passing**, 0 failures
- T-1 path traversal preserved: suffix charclass `[A-Za-z0-9]` excludes `/`, `.`, control chars; `../etc/passwd` and `FOO/../bar` asserted rejected

## Scope note

No VERSION/CHANGELOG bump here — the archived 2.40.1 is long superseded. This rides the next release.