### PR TITLE
feat(cli): close Phase 5 config and plugin surface

### DIFF
--- a/cli/datarim
+++ b/cli/datarim
@@ -79,6 +79,15 @@ Tmux pane control (Phase 4, /hooks/tmux HTTP-proxy):
   tmux kill <pane> [--force] [--json]
   tmux read <pane> [--lines N] [--json]
 
+Configuration + plugin proxy (Phase 5):
+  config get <key> [--json]
+  config set <key> <value>             Compatibility refusal (exit 20)
+  plugin list
+  plugin enable <absolute-plugin-path>
+  plugin disable <plugin-id>
+  plugin sync
+  plugin doctor [--fix]
+
 Slash dispatch + audit (Phase 3 baseline):
   run <slash-cmd> [args]                Dispatch slash command to /dr-orchestrate
   audit log [--day YYYY-MM-DD]
@@ -157,6 +166,27 @@ main() {
                 tmux_subcommand "$@"
             else
                 printf '[datarim] tmux subcommand not installed (cli/subcommands/tmux.sh missing)\n' >&2
+                exit 2
+            fi
+            ;;
+        config)
+            if [ -f "$SUBCMD_DIR/config.sh" ]; then
+                # shellcheck source=cli/subcommands/config.sh
+                . "$SUBCMD_DIR/config.sh"
+                config_subcommand "$@"
+            else
+                printf '[datarim] config subcommand not installed (cli/subcommands/config.sh missing)\n' >&2
+                exit 2
+            fi
+            ;;
+        plugin)
+            validate_agent_id || exit $?
+            if [ -f "$SUBCMD_DIR/plugin.sh" ]; then
+                # shellcheck source=cli/subcommands/plugin.sh
+                . "$SUBCMD_DIR/plugin.sh"
+                plugin_subcommand "$@"
+            else
+                printf '[datarim] plugin subcommand not installed (cli/subcommands/plugin.sh missing)\n' >&2
                 exit 2
             fi
             ;;

--- a/cli/subcommands/config.sh
+++ b/cli/subcommands/config.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# TUNE-0268 Phase 5 compatibility surface.
+#
+# The historic generic config-write design is superseded: current settings have
+# separate canonical owners and some contain secrets. This command therefore
+# exposes only non-secret derived state and refuses every mutation.
+
+set -u
+
+CLI_DIR_CONFIG_SUB="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LIB_DIR_CONFIG_SUB="$CLI_DIR_CONFIG_SUB/lib"
+
+# shellcheck source=cli/lib/workspace.sh
+. "$LIB_DIR_CONFIG_SUB/workspace.sh"
+# shellcheck source=cli/lib/output.sh
+. "$LIB_DIR_CONFIG_SUB/output.sh"
+
+_config_validate_key() {
+    local key="${1:-}"
+    case "$key" in [a-z][a-z0-9_]*) ;; *) return 1 ;; esac
+    case "$key" in *[!a-z0-9_]*) return 1 ;; esac
+}
+
+_config_emit_value() {
+    local key="$1" value_json="$2" plain="$3" json="$4"
+    if [ "$json" -eq 1 ]; then
+        export DATARIM_CLI_CMD="config get" OUTPUT_MODE=json
+        output_emit_json "$(jq -cn --arg key "$key" --argjson value "$value_json" '{key:$key,value:$value}')"
+    else
+        printf '%s\n' "$plain"
+    fi
+}
+
+_config_get() {
+    local key="" json=0 arg root version manifest status
+    while [ $# -gt 0 ]; do
+        arg="$1"
+        case "$arg" in
+            --json) json=1; shift ;;
+            --config) output_emit_error "$(exit_code_of AAL_LOCKED_KEY)" AAL_LOCKED_KEY \
+                "generic config files are superseded; --config is not supported" ;;
+            -*) output_emit_error "$(exit_code_of MISUSE)" MISUSE "config get: unknown flag $arg" ;;
+            *) [ -z "$key" ] || output_emit_error "$(exit_code_of MISUSE)" MISUSE "config get: extra argument $arg"
+               key="$arg"; shift ;;
+        esac
+    done
+    _config_validate_key "$key" || output_emit_error "$(exit_code_of MISUSE)" MISUSE "config get: safe key required"
+    root="${DATARIM_ROOT:-${CLI_DIR_CONFIG_SUB%/cli}}"
+    case "$key" in
+        framework_version)
+            [ -f "$root/VERSION" ] || output_emit_error "$(exit_code_of NOT_FOUND)" NOT_FOUND "framework VERSION is unavailable"
+            version="$(tr -d '\r\n' < "$root/VERSION")"
+            _config_emit_value "$key" "$(jq -Rn --arg value "$version" '$value')" "$version" "$json"
+            ;;
+        plugin_manifest_status)
+            manifest="$(ws_resolve)/datarim/enabled-plugins.md"
+            if [ -f "$manifest" ]; then status=present; else status=absent; fi
+            _config_emit_value "$key" "$(jq -Rn --arg value "$status" '$value')" "$status" "$json"
+            ;;
+        *)
+            output_emit_error "$(exit_code_of AAL_LOCKED_KEY)" AAL_LOCKED_KEY \
+                "config key '$key' is managed by its canonical owner and is not exposed through this CLI"
+            ;;
+    esac
+}
+
+_config_set() {
+    local key="${1:-}" value="${2:-}"
+    _config_validate_key "$key" || output_emit_error "$(exit_code_of MISUSE)" MISUSE "config set: safe key required"
+    [ -n "$value" ] || output_emit_error "$(exit_code_of MISUSE)" MISUSE "config set: value required"
+    output_emit_error "$(exit_code_of AAL_LOCKED_KEY)" AAL_LOCKED_KEY \
+        "generic config mutation is superseded; use the canonical owner for '$key'"
+}
+
+config_subcommand() {
+    local op="${1:-}"; shift || true
+    case "$op" in
+        get) _config_get "$@" ;;
+        set) _config_set "$@" ;;
+        *) output_emit_error "$(exit_code_of MISUSE)" MISUSE "usage: datarim config get|set ..." ;;
+    esac
+}

--- a/cli/subcommands/plugin.sh
+++ b/cli/subcommands/plugin.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# TUNE-0268 Phase 5 — thin wrapper over the canonical dr-plugin controller.
+# This file never edits plugin state itself.
+
+set -u
+
+CLI_DIR_PLUGIN_SUB="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LIB_DIR_PLUGIN_SUB="$CLI_DIR_PLUGIN_SUB/lib"
+
+# shellcheck source=cli/lib/output.sh
+. "$LIB_DIR_PLUGIN_SUB/output.sh"
+# shellcheck source=cli/lib/exit-codes.sh
+. "$LIB_DIR_PLUGIN_SUB/exit-codes.sh"
+DR_PLUGIN_SCRIPT="${CLI_DIR_PLUGIN_SUB%/cli}/scripts/dr-plugin.sh"
+
+_plugin_invoke() {
+    [ -x "$DR_PLUGIN_SCRIPT" ] || output_emit_error "$(exit_code_of DEPENDENCY_MISSING)" DEPENDENCY_MISSING \
+        "canonical plugin controller is unavailable"
+    "$DR_PLUGIN_SCRIPT" "$@"
+}
+
+plugin_subcommand() {
+    local op="${1:-}"; shift || true
+    case "$op" in
+        list)
+            [ $# -eq 0 ] || output_emit_error "$(exit_code_of MISUSE)" MISUSE "usage: datarim plugin list"
+            _plugin_invoke list
+            ;;
+        enable|disable)
+            [ $# -eq 1 ] || output_emit_error "$(exit_code_of MISUSE)" MISUSE "usage: datarim plugin $op <target>"
+            _plugin_invoke "$op" "$1"
+            ;;
+        sync)
+            [ $# -eq 0 ] || output_emit_error "$(exit_code_of MISUSE)" MISUSE "usage: datarim plugin sync"
+            _plugin_invoke sync
+            ;;
+        doctor)
+            case $# in 0) _plugin_invoke doctor ;; 1) [ "$1" = "--fix" ] || output_emit_error "$(exit_code_of MISUSE)" MISUSE "usage: datarim plugin doctor [--fix]"; _plugin_invoke doctor --fix ;; *) output_emit_error "$(exit_code_of MISUSE)" MISUSE "usage: datarim plugin doctor [--fix]" ;; esac
+            ;;
+        *) output_emit_error "$(exit_code_of MISUSE)" MISUSE "usage: datarim plugin list|enable|disable|sync|doctor" ;;
+    esac
+}

--- a/cli/tests/config-phase5.bats
+++ b/cli/tests/config-phase5.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+# TUNE-0268 Phase 5 — non-secret derived reads and fail-closed writes.
+
+setup() {
+    CLI_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    DATARIM_BIN="$CLI_DIR/datarim"
+    TMP_DIR="$(mktemp -d)"
+    export HOME="$TMP_DIR/home"
+    export DATARIM_WORKSPACE_ROOT="$TMP_DIR/workspace"
+    export DATARIM_CLI_AUDIT_DIR="$TMP_DIR/audit"
+    export DATARIM_CLI_HALT_PATH="$TMP_DIR/HALT"
+    mkdir -p "$HOME/.config/datarim-cli" "$DATARIM_WORKSPACE_ROOT/datarim"
+    export DATARIM_ROOT="$DATARIM_WORKSPACE_ROOT"
+    printf '9.9.9-test\n' > "$DATARIM_ROOT/VERSION"
+    printf '%s\n' 'notifier_targets: secret-bearing' > "$HOME/.config/datarim-cli/config.yaml"
+    printf '%s\n' '# Enabled Plugins' 'secret_ref: must-not-leak' > "$DATARIM_WORKSPACE_ROOT/datarim/enabled-plugins.md"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+@test "Phase 5 config get exposes only derived framework version" {
+    run "$DATARIM_BIN" config get framework_version
+    [ "$status" -eq 0 ]
+    [ "$output" = "9.9.9-test" ]
+}
+
+@test "Phase 5 config get --json emits the canonical envelope" {
+    run "$DATARIM_BIN" config get plugin_manifest_status --json
+    [ "$status" -eq 0 ]
+    printf '%s' "$output" | jq -e '.command == "config get" and .data.key == "plugin_manifest_status" and .data.value == "present"' >/dev/null
+}
+
+@test "Phase 5 config get rejects arbitrary keys without returning source bytes" {
+    run "$DATARIM_BIN" config get notifier_targets
+    [ "$status" -eq 20 ]
+    [[ "$output" != *"secret-bearing"* ]]
+}
+
+@test "current-ground config set is read-only and preserves both sources" {
+    user_before="$(sha256sum "$HOME/.config/datarim-cli/config.yaml" | awk '{print $1}')"
+    manifest_before="$(sha256sum "$DATARIM_WORKSPACE_ROOT/datarim/enabled-plugins.md" | awk '{print $1}')"
+    run "$DATARIM_BIN" config set debug false
+    [ "$status" -eq 20 ]
+    [ "$user_before" = "$(sha256sum "$HOME/.config/datarim-cli/config.yaml" | awk '{print $1}')" ]
+    [ "$manifest_before" = "$(sha256sum "$DATARIM_WORKSPACE_ROOT/datarim/enabled-plugins.md" | awk '{print $1}')" ]
+}
+
+@test "V-AC-11: aal_class downgrade fails closed with exit 20 and preserves files" {
+    before="$(sha256sum "$DATARIM_WORKSPACE_ROOT/datarim/enabled-plugins.md" | awk '{print $1}')"
+    run "$DATARIM_BIN" config set aal_class 2
+    [ "$status" -eq 20 ]
+    [[ "$output" == *"AAL_LOCKED_KEY"* ]]
+    after="$(sha256sum "$DATARIM_WORKSPACE_ROOT/datarim/enabled-plugins.md" | awk '{print $1}')"
+    [ "$before" = "$after" ]
+}
+
+@test "enabled_plugins cannot create split-brain with the plugin manifest" {
+    run "$DATARIM_BIN" config set enabled_plugins anything
+    [ "$status" -eq 20 ]
+    ! grep -q 'anything' "$DATARIM_WORKSPACE_ROOT/datarim/enabled-plugins.md"
+}
+
+@test "config set refuses unsafe or unknown key syntax" {
+    run "$DATARIM_BIN" config set 'x.y' bad
+    [ "$status" -eq 2 ]
+    run "$DATARIM_BIN" config set unknown_key bad
+    [ "$status" -eq 20 ]
+}
+
+@test "HALT is evaluated before Phase 5 config dispatch" {
+    : > "$DATARIM_CLI_HALT_PATH"
+    run "$DATARIM_BIN" config get framework_version
+    [ "$status" -eq 17 ]
+    [[ "$output" == *"HALT"* ]]
+}

--- a/cli/tests/plugin-phase5.bats
+++ b/cli/tests/plugin-phase5.bats
@@ -1,0 +1,66 @@
+#!/usr/bin/env bats
+# TUNE-0268 Phase 5 — plugin operations delegate to the canonical controller.
+
+setup() {
+    CLI_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    DATARIM_BIN="$CLI_DIR/datarim"
+    TMP_DIR="$(mktemp -d)"
+    export DATARIM_CLI_AUDIT_DIR="$TMP_DIR/audit"
+    export DATARIM_CLI_HALT_PATH="$TMP_DIR/HALT"
+    export DATARIM_CLI_AGENT_ID="$("$CLI_DIR/lib/uuid7-gen.sh")"
+    unset DATARIM_CLI_NOTIFIER_TARGETS DATARIM_CLI_NOTIFY_STUB_RESULT
+    CONTROLLER="$TMP_DIR/dr-plugin-controller"
+    cat > "$CONTROLLER" <<'EOF'
+#!/usr/bin/env bash
+exit "${PLUGIN_RC:-0}"
+EOF
+    chmod +x "$CONTROLLER"
+}
+
+teardown() {
+    rm -rf "$TMP_DIR"
+}
+
+@test "plugin list delegates to the canonical dr-plugin script" {
+    run bash -c 'source "$1"; _plugin_invoke() { printf "delegated:%s\n" "$*"; }; plugin_subcommand list' _ "$CLI_DIR/subcommands/plugin.sh"
+    [ "$status" -eq 0 ]
+    [ "$output" = "delegated:list" ]
+    grep -q 'scripts/dr-plugin.sh' "$CLI_DIR/subcommands/plugin.sh"
+    ! grep -q 'run_subcommand' "$CLI_DIR/subcommands/plugin.sh"
+}
+
+@test "plugin wrapper preserves canonical controller exit codes" {
+    for expected in 0 1 2 3 64; do
+        run bash -c 'source "$1"; DR_PLUGIN_SCRIPT="$2"; export PLUGIN_RC="$3"; plugin_subcommand list' _ \
+            "$CLI_DIR/subcommands/plugin.sh" "$CONTROLLER" "$expected"
+        [ "$status" -eq "$expected" ]
+    done
+}
+
+@test "plugin enable passes an absolute source path unchanged" {
+    run bash -c 'source "$1"; _plugin_invoke() { printf "delegated:%s\n" "$*"; }; plugin_subcommand enable /opt/plugins/example' _ "$CLI_DIR/subcommands/plugin.sh"
+    [ "$status" -eq 0 ]
+    [ "$output" = "delegated:enable /opt/plugins/example" ]
+}
+
+@test "plugin disable reaches canonical delegation" {
+    run bash -c 'source "$1"; _plugin_invoke() { printf "delegated:%s\n" "$*"; }; plugin_subcommand disable dr-orchestrate' _ "$CLI_DIR/subcommands/plugin.sh"
+    [ "$status" -eq 0 ]
+    [ "$output" = "delegated:disable dr-orchestrate" ]
+}
+
+@test "plugin sync and doctor --fix remain in parity with the canonical CLI" {
+    run bash -c 'source "$1"; _plugin_invoke() { printf "delegated:%s\n" "$*"; }; plugin_subcommand sync' _ "$CLI_DIR/subcommands/plugin.sh"
+    [ "$status" -eq 0 ]
+    [ "$output" = "delegated:sync" ]
+    run bash -c 'source "$1"; _plugin_invoke() { printf "delegated:%s\n" "$*"; }; plugin_subcommand doctor --fix' _ "$CLI_DIR/subcommands/plugin.sh"
+    [ "$status" -eq 0 ]
+    [ "$output" = "delegated:doctor --fix" ]
+}
+
+@test "HALT is evaluated before Phase 5 plugin dispatch" {
+    : > "$DATARIM_CLI_HALT_PATH"
+    run "$DATARIM_BIN" plugin list
+    [ "$status" -eq 17 ]
+    [[ "$output" == *"HALT"* ]]
+}

--- a/documentation/reference/cli.md
+++ b/documentation/reference/cli.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `datarim` CLI is the external-agent surface for Datarim — it lets a non-interactive process (Codex, Cursor, or a custom agent) drive the full `/dr-*` pipeline through the existing `/dr-orchestrate v2.5.0` webhook. AAL 3 is opt-in only and requires an `accepted-risk-aal.yml` entry `tune-0268-aal3-cli`. Phase 3 ships HTTP dispatch plus six AAL 3 mitigations.
+The `datarim` CLI is the external-agent surface for Datarim — it lets a non-interactive process (Codex, Cursor, or a custom agent) inspect local state and drive eligible `/dr-*` operations through the existing `/dr-orchestrate` webhook. AAL 3 is opt-in only and requires an `accepted-risk-aal.yml` entry `tune-0268-aal3-cli`. Hard-gated actions remain operator-controlled; a notifier acknowledgement is observability, not authorization.
 
 ## When to use CLI vs slash command
 
@@ -40,7 +40,7 @@ To stand up the listener:
 
 ```bash
 # 1. Activate the plugin (creates ~/.claude/plugins/dr-orchestrate symlinks).
-/dr-plugin enable dr-orchestrate
+/dr-plugin enable /absolute/path/to/code/datarim/plugins/dr-orchestrate
 
 # 2. Install adnanh/webhook (one option — see https://github.com/adnanh/webhook for others).
 brew install webhook                  # macOS
@@ -80,13 +80,40 @@ Applies 90-day retention: files untouched for <90d remain as-is, files 90-180d o
 
 Prints summary counters for the audit log.
 
+### `datarim config get <key> [--json]`
+
+Exposes only non-secret derived state. Supported keys are
+`framework_version` and `plugin_manifest_status`. Generic config files no longer
+have one canonical schema: personal settings, peer-review settings,
+orchestrator settings, and plugin state each have separate owners. Arbitrary
+keys and `--config` are therefore rejected instead of risking disclosure.
+
+`datarim config set` is a compatibility refusal surface. Every mutation exits
+20 without changing config or manifest bytes. This includes the historical
+`aal_class` write: the old notifier-authorized AAL ratchet is superseded by the
+current hard-gated action floor.
+
+### `datarim plugin list | enable | disable | sync | doctor`
+
+Delegates directly to the canonical `scripts/dr-plugin.sh` controller and
+preserves its stdout, stderr, and exit code. `enable` accepts an absolute plugin
+source path; `disable` accepts a plugin ID; `doctor` accepts optional `--fix`.
+The wrapper never edits `datarim/enabled-plugins.md` itself, so canonical
+validation, locking, snapshots, rollback, dependency checks, and protected-core
+rules remain authoritative.
+
+Phase-5 derived reads do not append to the Phase-3 HTTP audit log. Plugin
+operations retain the canonical controller's manifest/snapshot/lock evidence.
+This ownership boundary supersedes the historic proposal that every CLI
+wrapper invocation must create a second audit record.
+
 ### `datarim version | help`
 
 Self-explanatory.
 
 ## AAL 3 mitigations (Phase 3 ships all six)
 
-- **Dual-channel notifier** — every irreversible action emits a Telegram alert via `@ArcanadaAssistantBot` before the action proceeds; zero ACK within 3000ms causes exit 18 and the action is aborted.
+- **Dual-channel notifier** — eligible actions emit an alert before execution; zero ACK within 3000ms causes exit 18. Notification never grants permission for a hard-gated action.
 - **JSONL audit log** — schema version 1, 10 keys, flock atomic append (portable python3 fcntl wrapper on macOS).
 - **Kill-switch sentinel** — presence of `~/.config/datarim-cli/HALT` triggers exit 17 on every subcommand.
 - **`accepted-risk-aal.yml` entry** — invocation-time gate (1h cache); missing or expired entry exits 23.
@@ -100,6 +127,7 @@ Self-explanatory.
 | 0 | Success |
 | 17 | Kill-switch sentinel present (`HALT` file) |
 | 18 | Dual-channel notifier timed out (no ACK in 3000ms) |
+| 20 | Config mutation or managed-key access refused |
 | 21 | Invalid or missing slash command |
 | 22 | Missing or malformed `$DATARIM_CLI_AGENT_ID` (must be UUID v7) |
 | 23 | `accepted-risk-aal.yml` entry `tune-0268-aal3-cli` missing or expired |
@@ -112,7 +140,8 @@ Self-explanatory.
 
 - `cli/datarim` — entry point
 - `cli/lib/` — http, audit, notify, kill-switch, agent-id, accepted-risk-check, uuid7-gen, slash-classification.yaml
-- `cli/subcommands/run.sh`, `audit.sh`
+- `cli/subcommands/run.sh`, `audit.sh`, `config.sh`, `plugin.sh`
+- `scripts/dr-plugin.sh` — canonical plugin-state controller used by the CLI wrapper
 - `cli/install.sh`, `cli/install-warning.sh`
 - `accepted-risk-aal.yml` — repo root
 - `dev-tools/check-cli-audit-schema.sh`


### PR DESCRIPTION
## Scope

TUNE-0268 Phase 5 only. This PR contains exact commit `c12f26e27e867d88e7f5220477c3b4b2a4eff5ce`; no B3 ADR or testing-contract work is included.

- expose only derived, non-secret `config get` keys
- fail closed on all generic config mutations and managed-key reads
- delegate plugin list/enable/disable/sync/doctor directly to canonical `scripts/dr-plugin.sh`
- preserve controller exit codes and HALT-first behavior
- document why the historic generic config/AAL write and duplicate-audit design is superseded

## Verification

- config Phase-5 Bats: 8/8
- plugin Phase-5 Bats: 6/6
- canonical plugin Bats: 80/80
- plugin coverage Bats: 4/4
- Bats discovery registry: clean, zero exclusions
- ShellCheck: clean
- staged whitespace and exact-path checks: clean
- independent exact-staged review: APPROVE

## Mutation evidence

- replacing config refusal with a success bypass turns the byte-preservation test RED
- replacing canonical delegation with the old webhook path turns the delegation test RED
- swallowing canonical controller exits with `|| true; return 0` turns the exit-preservation test RED

The restored exact tree is green and was reviewed as staged tree `1a2b14cf3c54b418d1a5cb2d570b78a08fa72a04`.