### PR TITLE
docs: reconcile backlog schema contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@ All notable changes to the Datarim framework are documented here. Format follows
 
 ## [Unreleased]
 
-_Nothing yet._
+### Changed
+
+- **TUNE-0196 backlog schema fork is superseded.** The later field-proven
+  backlog contract already permits a single-line inline pending-work
+  description without a task-description pointer, while `tasks.md` and
+  `activeContext.md` retain required pointers. The system skill, Doctor skill,
+  and backlog template now match the canonical regex split in
+  `scripts/lib/schema-regex.sh`; a focused regression pins both sides without
+  changing Doctor runtime behavior.
 
 ## [2.61.0] — 2026-08-02
 

--- a/datarim/creative/creative-TUNE-0196-backlog-schema-adr.md
+++ b/datarim/creative/creative-TUNE-0196-backlog-schema-adr.md
@@ -1,0 +1,120 @@
+---
+task_id: TUNE-0196
+artifact: creative
+captured_at: 2026-08-02
+captured_by: /dr-design
+agent: architect
+status: decided
+schema_version: 1
+consilium: true
+---
+
+# TUNE-0196 · Backlog Follow-up Schema Decision
+
+## Decision
+
+The original A/B/C fork is **SUPERSEDED**. Preserve the current relaxed
+`backlog.md` contract and do not change runtime behavior:
+
+- a backlog item may keep a long, single-line inline description;
+- a `tasks/{ID}-task-description.md` pointer is optional in `backlog.md`;
+- the wider backlog status vocabulary and priorities P0-P4 remain accepted;
+- `tasks.md` and `activeContext.md` remain strict thin indexes whose entries
+  require a description pointer.
+
+The shared strict-index regex retains `pending`, `blocked-pending`, and
+`cancelled` as compatibility inputs for legacy and migration paths. Canonical
+active-index writers emit `in_progress`, `blocked`, or `not_started`; backlog
+intake and cancellation flows own the other statuses.
+
+The framework must synchronize its shipped documentation and template to that
+already-ratified distinction and add a falsifiable regression. TUNE-0196 is not
+closed as option C: current authority deliberately chose a more permissive
+backlog ledger after the original fork was filed.
+
+## Authority and chronology
+
+The 2026-05-12 TUNE-0194 archive left 42 paragraph-length follow-up bullets as
+an open A/B/C operator decision and explicitly classified the cohort as “not a
+framework defect.”
+
+Commit `a0e7b136eb9d3979c1d23f205cfaaf7f0ae7574b` (merged PR #62,
+2026-05-31) later resolved the same behavior on live evidence:
+
+- `BACKLOG_ITEM_RE` made the pointer optional and accepted a nonempty inline
+  description, wider statuses, optional bold priority/complexity, and P0-P4;
+- `SCHEMA_BACKLOG_RE` mirrored the backlog behavior for the pre-archive gate;
+- `/dr-doctor` routed `backlog.md` through the relaxed pattern while retaining
+  `ONELINER_RE` for active indexes;
+- the hotfix reduced the live workspace from 572 findings to zero, and the
+  merged extraction preserved that deployed behavior.
+
+Current `origin/main@f6e1845ae69fb874e72009c488fafca3f5f30df6` retains those
+runtime rules, but the Datarim system skill, Doctor skill, and backlog template
+still describe the older pointer-required 80-character schema. That is the
+remaining defect.
+
+## Consilium
+
+This was a genuine design fork. Cursor Agent independently returned
+`SUPERSEDED`; the orchestrating OpenAI model independently reached the same
+verdict from the later commit and current source. Anthropic Claude could not
+participate because its CLI reported a non-transient weekly subscription limit
+until 2026-08-04 11:00 UTC; it was not retried and supplied no evidence.
+
+## Rejected alternatives
+
+### A — Split and truncate
+
+Rejected. Automatic truncation discards operator-authored pending-work context
+and contradicts the later field-proven rule. Description externalization may
+still happen when a task enters the active workflow, but Doctor must not invent
+that transition merely to normalize a backlog line.
+
+### B — Informational finding
+
+Rejected as current behavior. The later rule accepts the line as compliant;
+emitting a finding would reintroduce noise for a shape the canonical regex
+explicitly allows. A new measurable usability defect could justify a separate
+advisory in the future.
+
+### C — Explicit rejection
+
+Rejected. Restoring a mandatory pointer would reverse a later deliberate
+decision and reopen accepted downstream ledgers without a current failure.
+Strict rejection remains correct for a pointerless line in `tasks.md` or
+`activeContext.md`, not for `backlog.md`.
+
+## Required changes
+
+1. Split the shipped operational-schema prose into strict active-index and
+   relaxed backlog-ledger contracts.
+2. Update the backlog template to show both pointerless and pointer-bearing
+   examples without embedding real project identifiers.
+3. Record the supersession in the unreleased changelog.
+4. Add a regression proving the same rich-inline pointerless line is accepted
+   by both backlog regexes and rejected by both active-index regexes. Pin the
+   documentation and template wording in the same suite.
+
+No Doctor runtime, regex, migration, archive, or version behavior changes in
+this task.
+
+## Mutation proof
+
+- Substitute `ONELINER_RE` for `BACKLOG_ITEM_RE`: the pointerless backlog case
+  must fail.
+- Substitute `SCHEMA_TASKS_RE` for `SCHEMA_BACKLOG_RE`: the same case must
+  fail.
+- Remove the explicit optional-pointer statement from any shipped schema
+  surface: the contract test must fail.
+- Remove the required-pointer statement for active indexes: the contract test
+  must fail.
+
+## Reopen conditions
+
+Reopen only with new measured evidence, such as a live consumer that fails on
+pointerless backlog entries, a bounded-context or operator-scanability
+regression attributable to long inline descriptions, or a new product
+requirement that makes the backlog machine-only. Any future strict migration
+must preserve existing prose and include a downstream migration plan; it must
+not relabel the superseded 2026 fork as still undecided.

--- a/skills/datarim-doctor/SKILL.md
+++ b/skills/datarim-doctor/SKILL.md
@@ -7,22 +7,24 @@ target_aal: 3
 
 # Datarim Doctor — Schema and Migration Semantics
 
-This skill is the runtime knowledge module for `/dr-doctor`. It defines the **canonical thin contract** that operational files (`tasks.md`, `backlog.md`, `activeContext.md`) MUST conform to, the **6-pass migration algorithm** that `scripts/datarim-doctor.sh` applies, and the **data-loss safety contract** that wraps every `--fix` invocation.
+This skill is the runtime knowledge module for `/dr-doctor`. It defines the strict active-index contract for `tasks.md` / `activeContext.md`, the relaxed line-oriented ledger contract for `backlog.md`, the **6-pass migration algorithm** that `scripts/datarim-doctor.sh` applies, and the **data-loss safety contract** that wraps every `--fix` invocation.
 
 Loaded by:
 - `/dr-doctor` (always)
 - `/dr-init` self-heal (when `--quiet` probe returns exit 1)
 - `/dr-archive` line-format gate (on failure, to explain non-compliance)
 
-Not loaded by other commands — they read the operational files as opaque indexes and follow the description-file pointer.
+Not loaded by other commands — they read operational files as line-oriented ledgers and resolve a description pointer when one is present.
 
 ## Why Thin Indexes
 
-Operational files are **indexes**, not content. Each line answers four questions: which task, what state, where the description lives. No prose, no requirements, no plan content lives in `tasks.md` / `backlog.md`.
+`tasks.md` and `activeContext.md` are strict pointer indexes. `backlog.md` is a
+pending-work ledger: each entry remains one line and machine-parseable, but may
+preserve its pending-work description inline until the task is promoted.
 
 Goals:
 - **Bounded context** — agents read 1 KB index instead of 100 KB monolith.
-- **Single source of truth per task** — description, ACs, constraints live in one file: `datarim/tasks/{TASK-ID}-task-description.md`.
+- **Single source of truth for active tasks** — description, ACs, and constraints live in `datarim/tasks/{TASK-ID}-task-description.md`; pointerless backlog prose is intake context, not an active plan.
 - **Greppable state** — line format is machine-parseable; status changes are 1-line diffs.
 - **Idempotent migrations** — `/dr-doctor` can run any number of times without drift.
 
@@ -30,30 +32,56 @@ Goals:
 
 ## Operational File Schema
 
-### `tasks.md` and `backlog.md` line format
+Exact regex constants are sourced from `scripts/lib/schema-regex.sh`. Do not
+redefine them inside Doctor or a downstream validator.
 
-Canonical regex (anchored, single-line):
+### Strict active-index line format
+
+`tasks.md` and `activeContext.md` use `ONELINER_RE`:
 
 ```
 ^- ([A-Z]{2,10}-[0-9]{4}) · (STATUS) · P[0-3] · L[1-4] · (.+) → tasks/\1-(task-description|init-task)\.md$
 ```
 
-Where `STATUS` ∈:
-- `tasks.md`: `in_progress|blocked|not_started`
-- `backlog.md`: `pending|blocked-pending|cancelled`
+`ONELINER_RE` accepts `in_progress|blocked|not_started|pending|blocked-pending|cancelled`
+for legacy and migration compatibility. Canonical active-index writers emit
+`in_progress|blocked|not_started`; `pending` and `blocked-pending` belong to
+the backlog intake flow, and `cancelled` is archived from the backlog rather
+than mirrored as an active task.
 
-Separator: `·` (U+00B7 MIDDLE DOT, NOT bullet, NOT period). Arrow: `→` (U+2192). Title length: 1–80 chars, no newlines, no `→`.
+**Active-index pointer: required.** Separator: `·` (U+00B7 MIDDLE DOT, not a
+bullet or period). Arrow: `→` (U+2192). The pointer task ID must match the
+entry task ID.
 
-Examples (compliant):
+Compliant active entry:
 
 <!-- gate:history-allowed -->
 ```
 - <TASK-ID-A> · in_progress · P1 · L3 · <Title> → tasks/<TASK-ID-A>-task-description.md
-- <TASK-ID-B> · pending · P2 · L2 · <Title> → tasks/<TASK-ID-B>-task-description.md
 ```
 <!-- /gate:history-allowed -->
 
-Section headers (`## Active`, `## Pending`, etc.) and blank lines are allowed — only bullet lines starting with `- {PREFIX}-{NNNN}` are validated against the regex.
+### Backlog ledger line format
+
+`backlog.md` uses `BACKLOG_ITEM_RE`, not the active-index regex. It accepts the
+wider backlog status set (`pending`, `blocked-pending`, `cancelled`,
+`superseded`, `absorbed`, `deferred`, plus active states), priorities P0-P4,
+optional bold priority/complexity tokens, and a nonempty single-line inline
+description.
+
+**Pointer: optional for backlog entries.** An existing description may be
+linked, but a compliant inline entry is not a Doctor finding and `--fix` must
+not truncate it or invent a relocation.
+
+<!-- gate:history-allowed -->
+```
+- <TASK-ID-B> · pending · P2 · L2 · <Inline pending-work description>
+- <TASK-ID-C> · blocked · P3 · L2 · <Title> → tasks/<TASK-ID-C>-task-description.md
+```
+<!-- /gate:history-allowed -->
+
+Section headers and blank lines are allowed; only task bullet lines are schema
+validated.
 
 ### `activeContext.md` thin contract
 
@@ -67,9 +95,6 @@ Section headers (`## Active`, `## Pending`, etc.) and blank lines are allowed �
 <!-- strict mirror of tasks.md § Active — identical lines, identical order -->
 
 - <TASK-ID-A> · in_progress · P1 · L3 · <Title> → tasks/<TASK-ID-A>-task-description.md
-
-## Last Updated
-YYYY-MM-DD HH:MM · short summary
 ```
 <!-- /gate:history-allowed -->
 
@@ -254,7 +279,7 @@ Log line: `Pass 7 {file}: stripped={N} preserved={M}`. **Idempotent:** second `-
 
 ### Idempotency Guard
 
-Before Pass 1: if every operational file is already in canonical shape — zero `### TASK-ID:` headings in `tasks.md` / `backlog.md`, no legacy `backlog-archive.md` (or only the `.pre-v2.bak` sidecar remains), `progress.md` does not exist, no `## Последние завершённые` section in `activeContext.md`, and every bullet line matches the canonical regex — exit 0 immediately. Cheap probe used by `/dr-init` self-heal. <!-- allow-non-ascii: russian-legacy-section-marker-cited-from-prior-schema -->
+Before Pass 1: if every operational file is already in canonical shape — zero `### TASK-ID:` headings in `tasks.md` / `backlog.md`, no legacy `backlog-archive.md` (or only the `.pre-v2.bak` sidecar remains), `progress.md` does not exist, no `## Последние завершённые` section in `activeContext.md`, and every bullet line matches the regex applicable to its file — exit 0 immediately. Cheap probe used by `/dr-init` self-heal. <!-- allow-non-ascii: russian-legacy-section-marker-cited-from-prior-schema -->
 
 ## Data-Loss Safety Contract
 

--- a/skills/datarim-system/SKILL.md
+++ b/skills/datarim-system/SKILL.md
@@ -19,34 +19,55 @@ target_aal: 2
 - Keep `datarim/` for local workflow state and `documentation/archive/` for committed long-term archives.
 - Never create `documentation/tasks/`.
 - Use `$HOME/.claude/` or project-relative paths, not absolute machine-specific paths.
-- **Operational files are thin indexes**: `tasks.md`, `backlog.md`, `activeContext.md` carry one-liner-per-task pointers — never full task content. Descriptions live in `tasks/{TASK-ID}-task-description.md`. `progress.md` is **abolished**. See § Operational File Schema below.
+- **Operational state is line-oriented**: `tasks.md` and `activeContext.md` are strict thin indexes with one pointer per task; `backlog.md` is the pending-work ledger and may carry a single-line inline description without a pointer. Full active-task content lives in `tasks/{TASK-ID}-task-description.md`. `progress.md` is **abolished**. See § Operational File Schema below.
 
 ## Operational File Schema (v1.19.0+)
 
-Operational files are **indexes**, not content. Each line answers: which task, what state, where the description lives. Detailed contract: `skills/datarim-doctor/SKILL.md`.
+Operational files are machine-parseable, single-line ledgers. Active indexes are pointer-based; the backlog may preserve pending-work context inline until a task is promoted. Exact regex constants live only in `scripts/lib/schema-regex.sh`; detailed semantics live in `skills/datarim-doctor/SKILL.md`.
 
-### `tasks.md` and `backlog.md` line format
+### Strict active-index line format
 
-Canonical regex (anchored, single-line):
+`tasks.md` and `activeContext.md` use the strict `ONELINER_RE` contract:
 
 ```
 ^- ([A-Z]{2,10}-[0-9]{4}) · (STATUS) · P[0-3] · L[1-4] · (.+) → tasks/\1-(task-description|init-task)\.md$
 ```
 
-`STATUS` ∈
-- `tasks.md`: `in_progress|blocked|not_started`
-- `backlog.md`: `pending|blocked-pending|cancelled`
+`ONELINER_RE` accepts `in_progress|blocked|not_started|pending|blocked-pending|cancelled`
+for legacy and migration compatibility. Canonical active-index writers emit
+`in_progress|blocked|not_started`; `pending` and `blocked-pending` belong to
+the backlog intake flow, and `cancelled` is archived from the backlog rather
+than mirrored as an active task.
 
-Separator: `·` (U+00B7 MIDDLE DOT). Arrow: `→` (U+2192). Title: 1–80 chars, single-line, no `→`.
+**Active-index pointer: required.** Separator: `·` (U+00B7 MIDDLE DOT).
+Arrow: `→` (U+2192). The description pointer must carry the same task ID.
 
-Example:
 <!-- gate:history-allowed -->
 ```
 - <TASK-ID> · in_progress · P1 · L3 · <Title> → tasks/<TASK-ID>-task-description.md
 ```
 <!-- /gate:history-allowed -->
 
-Section headers (`## Active`, `## Pending`) and blank lines allowed; only `- {PREFIX}-{NNNN}` bullets are validated.
+### Backlog ledger line format
+
+`backlog.md` uses `BACKLOG_ITEM_RE`: the status vocabulary also accepts
+`pending`, `blocked-pending`, `cancelled`, `superseded`, `absorbed`, and
+`deferred`; priority may be P0-P4; priority and complexity may be bold. The
+description is nonempty and single-line.
+
+**Pointer: optional for backlog entries.** A pointer may be appended when a
+description artefact already exists, but Doctor must not truncate or relocate
+valid inline backlog prose merely to create one.
+
+<!-- gate:history-allowed -->
+```
+- <TASK-ID> · pending · P2 · L2 · <Inline pending-work description>
+- <TASK-ID> · blocked · P3 · L2 · <Title> → tasks/<TASK-ID>-task-description.md
+```
+<!-- /gate:history-allowed -->
+
+Section headers and blank lines are allowed; only task bullet lines are schema
+validated.
 
 ### `activeContext.md` thin contract (v2 — ≤30 lines)
 
@@ -360,4 +381,3 @@ When closing a task, choose the disposition that matches the actual outcome:
 | `superseded` | Replaced by a newer task with broader/different scope; no deliverable from this ID | Write `documentation/archive/cancelled/archive-{ID}.md` with status `superseded` and a link to the replacing task; remove entry from `backlog.md`. |
 
 Source: prior incident — an `update.sh` deliverable was shipped inside a different task's scope; `cancelled` was inaccurate (deliverable existed) and `completed` was inaccurate (no separate archive). `absorbed` captures the reality and preserves audit trail.
-

--- a/skills/datarim-system/backlog-and-routing.md
+++ b/skills/datarim-system/backlog-and-routing.md
@@ -4,9 +4,14 @@
 
 ### Single-File Architecture
 
-**Backlog** (`backlog.md`) — thin one-liner index
-- contains only `pending` / `blocked-pending` / `cancelled` (transient state)
-- optimized for normal reads
+**Backlog** (`backlog.md`) — line-oriented pending-work ledger
+- keeps each task on one machine-parseable line with a nonempty, single-line
+  description that may remain inline until the task is promoted
+- treats `pending`, `blocked-pending`, and `cancelled` as the canonical intake
+  states; the schema also preserves `superseded`, `absorbed`, `deferred`, and
+  active-state rows during transitions and legacy migration
+- accepts an optional task-description pointer when a separate description
+  already exists; Doctor must not invent one by truncating inline context
 - uses the same `{PREFIX}-{NNNN}` ID the task will keep later
 
 `backlog-archive.md` was retired in v1.19.1. Completion archive

--- a/templates/backlog-template.md
+++ b/templates/backlog-template.md
@@ -1,20 +1,22 @@
 # Backlog
 
 <!--
-Thin-index schema (v1.19.0+).
+Pending-work ledger schema.
 
-Each line is a one-liner pointer to a description file. NO task content here.
-Full task body lives in datarim/tasks/{TASK-ID}-task-description.md.
+Each task remains on one machine-parseable line. A pending-work description may
+remain inline until the task is promoted. Full active-task plans, ACs, and
+constraints live in datarim/tasks/{TASK-ID}-task-description.md.
 
-Canonical regex (single-line, anchored):
-  ^- ([A-Z]{2,10}-[0-9]{4}) · (pending|blocked-pending|cancelled) · P[0-3] · L[1-4] · (.+) → tasks/\1-(task-description|init-task)\.md$
+Canonical source: scripts/lib/schema-regex.sh BACKLOG_ITEM_RE.
+Statuses include pending, blocked-pending, cancelled, superseded, absorbed,
+deferred, and active states. Priority is P0-P4; complexity is L1-L4.
 
-Separator: · (U+00B7 MIDDLE DOT). Arrow: → (U+2192). Title: free-form (single line).
+Pointer: optional for backlog entries. When present, use → (U+2192) and the
+same task ID. Inline descriptions must be nonempty and single-line.
 
-Example:
-<!-- gate:history-allowed -->
-  - INFRA-0099 · pending · P2 · L2 · Vault MFA Rollout → tasks/INFRA-0099-task-description.md
-<!-- /gate:history-allowed -->
+Examples:
+  - <TASK-ID-A> · pending · P2 · L2 · <Inline pending-work description>
+  - <TASK-ID-B> · blocked · P3 · L2 · <Title> → tasks/<TASK-ID-B>-task-description.md
 
 Validation: scripts/datarim-doctor.sh / pre-archive-check.sh. Self-heal: /dr-doctor --fix.
 Schema reference: skills/datarim-system/SKILL.md § Operational File Schema.
@@ -31,6 +33,5 @@ Schema reference: skills/datarim-system/SKILL.md § Operational File Schema.
 ## Cancelled
 
 <!-- Recently cancelled tasks (transient — full archive in
-     documentation/archive/cancelled/archive-{ID}.md). Thin-index schema
-     (v1.19.1+): backlog-archive.md retired. -->
-
+     documentation/archive/cancelled/archive-{ID}.md). backlog-archive.md is
+     retired. -->

--- a/tests/tune-0196-backlog-schema-contract.bats
+++ b/tests/tune-0196-backlog-schema-contract.bats
@@ -1,0 +1,170 @@
+#!/usr/bin/env bats
+
+setup() {
+    ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    DOCTOR="$ROOT/scripts/datarim-doctor.sh"
+    TMP_CASE="$(mktemp -d)"
+    # Dynamic repository root is resolved by Bats setup.
+    # shellcheck disable=SC1091
+    source "$ROOT/scripts/lib/schema-regex.sh"
+    INLINE_LINE='- TUNE-9001 · blocked · P3 · L2 · Preserve this deliberately long pending-work description because backlog is the operator ledger and not the strict active-task index'
+    POINTER_LINE="$INLINE_LINE → tasks/TUNE-9001-task-description.md"
+}
+
+teardown() {
+    rm -rf -- "$TMP_CASE"
+}
+
+assert_regex_match() {
+    local regex="$1"
+    local line="$2"
+    [[ "$line" =~ $regex ]]
+}
+
+assert_doc_contract() {
+    local root="$1"
+
+    grep -Fq '### Backlog ledger line format' "$root/skills/datarim-system/SKILL.md" || return 1
+    grep -Fq 'Pointer: optional for backlog entries.' "$root/skills/datarim-system/SKILL.md" || return 1
+    grep -Fq 'Active-index pointer: required.' "$root/skills/datarim-system/SKILL.md" || return 1
+    grep -Fq -- "ONELINER_RE\` accepts \`in_progress|blocked|not_started|pending|blocked-pending|cancelled\`" "$root/skills/datarim-system/SKILL.md" || return 1
+    grep -Fq 'Canonical active-index writers emit' "$root/skills/datarim-system/SKILL.md" || return 1
+    grep -Fq 'line-oriented pending-work ledger' "$root/skills/datarim-system/backlog-and-routing.md" || return 1
+    grep -Fq 'optional task-description pointer' "$root/skills/datarim-system/backlog-and-routing.md" || return 1
+
+    grep -Fq '### Backlog ledger line format' "$root/skills/datarim-doctor/SKILL.md" || return 1
+    grep -Fq 'Pointer: optional for backlog entries.' "$root/skills/datarim-doctor/SKILL.md" || return 1
+    grep -Fq 'Active-index pointer: required.' "$root/skills/datarim-doctor/SKILL.md" || return 1
+    grep -Fq -- "ONELINER_RE\` accepts \`in_progress|blocked|not_started|pending|blocked-pending|cancelled\`" "$root/skills/datarim-doctor/SKILL.md" || return 1
+    grep -Fq 'Canonical active-index writers emit' "$root/skills/datarim-doctor/SKILL.md" || return 1
+    ! grep -Fq '## Last Updated' "$root/skills/datarim-doctor/SKILL.md" || return 1
+
+    grep -Fq 'Pointer: optional for backlog entries.' "$root/templates/backlog-template.md" || return 1
+    grep -Fq -- '- <TASK-ID-A> · pending · P2 · L2 · <Inline pending-work description>' "$root/templates/backlog-template.md" || return 1
+    grep -Fq -- '- <TASK-ID-B> · blocked · P3 · L2 · <Title> → tasks/<TASK-ID-B>-task-description.md' "$root/templates/backlog-template.md" || return 1
+    grep -Fq 'TUNE-0196 backlog schema fork is superseded' "$root/CHANGELOG.md" || return 1
+}
+
+copy_doc_contract() {
+    local target="$1"
+    mkdir -p "$target/skills/datarim-system" "$target/skills/datarim-doctor" "$target/templates"
+    cp "$ROOT/skills/datarim-system/SKILL.md" "$target/skills/datarim-system/SKILL.md"
+    cp "$ROOT/skills/datarim-system/backlog-and-routing.md" "$target/skills/datarim-system/backlog-and-routing.md"
+    cp "$ROOT/skills/datarim-doctor/SKILL.md" "$target/skills/datarim-doctor/SKILL.md"
+    cp "$ROOT/templates/backlog-template.md" "$target/templates/backlog-template.md"
+    cp "$ROOT/CHANGELOG.md" "$target/CHANGELOG.md"
+}
+
+rewrite_file() {
+    local expression="$1"
+    local file="$2"
+    local replacement="${file}.next"
+
+    sed "$expression" "$file" >"$replacement" || return 1
+    mv "$replacement" "$file" || return 1
+}
+
+@test "relaxed backlog regexes accept a long pointerless inline description" {
+    assert_regex_match "$BACKLOG_ITEM_RE" "$INLINE_LINE" || return 1
+    assert_regex_match "$SCHEMA_BACKLOG_RE" "$INLINE_LINE" || return 1
+}
+
+@test "strict active-index regexes require the description pointer" {
+    ! assert_regex_match "$ONELINER_RE" "$INLINE_LINE" || return 1
+    ! assert_regex_match "$SCHEMA_TASKS_RE" "$INLINE_LINE" || return 1
+    assert_regex_match "$ONELINER_RE" "$POINTER_LINE" || return 1
+    assert_regex_match "$SCHEMA_TASKS_RE" "$POINTER_LINE" || return 1
+}
+
+@test "mandatory-pointer backlog mutants reject the accepted line" {
+    local doctor_mutant="$TMP_CASE/schema-doctor-mutant.sh"
+    local archive_mutant="$TMP_CASE/schema-archive-mutant.sh"
+
+    cp "$ROOT/scripts/lib/schema-regex.sh" "$doctor_mutant"
+    # Literal variable references are required in the sourced mutant.
+    # shellcheck disable=SC2016
+    rewrite_file 's/^BACKLOG_ITEM_RE=.*/BACKLOG_ITEM_RE="$ONELINER_RE"/' "$doctor_mutant"
+    # shellcheck disable=SC2016
+    grep -Fq 'BACKLOG_ITEM_RE="$ONELINER_RE"' "$doctor_mutant" || return 1
+
+    # A new shell must source the rewritten file; no parent-process variables.
+    # shellcheck disable=SC2016
+    run bash -c 'source "$1"; line="$2"; [[ "$line" =~ $BACKLOG_ITEM_RE ]]' _ "$doctor_mutant" "$INLINE_LINE"
+    [ "$status" -ne 0 ] || return 1
+
+    cp "$ROOT/scripts/lib/schema-regex.sh" "$archive_mutant"
+    # shellcheck disable=SC2016
+    rewrite_file 's/^SCHEMA_BACKLOG_RE=.*/SCHEMA_BACKLOG_RE="$SCHEMA_TASKS_RE"/' "$archive_mutant"
+    # shellcheck disable=SC2016
+    grep -Fq 'SCHEMA_BACKLOG_RE="$SCHEMA_TASKS_RE"' "$archive_mutant" || return 1
+
+    # shellcheck disable=SC2016
+    run bash -c 'source "$1"; line="$2"; [[ "$line" =~ $SCHEMA_BACKLOG_RE ]]' _ "$archive_mutant" "$INLINE_LINE"
+    [ "$status" -ne 0 ] || return 1
+}
+
+@test "Doctor accepts the pointerless line in backlog without a finding" {
+    local datarim_root="$TMP_CASE/accepted/datarim"
+    mkdir -p "$datarim_root/tasks"
+    printf '# Tasks\n\n## Active\n' >"$datarim_root/tasks.md"
+    printf '# Backlog\n\n## Pending\n\n%s\n' "$INLINE_LINE" >"$datarim_root/backlog.md"
+
+    run "$DOCTOR" --root="$datarim_root"
+    [ "$status" -eq 0 ] || return 1
+    [[ "$output" != *"non-compliant backlog item"* ]] || return 1
+}
+
+@test "Doctor rejects the same pointerless line in tasks" {
+    local datarim_root="$TMP_CASE/rejected/datarim"
+    mkdir -p "$datarim_root/tasks"
+    printf '# Tasks\n\n## Active\n\n%s\n' "$INLINE_LINE" >"$datarim_root/tasks.md"
+    printf '# Backlog\n\n## Pending\n' >"$datarim_root/backlog.md"
+
+    run "$DOCTOR" --root="$datarim_root"
+    [ "$status" -eq 1 ] || return 1
+    [[ "$output" == *"non-compliant bullet"* ]] || return 1
+}
+
+@test "shipped docs distinguish backlog ledger from strict active indexes" {
+    assert_doc_contract "$ROOT"
+}
+
+@test "mutation removing optional-pointer guidance makes the contract red" {
+    copy_doc_contract "$TMP_CASE"
+    assert_doc_contract "$TMP_CASE" || return 1
+    rewrite_file 's/Pointer: optional for backlog entries\./Pointer behavior removed./g' "$TMP_CASE/skills/datarim-system/SKILL.md"
+
+    run assert_doc_contract "$TMP_CASE"
+    [ "$status" -ne 0 ] || return 1
+}
+
+@test "mutation removing optional-pointer guidance from every shipped surface makes the contract red" {
+    for relative in \
+        skills/datarim-doctor/SKILL.md \
+        templates/backlog-template.md; do
+        case_dir="$TMP_CASE/optional-${relative//\//-}"
+        copy_doc_contract "$case_dir"
+        rewrite_file 's/Pointer: optional for backlog entries\./Pointer behavior removed./g' "$case_dir/$relative"
+        run assert_doc_contract "$case_dir"
+        [ "$status" -ne 0 ] || return 1
+    done
+}
+
+@test "mutation removing backlog-ledger fragment guidance makes the contract red" {
+    copy_doc_contract "$TMP_CASE"
+    assert_doc_contract "$TMP_CASE" || return 1
+    rewrite_file 's/optional task-description pointer/removed task-description pointer/g' \
+        "$TMP_CASE/skills/datarim-system/backlog-and-routing.md"
+
+    run assert_doc_contract "$TMP_CASE"
+    [ "$status" -ne 0 ] || return 1
+}
+
+@test "mutation removing required active pointer makes the contract red" {
+    copy_doc_contract "$TMP_CASE"
+    assert_doc_contract "$TMP_CASE" || return 1
+    rewrite_file 's/Active-index pointer: required\./Active-index pointer rule removed./g' "$TMP_CASE/skills/datarim-doctor/SKILL.md"
+
+    run assert_doc_contract "$TMP_CASE"
+    [ "$status" -ne 0 ] || return 1
+}


### PR DESCRIPTION

## Summary

- Reconciles the shipped backlog ledger contract with the already-landed relaxed runtime behavior.
- Documents strict active-index compatibility inputs versus canonical writer statuses.
- Preserves runtime, regex, migration, archive, and version behavior.
- Adds the routed backlog fragment, valid template examples, ADR, and falsifiable regression coverage.

## Evidence

- Focused Bats: 10/10.
- Existing Doctor suite: 54/54.
- Fresh-process regex mutants: both pointer-required substitutions turn the suite red; restored tree is green.
- Documentation and compatibility gates: 158-file English surface, stack-agnostic checks, 251-file doc references, zero-exclusion Bats registry, ShellCheck, and balanced template comments all pass.
- Independent findings-only Cursor review: APPROVE after resolving the HTML-comment, routed-fragment, obsolete-example, status-prose, and mutation-coverage findings.

## Scope

Exactly seven files are changed. PRs 329 and 330 are unrelated and untouched. No runtime source files are included.
