### PR TITLE
fix(snapshot): normalize frontmatter terminator spacing

### DIFF
--- a/scripts/lib/snapshot-writer.sh
+++ b/scripts/lib/snapshot-writer.sh
@@ -77,6 +77,26 @@ _snapshot_render_frontmatter() {
     printf -- '---\n\n'
 }
 
+# Guarantee the emitted frontmatter footer is always followed by a blank body separator
+# line, even if the transport path strips trailing newlines in the future.
+_snapshot_render_frontmatter_terminal() {
+    local path="$1"
+    local tail2_hex
+
+    # shellcheck disable=SC2016
+    # We compare trailing bytes (hex), because command substitution drops trailing
+    # newlines. A single quoted '---\n\n' can still look wrong after substitution.
+    while :; do
+        tail2_hex="$(tail -c 2 "$path" 2>/dev/null \
+            | od -An -t x1 \
+            | tr -d ' \n' || true)"
+        if [ "$tail2_hex" = "0a0a" ]; then
+            return 0
+        fi
+        printf '\n' >> "$path"
+    done
+}
+
 # Render frontmatter until its declared size is the exact fixed point of:
 #
 #   frontmatter bytes (including decimal size width) + final body bytes
@@ -97,6 +117,7 @@ _snapshot_render_exact_frontmatter() {
             "$task_id" "$stage" "$command" "$captured_at" "$captured_by" \
             "$recommended_next" "$options_file" "$size_bytes" "$truncated" \
             > "$output_file"
+        _snapshot_render_frontmatter_terminal "$output_file"
         fm_bytes="$(wc -c < "$output_file" | tr -d ' ')"
         actual_size=$(( fm_bytes + body_bytes ))
         if [ "$actual_size" -eq "$size_bytes" ]; then

--- a/tests/stage-snapshot-e2e.bats
+++ b/tests/stage-snapshot-e2e.bats
@@ -105,6 +105,11 @@ EOB
     [ "$status" -eq 1 ]
     grep -q '^---$' "${snapshot}"
     grep -q '^Implementation TUNE-0259' "${snapshot}"
+    local term_line body_line
+    term_line="$(grep -n '^---$' "${snapshot}" | sed -n '2p' | cut -d: -f1)"
+    [ -n "${term_line}" ]
+    body_line="$(sed -n "$((term_line + 2))p" "${snapshot}")"
+    [[ "${body_line}" == "Implementation TUNE-0259"* ]]
 }
 
 @test "E2E wrapper — ordinary body without a leading newline stays unglued" {
@@ -120,6 +125,43 @@ EOB
     local snapshot="${FAKE_ROOT}/datarim/snapshots/${TASK_ID}.snapshot.md"
     run grep -F -q -- '---Implementation TUNE-0259 ordinary first line' "${snapshot}"
     [ "$status" -eq 1 ]
+}
+
+@test "E2E wrapper — ordinary body near 1000-byte boundary keeps exact size declaration" {
+    local body="${BATS_TEST_TMPDIR}/boundary-body.txt"
+    local probe="${BATS_TEST_TMPDIR}/boundary-frontmatter-probe.md"
+    local captured_at="2026-08-03T00:00:00Z"
+    local probe_bytes body_bytes declared actual snapshot
+    local target=1000
+
+    # shellcheck source=/dev/null
+    source "${WRITER_LIB}"
+    _snapshot_render_frontmatter \
+        "${TASK_ID}" do /dr-do "${captured_at}" agent /dr-qa \
+        "${OPTIONS_TMP}" "${target}" false > "${probe}"
+
+    probe_bytes="$(wc -c < "${probe}" | tr -d ' ')"
+    body_bytes=$(( target - probe_bytes ))
+    [ "${body_bytes}" -gt 0 ]
+    python3 -c "print('B' * ${body_bytes}, end='')" > "${body}"
+
+    run bash "${WRITER_WRAPPER}" \
+        --root "${FAKE_ROOT}" --task "${TASK_ID}" --stage do --command /dr-do \
+        --captured-by agent --recommended-next /dr-qa \
+        --options-file "${OPTIONS_TMP}" --body-file "${body}"
+    [ "$status" -eq 0 ]
+
+    snapshot="${FAKE_ROOT}/datarim/snapshots/${TASK_ID}.snapshot.md"
+    declared="$(sed -n 's/^size_bytes: //p' "${snapshot}")"
+    actual="$(wc -c < "${snapshot}" | tr -d ' ')"
+    [ "${actual}" -eq "${declared}" ]
+    [ "${declared}" -le "${target}" ]
+    [ "${declared}" -gt 0 ]
+    local boundary_term_line boundary_gap
+    boundary_term_line="$(grep -n '^---$' "${snapshot}" | tail -1 | cut -d: -f1)"
+    [ -n "${boundary_term_line}" ]
+    boundary_gap="$(sed -n "$((boundary_term_line + 1))p" "${snapshot}")"
+    [ -z "${boundary_gap}" ]
 }
 
 @test "E2E — declared size_bytes equals exact snapshot bytes" {


### PR DESCRIPTION
## Summary
- Ensure stage snapshot frontmatter terminator always has a trailing blank separator line so exact-size snapshots stay stable across transport newline stripping.
- Add regression coverage for boundary case and frontmatter/body separation correctness.
- Keep the exact-size loop behavior unchanged apart from separator normalization.

## Verification
- bats tests/stage-snapshot-*.bats (67 passed)
- Diff versus origin/main includes only:
  - scripts/lib/snapshot-writer.sh
  - tests/stage-snapshot-e2e.bats