### PR TITLE
fix(INFRA-0202): keep protected state checks runnable

### DIFF
--- a/.github/workflows/sha-bridge-currency-audit.yml
+++ b/.github/workflows/sha-bridge-currency-audit.yml
@@ -87,7 +87,7 @@ jobs:
           git config user.email 'github-actions[bot]@users.noreply.github.com'
           git add -A dev-tools/.state/
           git diff --cached --quiet && exit 0
-          git commit -m 'chore(INFRA-0202): sha-bridge-audit state update [skip ci]'
+          git commit -m 'chore(INFRA-0202): sha-bridge-audit state update'
           git push origin "HEAD:$STATE_BRANCH"
 
           pr_number="$(gh pr list \
@@ -98,12 +98,12 @@ jobs:
             --json number \
             --jq '.[0].number // empty')"
           if [ -n "$pr_number" ]; then
-            echo "Updated protected state PR #$pr_number. Operator review/landing remains required."
+            echo "Updated protected state PR #$pr_number. Ordinary protected landing remains required."
           else
             gh pr create \
               --repo "$GITHUB_REPOSITORY" \
               --base "$BASE_BRANCH" \
               --head "$STATE_BRANCH" \
               --title 'chore(INFRA-0202): persist SHA-bridge audit state' \
-              --body 'This automation PR persists the SHA-bridge decommission clock state produced by the scheduled audit. It deliberately targets an automation branch because main is protected. Do not auto-merge; review the state-only diff and land through the ordinary protected path.'
+              --body 'This automation PR persists the SHA-bridge decommission clock state produced by the scheduled audit. It deliberately targets an automation branch because main is protected. Do not auto-merge; preserve state-only review and land through the ordinary protected path.'
           fi

--- a/tests/sha-bridge-audit.bats
+++ b/tests/sha-bridge-audit.bats
@@ -89,3 +89,13 @@ teardown() {
     run grep -Eq '^ *git push[[:space:]]*$' "$workflow"
     [ "$status" -ne 0 ]
 }
+
+@test "workflow-does-not-suppress-protected-pr-checks" {
+    workflow="${BATS_TEST_DIRNAME}/../.github/workflows/sha-bridge-currency-audit.yml"
+
+    run grep -F '[skip ci]' "$workflow"
+    [ "$status" -ne 0 ]
+
+    run grep -Eiq 'operator (review|landing)|operator must|needs operator' "$workflow"
+    [ "$status" -ne 0 ]
+}


### PR DESCRIPTION
## Scope\n\nKeep the protected SHA-bridge state PR eligible for ordinary CI by removing the skip-CI marker from generated state commits. Add a regression test for the workflow contract and keep the state-only landing language aligned with the protected path.\n\n## Verification\n\n- Targeted Bats: 8/8\n- ShellCheck: pass\n- Workflow YAML and extracted shell syntax: pass\n- Signed local commit, based on Datarim main f033b706eb1c4c5401412fd025ee071a5c9adf10\n\nThis preserves the dedicated automation branch and does not weaken main protection.