### PR TITLE
feat(skills): TUNE-0447/0453/0556/0157/0152 — provider-race pattern, independent compliance, negative-claim scope guard, anti-decay tests, brand audit

### DIFF
--- a/skills/autonomous-mode/SKILL.md
+++ b/skills/autonomous-mode/SKILL.md
@@ -216,6 +216,33 @@ operator.
 
 **Not hard-gated:** infra-side actions on Arcanada-owned resources (SSH, `docker restart`, `git push` on a feature branch, Vault read, Cloudflare API read) — these are permitted per `feedback_autonomous_ops`.
 
+## Independent Compliance on Framework Self-Modification
+
+When an autonomous run's task **modifies the framework the agent itself
+operates under** — its skills, agents, commands, templates, pipeline gates,
+or the rules governing autonomous execution — the compliance stage MUST be
+dispatched to an **independent compliance agent in a clean context**: a
+fresh subagent that carries **no do/qa session history** from the same run.
+
+Rationale: an agent verifying a change to the very rules it is currently
+executing under is subject to self-reflexive bias — it has already accepted
+the change's framing during implementation, so an in-session verification
+tends to re-confirm rather than challenge. A clean-context compliance agent
+reads only the artefacts (PRD, plan, diff, QA report) and the current rule
+set, and judges the change against them without the implementation session's
+accumulated rationalizations.
+
+Operationally:
+
+- The orchestrator spawns the compliance stage as a separate subagent with
+  a fresh context window; it passes artefact paths, never a conversation
+  transcript or a summary of "what we decided during do/qa".
+- This applies to self-modification tasks regardless of complexity level —
+  the trigger is *what* is being changed (the operating rules), not the
+  change's size.
+- For non-self-modification tasks the standard compliance dispatch is
+  unchanged; independence is recommended but not mandatory there.
+
 ## Failure modes
 
 - **Env-var leak**: a parent shell kept `DATARIM_AUTO_MODE=1` set after `/clear`. **Mitigation:** mismatch detection (env var set, marker absent) treats the situation as non-auto and emits a warning. The 24h marker TTL prevents stale leaks from carrying further.

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -57,7 +57,7 @@ digraph brainstorming {
 }
 ```
 
-**The terminal state is invoking writing-plans.** Do NOT invoke other implementation skills (frontend-design, mcp-builder, infra-automation, etc.). The ONLY skill you invoke after brainstorming is `writing-plans`.
+**The terminal state is invoking writing-plans.** Do NOT invoke other implementation skills (frontend-ui, infra-automation, project-init, etc.). The ONLY skill you invoke after brainstorming is `writing-plans`.
 
 ## The Process
 

--- a/skills/datarim-system/path-and-storage.md
+++ b/skills/datarim-system/path-and-storage.md
@@ -58,6 +58,50 @@ printf '%s/datarim\n' "$DR_DIR"
 
 This rule is implemented once, canonically, in `scripts/lib/resolve-datarim-root.sh` — `resolve_datarim_root [start]` echoes the **repo-root** (the parent of the KB-marked `datarim/`), and `assert_not_nested_datarim <root>` rejects a root already inside a `datarim/` (the `datarim/datarim/` nesting vector). Every consumer that needs the KB location (the snapshot writer, `datarim-doctor.sh`, the `dev-tools/check-*.sh` validators) sources this file rather than re-implementing the walk-up — three divergent re-implementations were the root cause of nested directories and a missed `docs→history` migration. The `--root` argument means **repo-root** everywhere.
 
+## Negative-Claim Scope Precondition
+
+Any **negative claim** about the knowledge base — "the KB has no X",
+"no prior art exists", "zero matches for Y" — MUST be grounded in the
+**canonical workspace KB root** (the KB-marked `datarim/` resolved by the
+Path Resolution Rule above at the primary workspace), never in a
+`datarim/` directory observed **inside a git worktree**.
+
+Why: `datarim/` is gitignored, so a freshly created worktree carries only a
+partial skeleton of it — a handful of subdirectories instead of the full
+canonical set, with knowledge-bearing directories (insights, research,
+creative, design) simply absent. A search inside that skeleton returns zero
+matches that *look* like a clean negative result, when in reality the files
+were never there to be searched. Acting on such a false negative means
+re-doing research the KB already contains, or asserting "no prior art" over
+prior art that exists.
+
+**Cheap precondition (run before asserting any negative):** compare the
+KB subdirectory count in the current scope against the canonical root's
+count:
+
+```bash
+ls -d datarim/*/ | wc -l          # current scope
+ls -d "<canonical-root>"/datarim/*/ | wc -l   # canonical workspace KB
+```
+
+If the current scope's count is **lower**, the scope is a partial skeleton
+and is **unfit for negative claims** — re-run the search against the
+canonical root before asserting absence. (A positive match found in a
+worktree skeleton is still valid; only *negative* conclusions are scope-
+sensitive.)
+
+Two companion rules from the same failure class:
+
+- **(a) Search the literal term.** When claiming "X is absent", the search
+  MUST have included the literal term `X` (not only synonyms or adjacent
+  phrasing). A query about a concept that never greps the concept's own
+  name can miss live documents that use it verbatim.
+- **(b) Canonical outranks local.** A canonical document carrying
+  `status: accepted` outranks a project-local note on the same subject.
+  When the two disagree, cite and follow the canonical accepted document;
+  flag the local note for reconciliation rather than treating them as
+  peers.
+
 ## Core Files
 
 - `tasks.md` — active task tracking

--- a/skills/testing/SKILL.md
+++ b/skills/testing/SKILL.md
@@ -301,6 +301,9 @@ Load only the fragment needed for the current sub-problem:
 - `triaging-legacy-failures.md`
   Use when inheriting a test suite with pre-existing failures. Three-bucket triage: stale-delete, fixable-patch, rephrase-the-content.
 
+- `concurrency-patterns.md`
+  Use when an agent/service fans one request out over multiple interchangeable endpoints (LLM providers, fallback chains, mirror APIs). Provider-race pattern: bounded worker pool + completion-ordered iteration + first-success short-circuit + alert-only-when-ALL-fail + barrier-based concurrency test, plus the one-cap latency caveat (a join-all wait returns at slowest-attempt latency — the win is correctness/fewer alerts, not speed) and budget sizing (worst case ≤ one per-endpoint cap, not the sum).
+
 ## Reusable Templates
 
 - `${DATARIM_RUNTIME:-$HOME/.claude}/templates/docker-smoke-checklist.md` — 5-step reusable checklist for cross-container smoke (Compose validity → container health → endpoint smoke → end-to-end action with post-conditions → rollback). Reference this when applying the Live Docker Smoke gate.
@@ -314,6 +317,7 @@ Load only the fragment needed for the current sub-problem:
 - Wrapping a CLI / subprocess that exits 0 on error? → `silent-failure-detection.md`.
 - Writing or maintaining bats tests, or regex-asserting markdown prose? → `bats-and-spec-lint.md`.
 - Inherited a red test suite? → `triaging-legacy-failures.md`.
+- Fanning one request out over multiple provider/endpoint alternatives with first-success semantics? → `concurrency-patterns.md` § Provider Race.
 
 ## Why This Skill Is Split
 

--- a/skills/testing/concurrency-patterns.md
+++ b/skills/testing/concurrency-patterns.md
@@ -1,0 +1,76 @@
+---
+name: testing/concurrency-patterns
+description: Provider-race pattern for fan-out over multiple LLM/provider endpoints — bounded worker pool, completion-ordered iteration, first-success short-circuit, alert-only-when-all-fail, barrier-based concurrency test, one-cap latency caveat, budget sizing.
+---
+
+# Testing — Concurrency Patterns
+
+## Provider Race (bounded fan-out, first-success short-circuit)
+
+Use this pattern whenever an agent, daemon, or service fans a single request
+out over **multiple interchangeable endpoints** (LLM providers, model
+fallback chains, mirror APIs, redundant upstreams) and any one successful
+response is sufficient.
+
+### Pattern components (all five are load-bearing)
+
+1. **Bounded worker pool.** Submit one attempt per endpoint to a pool whose
+   size is capped at the number of endpoints (or lower). Unbounded spawning
+   turns a provider outage into a resource leak.
+2. **Completion-ordered iteration.** Consume results in the order attempts
+   *finish*, not the order they were submitted. Submission-ordered joining
+   serializes on the slowest early entry and defeats the race.
+3. **First-success short-circuit.** The first successful result wins: return
+   it immediately and cancel (or abandon-with-cleanup) the still-running
+   attempts. Losers' results are discarded, and their failures are recorded
+   at debug level only.
+4. **Alert only when ALL fail.** A single provider failing while another
+   succeeds is normal operation, not an incident. Raise the operator-facing
+   alert (and the loud error log) only when every endpoint in the fan-out
+   has failed. Per-provider failures inside a won race are noise — alerting
+   on them is the alert-fatigue anti-pattern this pattern exists to remove.
+5. **Barrier-based concurrency test.** The regression test MUST prove the
+   attempts actually overlap: give each fake provider a synchronization
+   barrier sized to the expected parallelism and have every attempt wait on
+   it before responding. If the implementation silently degrades to
+   sequential calls, the barrier never releases and the test times out —
+   a deterministic red, with no sleep-based flakiness.
+
+### IMPORTANT caveat — join-all latency
+
+If the call site waits for **all** workers to finish before returning
+(a join-all / wait-for-pool-shutdown construct), the function returns at
+the latency of the **slowest** attempt — one full per-endpoint timeout cap
+in the worst case. The win of this pattern is **correctness and fewer
+alerts** (no false incident when one provider is down), **NOT speed**. Do
+not present or measure it as a latency optimization unless the losers are
+genuinely cancelled before return.
+
+### Budget sizing
+
+Size the worst-case latency budget of the caller at **one** per-endpoint
+timeout cap — the race runs the attempts concurrently, so the worst case is
+the slowest single attempt, **not the sum** of all caps (that would be the
+sequential-fallback budget). When reserving an upstream deadline or cron
+slot for the racing call, reserve `max(per-endpoint caps) + small overhead`.
+
+<!-- gate:example-only -->
+```python
+# Illustrative only (Python): bounded pool + completion order + short-circuit.
+from concurrent.futures import ThreadPoolExecutor, as_completed
+
+with ThreadPoolExecutor(max_workers=len(providers)) as pool:
+    futures = {pool.submit(attempt, p): p for p in providers}
+    errors = []
+    for fut in as_completed(futures):
+        try:
+            return fut.result()          # first success wins
+        except Exception as exc:         # loser failure -> debug, not alert
+            errors.append((futures[fut], exc))
+    alert_all_providers_failed(errors)   # only reached when ALL failed
+```
+<!-- /gate:example-only -->
+
+Any language with a bounded task pool, completion-ordered result stream, and
+a barrier primitive can express the same contract — the components above are
+the portable specification; the fenced block is one concrete rendering.

--- a/tests/skill-autonomous-mode-independent-compliance.bats
+++ b/tests/skill-autonomous-mode-independent-compliance.bats
@@ -1,0 +1,38 @@
+#!/usr/bin/env bats
+#
+# Anti-decay spec-regression: skills/autonomous-mode/SKILL.md must mandate
+# an independent, clean-context compliance agent for autonomous runs on
+# framework self-modification tasks (self-reflexive-bias mitigation).
+
+SKILL="${BATS_TEST_DIRNAME}/../skills/autonomous-mode/SKILL.md"
+
+@test "skill file exists" {
+    [ -f "$SKILL" ]
+}
+
+@test "Independent Compliance section header present" {
+    run grep -cE "^## Independent Compliance on Framework Self-Modification" "$SKILL"
+    [ "$status" -eq 0 ]
+}
+
+@test "section mandates a clean context with no do/qa session history" {
+    run grep -ciE "clean context" "$SKILL"
+    [ "$status" -eq 0 ]
+    run grep -ciE "no do/qa session history" "$SKILL"
+    [ "$status" -eq 0 ]
+}
+
+@test "section names the self-reflexive bias rationale" {
+    run grep -ciE "self-reflexive bias" "$SKILL"
+    [ "$status" -eq 0 ]
+}
+
+@test "section uses MUST (mandatory, not advisory) for self-modification tasks" {
+    sec_line=$(grep -nE "^## Independent Compliance on Framework Self-Modification" "$SKILL" | head -1 | cut -d: -f1)
+    [ -n "$sec_line" ]
+    next_h2=$(awk -v start="$sec_line" 'NR>start && /^## / {print NR; exit}' "$SKILL")
+    [ -n "$next_h2" ] || next_h2=$(wc -l < "$SKILL")
+    body=$(sed -n "${sec_line},${next_h2}p" "$SKILL")
+    count=$(printf '%s\n' "$body" | grep -cE "MUST" || true)
+    [ "$count" -ge 1 ]
+}

--- a/tests/skill-network-exposure-consumer-wiring.bats
+++ b/tests/skill-network-exposure-consumer-wiring.bats
@@ -1,0 +1,65 @@
+#!/usr/bin/env bats
+#
+# Anti-decay spec-regression for three Class-A guidance sections:
+#   1. skills/network-exposure-baseline/SKILL.md § Consumer Wiring Example
+#      (array-form `needs`, parallel-not-sequential job ordering)
+#   2. same skill § Local Pre-PR Smoke Recipe (positive control on the live
+#      compose config + negative control on a scratch /tmp copy + cleanup)
+#   3. skills/datarim-system/backlog-and-routing.md § Pre-merge baseline
+#      cleanup spawn (separate cleanup task for baseline-red CI noise)
+
+NEB="${BATS_TEST_DIRNAME}/../skills/network-exposure-baseline/SKILL.md"
+ROUTING="${BATS_TEST_DIRNAME}/../skills/datarim-system/backlog-and-routing.md"
+
+@test "both skill files exist" {
+    [ -f "$NEB" ]
+    [ -f "$ROUTING" ]
+}
+
+@test "Consumer Wiring Example section present with array-form needs" {
+    run grep -cE "^## Consumer Wiring Example" "$NEB"
+    [ "$status" -eq 0 ]
+    run grep -cE "needs: \[" "$NEB"
+    [ "$status" -eq 0 ]
+}
+
+@test "scalar-to-array needs promotion note present" {
+    run grep -ciE "scalar" "$NEB"
+    [ "$status" -eq 0 ]
+    run grep -ciE "array form" "$NEB"
+    [ "$status" -eq 0 ]
+}
+
+@test "parallel-not-sequential job ordering note present" {
+    # "run in / parallel" may wrap across a line boundary — assert the
+    # word itself plus the sequential-chain warning on their own lines.
+    run grep -ciE "parallel" "$NEB"
+    [ "$status" -eq 0 ]
+    run grep -ciE "sequential chain" "$NEB"
+    [ "$status" -eq 0 ]
+}
+
+@test "Local Pre-PR Smoke Recipe with positive and negative cases" {
+    run grep -cE "^## Local Pre-PR Smoke Recipe" "$NEB"
+    [ "$status" -eq 0 ]
+    run grep -cE "^### Positive case" "$NEB"
+    [ "$status" -eq 0 ]
+    run grep -cE "^### Negative case" "$NEB"
+    [ "$status" -eq 0 ]
+}
+
+@test "negative case uses a scratch copy and cleans it up" {
+    run grep -cE '/tmp/' "$NEB"
+    [ "$status" -eq 0 ]
+    run grep -cE 'rm -rf "\$NEG_DIR"' "$NEB"
+    [ "$status" -eq 0 ]
+}
+
+@test "Pre-merge baseline cleanup spawn bullet present in routing fragment" {
+    run grep -cE "^### Pre-merge baseline cleanup spawn" "$ROUTING"
+    [ "$status" -eq 0 ]
+    run grep -ciE "separate.*cleanup task" "$ROUTING"
+    [ "$status" -eq 0 ]
+    run grep -ciE "baseline-red CI noise" "$ROUTING"
+    [ "$status" -eq 0 ]
+}

--- a/tests/skill-path-storage-negative-claim-scope.bats
+++ b/tests/skill-path-storage-negative-claim-scope.bats
@@ -1,0 +1,59 @@
+#!/usr/bin/env bats
+#
+# Anti-decay spec-regression: skills/datarim-system/path-and-storage.md must
+# carry the Negative-Claim Scope Precondition — negative claims about the
+# knowledge base must be grounded in the canonical KB root, never in the
+# partial datarim/ skeleton inside a git worktree — plus the two companion
+# rules (literal-term search; canonical accepted doc outranks local note).
+
+FRAGMENT="${BATS_TEST_DIRNAME}/../skills/datarim-system/path-and-storage.md"
+
+@test "fragment file exists" {
+    [ -f "$FRAGMENT" ]
+}
+
+@test "Negative-Claim Scope Precondition section header present" {
+    run grep -cE "^## Negative-Claim Scope Precondition" "$FRAGMENT"
+    [ "$status" -eq 0 ]
+}
+
+@test "section explains the worktree partial-skeleton trap" {
+    run grep -ciE "git worktree" "$FRAGMENT"
+    [ "$status" -eq 0 ]
+    run grep -ciE "gitignored" "$FRAGMENT"
+    [ "$status" -eq 0 ]
+    run grep -ciE "partial skeleton" "$FRAGMENT"
+    [ "$status" -eq 0 ]
+}
+
+@test "cheap precondition command (subdirectory-count comparison) present" {
+    run grep -cF 'ls -d datarim/*/ | wc -l' "$FRAGMENT"
+    [ "$status" -eq 0 ]
+}
+
+@test "lower count declares the scope unfit for negative claims" {
+    run grep -ciE "unfit for negative claims" "$FRAGMENT"
+    [ "$status" -eq 0 ]
+}
+
+@test "companion rule (a): search the literal term" {
+    run grep -ciE "literal term" "$FRAGMENT"
+    [ "$status" -eq 0 ]
+}
+
+@test "companion rule (b): canonical status: accepted outranks local note" {
+    run grep -cE "status: accepted" "$FRAGMENT"
+    [ "$status" -eq 0 ]
+    run grep -ciE "outranks" "$FRAGMENT"
+    [ "$status" -eq 0 ]
+}
+
+@test "section carries no personal absolute paths" {
+    sec_line=$(grep -nE "^## Negative-Claim Scope Precondition" "$FRAGMENT" | head -1 | cut -d: -f1)
+    [ -n "$sec_line" ]
+    next_h2=$(awk -v start="$sec_line" 'NR>start && /^## / {print NR; exit}' "$FRAGMENT")
+    [ -n "$next_h2" ] || next_h2=$(wc -l < "$FRAGMENT")
+    body=$(sed -n "${sec_line},${next_h2}p" "$FRAGMENT")
+    count=$(printf '%s\n' "$body" | grep -cE "/home/[a-z]|/Users/[a-z]" || true)
+    [ "$count" -eq 0 ]
+}

--- a/tests/skill-testing-provider-race-fragment.bats
+++ b/tests/skill-testing-provider-race-fragment.bats
@@ -1,0 +1,62 @@
+#!/usr/bin/env bats
+#
+# Anti-decay spec-regression: skills/testing/concurrency-patterns.md must
+# document the provider-race pattern (bounded fan-out over multiple
+# provider/endpoint alternatives) and stay wired into the testing entry
+# skill's Fragment Routing section. Stack-specific literals are allowed
+# only inside a gate:example-only fence.
+
+FRAGMENT="${BATS_TEST_DIRNAME}/../skills/testing/concurrency-patterns.md"
+ENTRY="${BATS_TEST_DIRNAME}/../skills/testing/SKILL.md"
+
+@test "fragment file exists" {
+    [ -f "$FRAGMENT" ]
+}
+
+@test "fragment carries the Provider Race section header" {
+    run grep -cE "^## Provider Race" "$FRAGMENT"
+    [ "$status" -eq 0 ]
+}
+
+@test "all five pattern components are named" {
+    run grep -ciE "bounded worker pool" "$FRAGMENT"
+    [ "$status" -eq 0 ]
+    run grep -ciE "completion-ordered" "$FRAGMENT"
+    [ "$status" -eq 0 ]
+    run grep -ciE "first-success short-circuit" "$FRAGMENT"
+    [ "$status" -eq 0 ]
+    run grep -ciE "alert only when ALL fail" "$FRAGMENT"
+    [ "$status" -eq 0 ]
+    run grep -ciE "barrier" "$FRAGMENT"
+    [ "$status" -eq 0 ]
+}
+
+@test "one-cap latency caveat present (correctness, not speed)" {
+    run grep -ciE "slowest" "$FRAGMENT"
+    [ "$status" -eq 0 ]
+    run grep -ciE "NOT speed" "$FRAGMENT"
+    [ "$status" -eq 0 ]
+}
+
+@test "budget sizing rule present (one cap, not the sum)" {
+    run grep -ciE "not the sum" "$FRAGMENT"
+    [ "$status" -eq 0 ]
+}
+
+@test "stack-specific pool literal appears only inside gate:example-only fence" {
+    # Every line mentioning ThreadPoolExecutor must sit between the
+    # example-only fence markers.
+    run awk '
+        /<!-- gate:example-only -->/  { fenced = 1 }
+        /<!-- \/gate:example-only -->/ { fenced = 0 }
+        /ThreadPoolExecutor/ && !fenced { bad++ }
+        END { exit (bad > 0 ? 1 : 0) }
+    ' "$FRAGMENT"
+    [ "$status" -eq 0 ]
+}
+
+@test "entry SKILL.md routes to the fragment in Fragment Routing" {
+    run grep -cE '`concurrency-patterns\.md`' "$ENTRY"
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" -ge 2 ]   # routing bullet + quick-heuristic line
+}


### PR DESCRIPTION
Batch of 5 backlog rows (TUNE round-5 group A2). All new bats suites mutation-tested (mangle -> red, restore -> green); gates green: `task-id-gate.sh`, `stack-agnostic-gate.sh` (per touched file, exit 0), `check-body-english.sh --scope all` (209 files PASS), `check-skill-frontmatter.sh` (68 PASS), `check-skill-sibling-refs.sh` PASS.

## TUNE-0447 (P3/L1) — provider-race concurrency pattern
- New fragment `skills/testing/concurrency-patterns.md`: bounded worker pool + completion-ordered iteration + first-success short-circuit + alert-only-when-ALL-fail + barrier-based concurrency test + the join-all one-cap latency caveat (win is correctness/fewer alerts, NOT speed) + budget sizing (worst case <= one per-endpoint cap, not the sum).
- Wired into `skills/testing/SKILL.md` Fragment Routing + Quick Routing Heuristic (same pattern as the other fragments).
- Stack-agnostic: the only concrete pool literal sits inside a `gate:example-only` fence; a bats test asserts the fence containment.
- Anti-decay: `tests/skill-testing-provider-race-fragment.bats` (7 tests; mutation: header rename + literal-outside-fence -> 2 red).

## TUNE-0453 (P3/L1) — independent compliance on self-modification
- `skills/autonomous-mode/SKILL.md` new section "Independent Compliance on Framework Self-Modification": autonomous runs on tasks that modify the agent's own operating rules MUST dispatch compliance to a clean-context subagent with no do/qa session history (self-reflexive-bias mitigation); artefact paths only, never a transcript.
- Anti-decay: `tests/skill-autonomous-mode-independent-compliance.bats` (5 tests; mutation: phrase strip -> 2 red).

## TUNE-0556 (P2/L1) — worktree-KB-search negative-claim guard
- `skills/datarim-system/path-and-storage.md` new section "Negative-Claim Scope Precondition": any negative KB claim must be grounded in the canonical workspace KB root, never a worktree's `datarim/` (gitignored -> partial skeleton -> false clean negatives). Cheap precondition: compare `ls -d datarim/*/ | wc -l` against the canonical root; lower count = scope unfit for negative claims. Companion rules: (a) search the literal term when claiming absence; (b) canonical `status: accepted` doc outranks a project-local note. Paths kept abstract.
- Anti-decay: `tests/skill-path-storage-negative-claim-scope.bats` (8 tests incl. no-personal-paths guard; mutation: command mangle -> 2 red).

## TUNE-0157 (P3/L2) — Class-A additions anti-decay coverage
- The three content items (network-exposure-baseline "Consumer Wiring Example" with array-form `needs` + scalar->array promotion + parallel-not-sequential ordering; "Local Pre-PR Smoke Recipe" with positive/negative controls on a /tmp scratch copy + cleanup; backlog-and-routing "Pre-merge baseline cleanup spawn") **already landed on main** in a prior round — verified section-by-section against the row spec.
- This PR adds the missing anti-decay coverage: `tests/skill-network-exposure-consumer-wiring.bats` (7 tests; mutation: header rename + needs-array strip -> 2 red).

## TUNE-0152 (P4/L2) — absorbed-skill brand-string audit
- Audited `skills/{receiving-code-review,brainstorming,verification-before-completion,dispatching-parallel-agents,finishing-a-development-branch}/SKILL.md` for source-project residuals (namespace literals, internal paths, tool names).
- One residual fixed: brainstorming referenced non-existent source-project skills `frontend-design` / `mcp-builder`; replaced with real Datarim skills (`frontend-ui`, `infra-automation`, `project-init`).
- Otherwise clean; cross-skill refs (`writing-plans`, `using-git-worktrees`) resolve to real Datarim skills. The "your human partner" idiom spans 6 absorbed skills (incl. out-of-scope ones) and is an accepted convention, not a brand string — left unchanged and noted for a possible follow-up sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115RceXgSzqMmyFXjuyHHFu