### PR TITLE
fix(hygiene): TUNE-0553/0232/0204/0549 — allocator fail-closed guard + three anti-decay regressions

### DIFF
--- a/.github/workflows/dev-tools-lint.yml
+++ b/.github/workflows/dev-tools-lint.yml
@@ -2,6 +2,7 @@ name: dev-tools-lint
 # Dev-tools lint + fast-feedback bats subset.
 # - bats-self-tests: BLOCKING. Fast subset; see the note on that job.
 # - linter-run:      doc-fanout-lint ERRs block; cross-root WARNs advisory.
+# - dr-auto-reassert-wiring: BLOCKING prose-decay lint (own job, no continue-on-error).
 # - dr-auto-cross-runtime: BLOCKING activation-primitive smoke.
 #
 # This workflow has a `paths:` filter, so it can skip entirely on a PR that
@@ -96,6 +97,23 @@ jobs:
                --config dev-tools/.doc-fanout.yml \
                --allow-cross-root --strict || \
           echo "::warning::doc-fanout-lint reported warnings (cross-root surfaces are expected to be missing in a single-repo CI checkout)"
+
+  dr-auto-reassert-wiring:
+    name: dr-auto reassert-wiring lint (blocking)
+    # The lint's own header promises that "a deterministic CI lint FAILS
+    # (exit 1) the moment that call decays back to advisory prose only". That
+    # promise only holds when the lint runs in a job with no continue-on-error
+    # and no shared steps that can skip it. It previously ran as a trailing
+    # step of `linter-run` — a job that historically carried
+    # `continue-on-error: true`, which made the lint advisory in practice and
+    # contradicted its header. Own blocking job, mirroring the sibling
+    # `dr-auto-cross-runtime` job. Regression:
+    # tests/check-dr-auto-reassert-wiring.bats (workflow-wiring test).
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Run dr-auto reassert-wiring lint
         run: bash dev-tools/check-dr-auto-reassert-wiring.sh --root .

--- a/.gitignore
+++ b/.gitignore
@@ -24,10 +24,13 @@ node_modules/
 __pycache__/
 *.pyc
 
-# TUNE-0090: framework repo MUST NOT contain documentation/ — that is a consumer-side artefact.
-# Consumer projects write task archives to documentation/archive/ per CLAUDE.md template.
-# Framework workflow state lives in Projects/Datarim/datarim/; security/insights archives in ~/arcanada/documentation/.
-documentation/
+# documentation/ is TRACKED — the docs migration deliberately moved the public
+# Diátaxis tree (tutorials/how-to/reference/explanation) plus framework task
+# archives into this repo, and CLAUDE.md § S4/S10 reference documentation/
+# paths as shipped surfaces. An earlier rule ignored the whole directory as a
+# "consumer-side artefact", which contradicted the tracked tree and forced
+# `git add -f` on every new doc. The tree is canon; do not re-add an ignore
+# rule for it (regression: tests/tune-0549-framework-hygiene.bats).
 
 # TUNE-0164: dr-orchestrate plugin operator config (mode-0600 secrets via secrets_backend.sh).
 # Template ships at plugins/dr-orchestrate/user-config.template.yaml.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,43 @@ All notable changes to the Datarim framework are documented here. Format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **TUNE-0553 — `next-free-id.sh` fails CLOSED on a ledger-less root.** The
+  allocator silently returned `<PREFIX>-0001` (exit 0) when pointed at a root
+  carrying neither `datarim/tasks.md` nor `datarim/backlog.md` — including the
+  tempting misuse of passing the `datarim/` directory itself as
+  `DATARIM_ROOT`. Both shapes now exit non-zero with a message naming the
+  expected layout (workspace root = parent of `datarim/`) and a parent-hint
+  for the subdir misuse. Regression: Group E in
+  `tests/tune-0542-next-free-id-claim-surfaces.bats`.
+- **TUNE-0549 — framework hygiene: tracked `documentation/` was gitignored;
+  reassert-wiring lint was advisory.** (1) The blanket `documentation/` ignore
+  rule contradicted the deliberately tracked docs tree (~44 files) and forced
+  `git add -f` on every new doc; the tree is canon, the rule is removed
+  (regression: `tests/tune-0549-framework-hygiene.bats`, using
+  `check-ignore --no-index` because index-aware `check-ignore` never reports
+  tracked files). (2) `check-dr-auto-reassert-wiring.sh` moved out of the
+  `linter-run` job into its own blocking `dr-auto-reassert-wiring` job in
+  `dev-tools-lint.yml`, matching its fail-hard header; workflow-wiring
+  assertions added to `tests/check-dr-auto-reassert-wiring.bats`.
+
+### Added
+
+- **TUNE-0232 — anti-decay regression for the pre-push local-validator
+  checklist.** `tests/tune-0232-prepush-validator-wiring.bats` extracts the
+  "Pre-push local validation (advisory)" section of
+  `skills/security-baseline/SKILL.md` and asserts all three validator
+  invocations (`check-security-policy.sh --validate-yaml`,
+  `check-expectations-checklist.sh --verify`, `actionlint`) appear inside the
+  section itself, not merely elsewhere in the file.
+- **TUNE-0204 — prose-contract regression for the `/dr-plan` stdlib-symbol
+  advisory.** `tests/tune-0204-dr-plan-stdlib-advisory.bats` pins the
+  standard-library symbol/module coverage bullet in `commands/dr-plan.md`:
+  the missing-import surface case (a wrong/renamed stdlib symbol still gets a
+  plan-time flag) and the already-imported pass-silently semantics (a
+  project-grep miss alone must not fail the plan).
+
 ## [2.62.0] — 2026-08-03
 
 ### Changed

--- a/dev-tools/next-free-id.sh
+++ b/dev-tools/next-free-id.sh
@@ -6,7 +6,13 @@
 #
 # Returns (stdout):  the next free ID in the form PREFIX-NNNN
 # On collision:      auto-bumps to next free, emits a warning to stderr
-# Exit codes:        0 = OK; 1 = usage/validation error, or 4-digit space exhausted
+# Exit codes:        0 = OK; 1 = usage/validation error (incl. a ledger-less
+#                    root — see the fail-closed guard below), or 4-digit space
+#                    exhausted
+#
+# <DATARIM_ROOT> is the WORKSPACE root — the PARENT of datarim/ — never the
+# datarim/ directory itself. A root carrying neither datarim/tasks.md nor
+# datarim/backlog.md fails CLOSED instead of emitting PREFIX-0001.
 #
 # ─────────────────────────────────────────────────────────────────────────────
 # ARCHITECTURE — two jobs, opposite biases, computed from DIFFERENT scans.
@@ -113,6 +119,31 @@ fi
 
 if [[ ! -d "$DATARIM_ROOT" ]]; then
     echo "ERROR: DATARIM_ROOT '${DATARIM_ROOT}' does not exist or is not a directory" >&2
+    exit 1
+fi
+
+# ── ledger-presence guard (fail CLOSED on a ledger-less root) ────────────────
+#
+# DATARIM_ROOT is the WORKSPACE root — the PARENT of datarim/ — so the ledgers
+# live at ${DATARIM_ROOT}/datarim/{tasks.md,backlog.md}. A root that carries
+# neither file cannot answer "how high has anyone counted?": the ceiling scan
+# sees nothing and the allocator would emit a plausible-looking ${PREFIX}-0001
+# with exit 0 — an ID that may already be claimed hundreds of times over in the
+# workspace the caller MEANT to point at. That silent-and-maximally-destructive
+# shape is worse than any loud failure, so a ledger-less root is a usage error.
+#
+# The most tempting misuse is handing over the datarim/ directory itself (the
+# parameter name invites it), so that shape gets its own diagnostic.
+if [[ ! -f "${DATARIM_ROOT}/datarim/tasks.md" && ! -f "${DATARIM_ROOT}/datarim/backlog.md" ]]; then
+    echo "ERROR: no task ledger found under '${DATARIM_ROOT}/datarim/'" >&2
+    echo "       Expected layout: DATARIM_ROOT is the WORKSPACE ROOT (the parent of datarim/)," >&2
+    echo "       carrying datarim/tasks.md and/or datarim/backlog.md." >&2
+    if [[ -f "${DATARIM_ROOT}/tasks.md" || -f "${DATARIM_ROOT}/backlog.md" ]]; then
+        echo "       Hint: '${DATARIM_ROOT}' looks like the datarim/ directory itself —" >&2
+        echo "       pass its PARENT directory instead." >&2
+    fi
+    echo "       Refusing to allocate against a ledger-less root: the result would be a" >&2
+    echo "       plausible ${PREFIX}-0001 that ignores every existing claim." >&2
     exit 1
 fi
 

--- a/tests/check-dr-auto-reassert-wiring.bats
+++ b/tests/check-dr-auto-reassert-wiring.bats
@@ -74,3 +74,42 @@ MDEOF
     run "$LINT" --root "/nonexistent-path-that-does-not-exist-for-lint-test"
     [ "$status" -eq 2 ]
 }
+
+# ──────────────────────────────────────────────────────────────────────────
+# Workflow wiring: the lint must run in a BLOCKING CI job.
+#
+# The lint's header promises "a deterministic CI lint FAILS (exit 1) the
+# moment that call decays back to advisory prose only". It once ran as a
+# trailing step of a job carrying `continue-on-error: true`, which made it
+# advisory in practice — a red run that blocks nothing. Mirrors the wiring
+# assertion precedent in tests/check-dr-auto-cross-runtime.bats.
+# ──────────────────────────────────────────────────────────────────────────
+@test "wiring: a CI job runs the lint itself, not only this suite" {
+    WF="$BATS_TEST_DIRNAME/../.github/workflows/dev-tools-lint.yml"
+    [ -f "$WF" ]
+    run grep -c 'check-dr-auto-reassert-wiring.sh' "$WF"
+    [ "$status" -eq 0 ]
+}
+
+@test "wiring: the job invoking the lint carries NO continue-on-error" {
+    WF="$BATS_TEST_DIRNAME/../.github/workflows/dev-tools-lint.yml"
+    [ -f "$WF" ]
+    # Walk every top-level job block; for the block(s) invoking the lint,
+    # assert `continue-on-error` never appears — at job level or on any step.
+    run python3 - "$WF" <<'PY'
+import re, sys
+raw = open(sys.argv[1], encoding='utf-8').read()
+# strip full-line YAML comments — prose may legitimately DISCUSS the key
+s = '\n'.join(l for l in raw.split('\n') if not l.lstrip().startswith('#'))
+jobs = s[s.index('\njobs:\n'):]
+# split into job blocks at two-space-indented top-level keys
+starts = [m.start() for m in re.finditer(r'\n  [a-zA-Z][a-zA-Z0-9_-]*:\n', jobs)]
+starts.append(len(jobs))
+blocks = [jobs[starts[i]:starts[i+1]] for i in range(len(starts)-1)]
+carrying = [b for b in blocks if 'check-dr-auto-reassert-wiring.sh' in b]
+if not carrying:
+    sys.exit(2)  # lint not wired into any job at all
+sys.exit(1 if any('continue-on-error' in b for b in carrying) else 0)
+PY
+    [ "$status" -eq 0 ]
+}

--- a/tests/tune-0204-dr-plan-stdlib-advisory.bats
+++ b/tests/tune-0204-dr-plan-stdlib-advisory.bats
@@ -1,0 +1,60 @@
+#!/usr/bin/env bats
+# tune-0204-dr-plan-stdlib-advisory.bats
+#
+# Prose-contract regression for the standard-library symbol/module coverage
+# advisory in commands/dr-plan.md (the Step 6.5 symbol-existence check family).
+#
+# The base symbol check greps the PROJECT tree, which by construction cannot
+# resolve a symbol shipping in the language's standard library — a plain grep
+# reports "not found" even when the reference is correct. The advisory bullet
+# closes both halves of that gap and each half is load-bearing:
+#
+#   (a) MISSING-IMPORT SURFACE CASE — a wrong or renamed stdlib symbol (a
+#       module absent in the target runtime version, a deprecated core module)
+#       still deserves a plan-time flag; the check is lowered to advisory, not
+#       deleted.
+#   (b) ALREADY-IMPORTED PASS-SILENTLY SEMANTICS — a project-grep miss alone
+#       must NOT fail the plan when the symbol is a plausible stdlib reference;
+#       the plan records a one-line advisory note instead of a hard fail.
+#
+# The command spec is prose executed by an LLM, so dropping either half in an
+# edit breaks nothing structurally — this suite is the load-bearing wiring.
+
+DOC="${BATS_TEST_DIRNAME}/../commands/dr-plan.md"
+
+# The whole bullet lives on one (very long) source line; capture it once.
+bullet() {
+    grep 'Standard-library symbol/module coverage' "$DOC"
+}
+
+@test "dr-plan.md carries the standard-library symbol/module coverage bullet" {
+    [ -f "$DOC" ]
+    # grep -c (not -q) — SIGPIPE-safe under pipefail
+    count="$(grep -c 'Standard-library symbol/module coverage' "$DOC")"
+    [ "$count" -ge 1 ]
+}
+
+@test "bullet is marked ADVISORY, not a hard fail" {
+    line="$(bullet)"
+    [[ "$line" == *"ADVISORY"* ]]
+    [[ "$line" == *"not a hard fail"* ]]
+}
+
+@test "(a) missing-import surface case: a wrong/renamed stdlib symbol still gets a plan-time flag" {
+    line="$(bullet)"
+    # the surface half: wrong or renamed stdlib references are still flagged
+    [[ "$line" == *"wrong or renamed stdlib symbol"* ]]
+    [[ "$line" == *"still deserves a plan-time flag"* ]]
+}
+
+@test "(b) already-imported pass-silently semantics: a project-grep miss alone must not fail the plan" {
+    line="$(bullet)"
+    # the pass-silently half: grep-miss on a plausible stdlib symbol is not a failure
+    [[ "$line" == *"do not fail the plan on a project-grep miss alone"* ]]
+}
+
+@test "bullet prescribes the advisory note so /dr-do sees the surface was sanity-checked" {
+    line="$(bullet)"
+    [[ "$line" == *"stdlib check"* ]]
+    [[ "$line" == *"advisory note"* ]]
+}

--- a/tests/tune-0232-prepush-validator-wiring.bats
+++ b/tests/tune-0232-prepush-validator-wiring.bats
@@ -1,0 +1,74 @@
+#!/usr/bin/env bats
+# tune-0232-prepush-validator-wiring.bats
+#
+# Anti-decay wiring for skills/security-baseline/SKILL.md § "Pre-push local
+# validation (advisory)". The section instructs an agent bootstrapping a
+# brand-new repo (wired to the reusable CI workflows) to run three local
+# validators BEFORE the first `git push`:
+#
+#   1. check-security-policy.sh --validate-yaml   (accepted-risk register)
+#   2. check-expectations-checklist.sh --verify   (operator wishlist)
+#   3. actionlint                                 (GitHub Actions workflows)
+#
+# The checklist is prose executed by an LLM — nothing structural breaks when a
+# validator name is dropped in an edit, so the decay is silent. This suite is
+# the load-bearing regression: it extracts EXACTLY the pre-push section (from
+# its heading to the next heading or horizontal rule) and asserts each of the
+# three validator invocations still appears inside it — not merely somewhere
+# in the file, where e.g. the S7 CI table also cites actionlint.
+
+SKILL="${BATS_TEST_DIRNAME}/../skills/security-baseline/SKILL.md"
+
+# Print only the pre-push section body: start at the section heading, stop at
+# the next markdown heading (#..######) or a horizontal rule.
+prepush_section() {
+    # `#+` not `#{1,6}` — regex intervals are unsupported in historic BSD awk
+    # (macOS CI leg); `+` is portable POSIX ERE.
+    awk '
+        /^#+ .*Pre-push local validation/ { inside = 1; next }
+        inside && (/^#+ / || /^---[[:space:]]*$/) { exit }
+        inside { print }
+    ' "$SKILL"
+}
+
+@test "skill file exists and carries the pre-push section heading" {
+    [ -f "$SKILL" ]
+    # grep -c (not -q) — SIGPIPE-safe under pipefail
+    count="$(grep -cE '^#{1,6} .*Pre-push local validation' "$SKILL")"
+    [ "$count" -ge 1 ]
+}
+
+@test "pre-push section extraction yields a non-empty body" {
+    body="$(prepush_section)"
+    [ -n "$body" ]
+}
+
+@test "pre-push section names check-security-policy.sh --validate-yaml" {
+    body="$(prepush_section)"
+    count="$(printf '%s\n' "$body" | grep -c 'check-security-policy.sh --validate-yaml')"
+    [ "$count" -ge 1 ]
+}
+
+@test "pre-push section names check-expectations-checklist.sh --verify" {
+    body="$(prepush_section)"
+    count="$(printf '%s\n' "$body" | grep -c 'check-expectations-checklist.sh --verify')"
+    [ "$count" -ge 1 ]
+}
+
+@test "pre-push section names actionlint against the workflows glob" {
+    body="$(prepush_section)"
+    count="$(printf '%s\n' "$body" | grep -c 'actionlint')"
+    [ "$count" -ge 1 ]
+}
+
+@test "all three validators appear inside the SECTION, not merely elsewhere in the file" {
+    # The specificity guard: mutate the extraction target, not the file scan.
+    # If the section were emptied and the names survived only in the S7 table,
+    # the three tests above must fail — this test documents that intent by
+    # asserting the section body itself carries all three.
+    body="$(prepush_section)"
+    for needle in 'check-security-policy.sh' 'check-expectations-checklist.sh' 'actionlint'; do
+        count="$(printf '%s\n' "$body" | grep -c "$needle")"
+        [ "$count" -ge 1 ]
+    done
+}

--- a/tests/tune-0285-id-reservation-race.bats
+++ b/tests/tune-0285-id-reservation-race.bats
@@ -20,6 +20,10 @@ setup() {
     FIXTURE_DIR="$(mktemp -d)"
     mkdir -p "${FIXTURE_DIR}/datarim"
     mkdir -p "${FIXTURE_DIR}/documentation/archive/framework"
+    # Ledger-presence guard: the helper now fails CLOSED on a root carrying
+    # neither datarim/tasks.md nor datarim/backlog.md. An empty ledger keeps
+    # every fixture semantically identical (no rows) while satisfying it.
+    : > "${FIXTURE_DIR}/datarim/tasks.md"
 }
 
 teardown() {

--- a/tests/tune-0461-id-collision-autobump.bats
+++ b/tests/tune-0461-id-collision-autobump.bats
@@ -79,6 +79,10 @@ setup() {
     FIXTURE_DIR="$(mktemp -d)"
     mkdir -p "${FIXTURE_DIR}/datarim"
     mkdir -p "${FIXTURE_DIR}/documentation/archive/framework"
+    # Ledger-presence guard: the helper now fails CLOSED on a root carrying
+    # neither datarim/tasks.md nor datarim/backlog.md. An empty ledger keeps
+    # every fixture semantically identical (no rows) while satisfying it.
+    : > "${FIXTURE_DIR}/datarim/tasks.md"
     # TUNE-0542: next-free-id.sh now also reads two HOST-GLOBAL claim surfaces
     # (live tmux session names, git worktree/branch names). Neutralise them so
     # this spec stays hermetic on a host running dozens of unrelated agents.

--- a/tests/tune-0542-next-free-id-claim-surfaces.bats
+++ b/tests/tune-0542-next-free-id-claim-surfaces.bats
@@ -43,6 +43,11 @@ setup() {
     FIXTURE_DIR="$(mktemp -d)"
     mkdir -p "${FIXTURE_DIR}/datarim"
     mkdir -p "${FIXTURE_DIR}/documentation/archive/framework"
+    # Ledger-presence guard: the helper now fails CLOSED on a root carrying
+    # neither datarim/tasks.md nor datarim/backlog.md. An empty ledger keeps
+    # every fixture semantically identical (no rows) while satisfying it.
+    # Group E below covers the guard itself with ledger-less fixtures.
+    : > "${FIXTURE_DIR}/datarim/tasks.md"
     # Hermetic by default: neutralise both host-global surfaces.
     export DATARIM_ID_TMUX_SESSIONS=""
     export DATARIM_ID_GIT_REFS=""
@@ -272,7 +277,8 @@ dr-arcanada-RESEARCH-0015"
     for n in 0038 0039 0040 0041 0042 0043 0044 0045 0046 0047 0048 0049; do
         printf '# brief\n' > "${FIXTURE_DIR}/datarim/tasks/CTRL-${n}-task-description.md"
     done
-    # tasks.md / backlog.md deliberately absent — that is the defect.
+    # tasks.md carries no rows (the setup-created ledger is empty) — the
+    # task-description FILENAMES are the only claim surface, which is the defect.
 
     run_helper CTRL "${FIXTURE_DIR}"
     [ "$HSTATUS" -eq 0 ]
@@ -355,4 +361,58 @@ dr-arcanada-RESEARCH-0015"
     run_helper TUNE "${FIXTURE_DIR}"
     [ "$HSTATUS" -eq 0 ]
     [ "$HID" = "TUNE-0004" ]
+}
+
+# ── Group E — fail-CLOSED ledger-presence guard ──────────────────────────────
+#
+# A root carrying neither datarim/tasks.md nor datarim/backlog.md cannot answer
+# the ceiling question; the pre-guard behaviour was a silent, plausible
+# `PREFIX-0001` with exit 0 — against a workspace whose real ceiling could be
+# hundreds of IDs higher. The guard turns both misuse shapes into loud usage
+# errors. The most tempting misuse is passing the datarim/ directory ITSELF
+# (the parameter is literally named DATARIM_ROOT), so that shape gets its own
+# diagnostic hint.
+
+@test "E01: a ledger-less root fails loud (non-zero exit, no ID emitted)" {
+    LEDGERLESS="$(mktemp -d)"
+    # a plain directory with no datarim/ ledger at all
+    run_helper TUNE "${LEDGERLESS}"
+    rm -rf "${LEDGERLESS}"
+    [ "$HSTATUS" -ne 0 ]
+    [ -z "$HID" ]
+    [[ "$HERR" == *"no task ledger"* ]]
+    [[ "$HERR" == *"parent of datarim/"* ]]
+}
+
+@test "E02: passing the datarim/ subdirectory itself fails loud with a parent hint" {
+    # The workspace root (FIXTURE_DIR) is valid — its datarim/tasks.md exists —
+    # but the caller hands over FIXTURE_DIR/datarim. The helper resolves the
+    # ledgers as <given>/datarim/tasks.md, which does not exist, while
+    # <given>/tasks.md DOES — the signature of the subdir misuse.
+    printf -- '- TUNE-0550 · real ceiling row\n' > "${FIXTURE_DIR}/datarim/tasks.md"
+
+    run_helper TUNE "${FIXTURE_DIR}/datarim"
+    [ "$HSTATUS" -ne 0 ]
+    [ -z "$HID" ]
+    [[ "$HERR" == *"no task ledger"* ]]
+    [[ "$HERR" == *"pass its PARENT directory"* ]]
+    # and emphatically NOT the pre-guard silent wrong answer on stdout
+    [[ "$HID" != "TUNE-0001" ]]
+}
+
+@test "E03: the documented invocation against the workspace root still allocates correctly" {
+    printf -- '- TUNE-0550 · ceiling row\n' > "${FIXTURE_DIR}/datarim/tasks.md"
+
+    run_helper TUNE "${FIXTURE_DIR}"
+    [ "$HSTATUS" -eq 0 ]
+    [ "$HID" = "TUNE-0551" ]
+}
+
+@test "E04: a root with only backlog.md (no tasks.md) is a valid ledger" {
+    rm -f "${FIXTURE_DIR}/datarim/tasks.md"
+    printf -- '- TUNE-0007 · backlog row\n' > "${FIXTURE_DIR}/datarim/backlog.md"
+
+    run_helper TUNE "${FIXTURE_DIR}"
+    [ "$HSTATUS" -eq 0 ]
+    [ "$HID" = "TUNE-0008" ]
 }

--- a/tests/tune-0549-framework-hygiene.bats
+++ b/tests/tune-0549-framework-hygiene.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+# tune-0549-framework-hygiene.bats
+#
+# Regression for the .gitignore ↔ tracked-tree contradiction on
+# documentation/. An old ignore rule declared «framework repo MUST NOT
+# contain documentation/» while ~44 files under documentation/ were TRACKED
+# (the docs migration deliberately force-added the Diátaxis tree, and
+# CLAUDE.md § S4/S10 reference documentation/ paths as shipped surfaces).
+# The consequence: every new doc needed `git add -f`, and a contributor
+# reasonably concluded the path was wrong.
+#
+# The TREE is canon. These tests pin both halves of the agreement:
+#   1. tracked documentation/ files must NOT be gitignored
+#      (`git check-ignore` on a tracked doc path must FAIL), and
+#   2. the tracked tree itself must still exist (so half 1 cannot pass
+#      vacuously against an emptied checkout).
+
+REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+
+@test "documentation/ tree is tracked (non-empty git ls-files)" {
+    # grep/wc over ls-files — count must be > 0; a zero here means the
+    # sibling check-ignore test below would pass vacuously.
+    count="$(git -C "$REPO_ROOT" ls-files documentation/ | wc -l)"
+    [ "$count" -gt 0 ]
+}
+
+@test "no tracked documentation/ file matches an ignore pattern (--no-index)" {
+    # LOAD-BEARING SUBTLETY: modern git check-ignore consults the INDEX and
+    # never reports a tracked file as ignored, so a plain check-ignore over
+    # tracked paths passes even WITH the blanket rule present (verified on
+    # git 2.43). `--no-index` tests the pattern set itself — which is what
+    # this regression is about.
+    ignored="$(git -C "$REPO_ROOT" ls-files documentation/ \
+        | git -C "$REPO_ROOT" check-ignore --stdin --no-index 2>/dev/null | wc -l)"
+    [ "$ignored" -eq 0 ]
+}
+
+@test "a brand-new doc file would NOT need git add -f (the original pain shape)" {
+    # The defect's operator-visible symptom: every NEW doc under
+    # documentation/ needed `git add -f`. Probe a hypothetical new path —
+    # check-ignore matches patterns for paths that do not exist yet, and an
+    # untracked path is index-invisible, so no --no-index caveat applies.
+    run git -C "$REPO_ROOT" check-ignore -q "documentation/how-to/hypothetical-new-doc-probe.md"
+    [ "$status" -eq 1 ]
+}
+
+@test "no blanket documentation/ ignore rule survives in .gitignore" {
+    # Anchored to a whole-line rule: a negation (`!documentation/...`) or a
+    # deliberately narrowed subpath rule would not match this pattern.
+    count="$(grep -cE '^documentation/[[:space:]]*$' "$REPO_ROOT/.gitignore" || true)"
+    [ "$count" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Four L1 framework-hygiene backlog rows in one batch.

### TUNE-0553 — `next-free-id.sh` fails CLOSED on a ledger-less root
- The allocator silently returned `<PREFIX>-0001` (exit 0) against a root with no ledger — including the tempting misuse of passing the `datarim/` directory itself as `DATARIM_ROOT` (a plausible-looking, 550-times-claimed ID with no warning).
- New guard: a root carrying neither `datarim/tasks.md` nor `datarim/backlog.md` exits 1 with a message naming the expected layout (workspace root = parent of `datarim/`); the subdir misuse shape gets a dedicated "pass its PARENT directory" hint.
- Regression: **Group E** (E01 ledger-less root, E02 `datarim/`-subdir misuse, E03 documented invocation still allocates correctly, E04 backlog-only ledger valid) extended into the existing `tests/tune-0542-next-free-id-claim-surfaces.bats` suite — not forked. Sibling suites' fixtures gain an empty `tasks.md` (semantics unchanged: still no rows).

### TUNE-0232 — pre-push validator anti-decay wiring test
- New `tests/tune-0232-prepush-validator-wiring.bats`: extracts exactly the "Pre-push local validation (advisory)" section of `skills/security-baseline/SKILL.md` and asserts all three validator invocations (`check-security-policy.sh --validate-yaml`, `check-expectations-checklist.sh --verify`, `actionlint`) appear **inside the section**, not merely elsewhere in the file (the S7 table also cites actionlint).

### TUNE-0204 — `/dr-plan` stdlib-symbol advisory prose-contract test
- New `tests/tune-0204-dr-plan-stdlib-advisory.bats`: pins the standard-library symbol/module coverage bullet in `commands/dr-plan.md` — (a) missing-import surface case ("wrong or renamed stdlib symbol … still deserves a plan-time flag") and (b) already-imported pass-silently semantics ("do not fail the plan on a project-grep miss alone").

### TUNE-0549 — two framework hygiene defects
1. **`.gitignore` vs tracked `documentation/`:** the blanket ignore rule contradicted the deliberately tracked docs tree (44 files; docs migration + CLAUDE.md § S4/S10 references) and forced `git add -f` on every new doc. Tree is canon → rule deleted (verified: zero newly-untracked noise in a clean checkout). Regression `tests/tune-0549-framework-hygiene.bats` uses `check-ignore --no-index` — load-bearing subtlety: index-aware `check-ignore` (git ≥2.x) never reports tracked files as ignored, so the naive tracked-path probe is vacuous; verified empirically on git 2.43.
2. **Advisory reassert lint:** `check-dr-auto-reassert-wiring.sh` promoted from a trailing `linter-run` step to its own blocking `dr-auto-reassert-wiring` job in `dev-tools-lint.yml` (mirrors the sibling `dr-auto-cross-runtime` job), matching its fail-hard header. Workflow-wiring assertions (a job invokes the lint AND that job carries no `continue-on-error`, comment-stripped) extended into `tests/check-dr-auto-reassert-wiring.bats`.

## Verification

- Every new/changed regression mutation-tested: break → red → restore → green (guard disabled → E01/E02 red; validator line dropped / heading renamed → red; load-bearing phrases gutted → red; blanket ignore re-added → 3 red; `continue-on-error` injected / lint step deleted → red).
- 130 tests across all 8 next-free-id-related suites green; suites asserting against `dev-tools-lint.yml` (closure-gate, cross-kb-evolution-digest, rename-task-prefix, check-dr-auto-cross-runtime) green.
- `shellcheck -S warning dev-tools/next-free-id.sh` clean; `actionlint` clean on the edited workflow; `scripts/task-id-gate.sh` PASS on touched shipped surfaces; `dev-tools/check-body-english.sh --scope all` PASS (208 files).
- Portability: `grep -c` (no `grep -q` under pipefail), `#+` instead of `{1,6}` awk intervals (BSD awk), no GNU-only flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115RceXgSzqMmyFXjuyHHFu