### PR TITLE
fix(dr-orchestrate): TUNE-0340 rule-first resolution — semantic_parser over-escalation root-cause + threshold re-design

### DIFF
--- a/dev-tools/measure-orchestrator-soak.sh
+++ b/dev-tools/measure-orchestrator-soak.sh
@@ -14,6 +14,23 @@
 #
 # Exit 0 if rate < threshold (default 0.15), exit 1 if >= threshold or no data,
 # exit 2 on usage error.
+#
+# Threshold derivation (0.15, re-validated after the over-escalation
+# root-cause redesign — see documentation/how-to/evolution-log.md):
+#   The unknown-prompt handler is rule-first: input that substring-matches a
+#   trusted rule at/above the confidence threshold resolves deterministically
+#   with zero LLM involvement (cmd_run.sh resolve_and_route). Every prompt in
+#   the PRD-canonical resolvable reference corpus (the soak driver's
+#   RESOLVED_PROMPTS) carries a rule-matching slash-command literal, so the
+#   expected false-escalate contribution from that corpus is 0. The residual
+#   escalation sources are (a) resolvable phrasings with no rule substring
+#   that the backend chain classifies under-confidently, and (b) backend-chain
+#   outages for such phrasings. 0.15 is retained as headroom for those organic
+#   cases — it is attainable by mechanism, not by backend luck. Prerequisites
+#   for a valid verdict: audit events MUST carry expected_outcome labels
+#   (schema-v2 additive field) and this label-aware formula MUST be the
+#   deployed one — a rate computed without the expected_outcome slice counts
+#   designed escalations as false positives and inflates the rate.
 set -euo pipefail
 
 AUDIT_DIR="${DR_ORCH_AUDIT_DIR:-$HOME/.local/share/datarim-orchestrate}"

--- a/plugins/dr-orchestrate/scripts/cmd_run.sh
+++ b/plugins/dr-orchestrate/scripts/cmd_run.sh
@@ -121,11 +121,42 @@ execute_selected_action() {
 }
 
 # resolve_and_route <pane_text> <pane_id> <start_ms> — Phase 2 unknown-prompt
-# handler. Calls subagent_resolver.sh, gates on confidence threshold, either
-# emits an audit v2 record with outcome=resolved or routes to escalation.
+# handler. Rule-first: consults the deterministic rule set (semantic_parser)
+# before any subagent inference; a trusted-rule hit at or above the confidence
+# threshold resolves locally with backend_used=rule. Only on rule miss (or a
+# sub-threshold hit) does it call subagent_resolver.sh, gate on the confidence
+# threshold, and either emit an audit v2 record with outcome=resolved or route
+# to escalation. Rationale: the escalate branch is the deterministic catch-all
+# whenever the LLM backend chain is absent, unauthenticated, or under-confident;
+# without the rule-first pass, input that already matches a trusted rule
+# (e.g. a prose-wrapped slash command) false-escalates on every such host.
 resolve_and_route() {
   local text="$1"; local pane="$2"; local start_ms="$3"
   local resolver_json conf action action_kind action_payload backend_used model end_ms dur hint=""
+
+  # --- Rule-first fast path (zero LLM cost, backend-independent) -----------
+  local rule_json rule_conf rule_action
+  rule_json="$(parse "$text")"
+  rule_conf="$(printf '%s' "$rule_json" | jq -r '.confidence // 0')"
+  rule_action="$(printf '%s' "$rule_json" | jq -r '.action // ""')"
+  if [[ -n "$rule_action" ]] \
+    && awk -v c="$rule_conf" -v t="$CONFIDENCE_THRESHOLD" 'BEGIN{ exit !(c+0 >= t+0) }'; then
+    end_ms="$(now_ms)"
+    dur=$(( end_ms - start_ms ))
+    local rule_outcome="resolved" rule_cycle_id
+    rule_cycle_id="$(hash_sha256 "$start_ms:$pane:$text")"
+    if ! execute_selected_action "$rule_action" "$pane" "$rule_cycle_id" "$rule_conf" "$text" 0; then
+      rule_outcome="blocked_execution"
+    fi
+    local rule_evt
+    rule_evt="$(make_event_v2 "$text" "$rule_action" 0 "$dur" "$pane" \
+            "$rule_conf" "" "rule" "" "resolve" "$rule_outcome" "rule_first_hit")"
+    emit "$AUDIT_FILE" "$rule_evt"
+    echo "dr-orchestrate: resolve | action=$rule_action | confidence=$rule_conf | backend=rule | outcome=$rule_outcome"
+    return 0
+  fi
+  # --- Rule miss / sub-threshold hit → subagent inference chain ------------
+
   if [[ -n "$ACTIVE_TASK" ]]; then hint="$(snapshot_hint_for_task "$ACTIVE_TASK" 2>/dev/null || true)"; fi
   if [[ -n "$hint" ]]; then
     resolver_json="$(bash "$DR_ORCH_DIR/scripts/subagent_resolver.sh" resolve --hint "$hint" -- "$text" 2>/dev/null || true)"

--- a/plugins/dr-orchestrate/tests/test_rule_first_resolution.bats
+++ b/plugins/dr-orchestrate/tests/test_rule_first_resolution.bats
@@ -1,0 +1,130 @@
+#!/usr/bin/env bats
+# test_rule_first_resolution.bats — over-escalation root-cause regression.
+#
+# Defect class: resolve_and_route (cmd_run.sh unknown-prompt handler) used to
+# go straight to the LLM subagent chain without consulting the deterministic
+# rule set. On any host where the chain is absent, unauthenticated, or
+# under-confident, the escalate branch is the guaranteed destination — so
+# rule-resolvable input (prose-wrapped slash commands, commands not yet in the
+# classifier's closed set) false-escalated on every cycle and the soak
+# false-escalate verdict gate failed far above its threshold.
+#
+# Fix under test: rule-first fast path — a trusted-rule hit at/above the
+# confidence threshold resolves locally (backend_used=rule) with zero LLM
+# involvement; only a rule miss or sub-threshold hit reaches the chain.
+#
+# T1  non-slash rule-matching prompt resolves via rule-first, no backends
+# T2  synthetic reference corpus: false-escalate rate 0 with backends absent
+#     (pre-fix mechanism: every resolvable prompt escalates → rate 1.0)
+# T3  non-matching prompt still escalates (no over-resolution regression)
+# T4  sub-threshold rule hit falls through to the chain (threshold respected)
+
+setup() {
+  export PLUGIN_ROOT
+  PLUGIN_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+  export REPO_ROOT
+  REPO_ROOT="$(cd "$PLUGIN_ROOT/../.." && pwd)"
+
+  export AUDIT_DIR="$BATS_TEST_TMPDIR/audit"
+  export DR_ORCH_STATE_DIR="$BATS_TEST_TMPDIR/state"
+  export DR_ORCH_ACTION_EXECUTOR_LOG="$BATS_TEST_TMPDIR/actions.log"
+  # Hermetic rules: bundled defaults only — no operator user.yaml leakage.
+  export DR_ORCH_RULES_USER="$BATS_TEST_TMPDIR/no-user-rules.yaml"
+  # Backend chain resolves to a binary that does not exist on any host.
+  export DR_ORCH_SUBAGENT_CHAIN="mock-absent"
+  export DR_ORCH_RESOLVER_TIMEOUT_S=2
+
+  # action_gate fixture: permissive space so framework_command executes.
+  export DATARIM_SPACES_ROOT="$BATS_TEST_TMPDIR/spaces"
+  export DATARIM_ACTIVE_SPACE=arcanada
+  export DR_AUTONOMY_RULES="$BATS_TEST_TMPDIR/fb-rules.yaml"
+  export DR_ORCH_AUTONOMY_AUDIT="$BATS_TEST_TMPDIR/autonomy.jsonl"
+  mkdir -p "$DATARIM_SPACES_ROOT/arcanada" "$AUDIT_DIR"
+  # audit_sink refuses group/other-writable audit parents; the default
+  # umask on some CI hosts creates 775 directories.
+  chmod 700 "$AUDIT_DIR"
+  cat > "$DATARIM_SPACES_ROOT/arcanada/space.yml" <<'YAML'
+space:
+  name: arcanada
+autonomy:
+  schema_version: 1
+  policy:
+    cross_project_write: auto
+YAML
+  cat > "$DR_AUTONOMY_RULES" <<'YAML'
+always_gated_floor: [finance_action]
+action_autonomy_map:
+  framework_command: cross_project_write
+YAML
+}
+
+audit_file() {
+  echo "$AUDIT_DIR/audit-$(date -u +%Y-%m-%d).jsonl"
+}
+
+@test "T1 rule-first: prose-wrapped slash command resolves without any LLM backend" {
+  run env DR_ORCH_EXPECTED_OUTCOME=resolved \
+    "$PLUGIN_ROOT/scripts/cmd_run.sh" --unknown-prompt "please run /dr-status"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"backend=rule"* ]]
+  [[ "$output" == *"action=/dr-status"* ]]
+  grep -qx "/dr-status" "$DR_ORCH_ACTION_EXECUTOR_LOG"
+  evt="$(tail -1 "$(audit_file)")"
+  [ "$(jq -r '.outcome' <<<"$evt")" = "resolved" ]
+  [ "$(jq -r '.reason' <<<"$evt")" = "rule_first_hit" ]
+  [ "$(jq -r '.backend_used' <<<"$evt")" = "rule" ]
+  [ "$(jq -r '.expected_outcome' <<<"$evt")" = "resolved" ]
+}
+
+@test "T2 synthetic reference corpus: false-escalate rate 0.0000 with backends absent" {
+  # Resolvable bucket — mirrors the soak driver's RESOLVED_PROMPTS corpus
+  # (PRD-canonical traffic-mix spec). Distinct panes dodge the per-pane
+  # 60 s decision cooldown so every resolution lands in the metric.
+  resolvable=(
+    "/dr-status" "/dr-help" "/dr-init" "/dr-prd" "/dr-plan" "/dr-do"
+    "/dr-qa" "/dr-archive" "/dr-continue" "/dr-design" "/dr-compliance"
+    "please run /dr-status" "run /dr-help now" "/dr-do please"
+  )
+  i=0
+  for p in "${resolvable[@]}"; do
+    i=$((i + 1))
+    env DR_ORCH_EXPECTED_OUTCOME=resolved \
+      "$PLUGIN_ROOT/scripts/cmd_run.sh" --unknown-prompt "$p" --pane "res:$i" \
+      >/dev/null
+  done
+  # Designed-escalation bucket (ASCII subset of the driver's corpus).
+  unresolvable=("hello world" "random text foo bar" "tell me a joke" "abc")
+  i=0
+  for p in "${unresolvable[@]}"; do
+    i=$((i + 1))
+    env DR_ORCH_EXPECTED_OUTCOME=escalated \
+      "$PLUGIN_ROOT/scripts/cmd_run.sh" --unknown-prompt "$p" --pane "esc:$i" \
+      >/dev/null
+  done
+
+  run "$REPO_ROOT/dev-tools/measure-orchestrator-soak.sh" \
+    --audit-dir "$AUDIT_DIR" --since 1h --max-false-escalate 0.15 --verbose
+  echo "measure: $output"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"resolved=14 escalated=0"* ]]
+  [[ "$output" == *"rate=0.0000"* ]]
+}
+
+@test "T3 non-matching prompt still escalates (no over-resolution)" {
+  run env DR_ORCH_EXPECTED_OUTCOME=escalated \
+    "$PLUGIN_ROOT/scripts/cmd_run.sh" --unknown-prompt "hello world"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dr-orchestrate: escalate"* ]]
+  evt="$(tail -1 "$(audit_file)")"
+  [ "$(jq -r '.outcome' <<<"$evt")" = "escalated" ]
+}
+
+@test "T4 sub-threshold rule hit falls through to the chain (and escalates here)" {
+  # /dr-status carries confidence 0.90 in the bundled rules; raising the
+  # runtime threshold above it must bypass the rule-first path.
+  run env DR_ORCH_CONFIDENCE_THRESHOLD=0.99 DR_ORCH_EXPECTED_OUTCOME=resolved \
+    "$PLUGIN_ROOT/scripts/cmd_run.sh" --unknown-prompt "/dr-status"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"dr-orchestrate: escalate"* ]]
+  [[ "$output" != *"backend=rule"* ]]
+}


### PR DESCRIPTION
## Summary

Root-causes the soak verdict-gate failure (false-escalate rate **0.7367** vs threshold 0.15) by decomposing the raw 48h audit JSONL (matched_text_hash mapped back to the traffic-driver corpus) and fixes the remaining structural defect at HEAD.

### Per-hypothesis verdicts (soak report § Root-Cause)

| # | Hypothesis | Verdict | Evidence |
|---|---|---|---|
| 1 | Parser threshold mis-calibration in `rules/default.yaml` | **Refuted as thresholds; confirmed as partial rule-set** | Rule confidences 0.90–0.95 all clear the 0.80 gate, and the rule-hit path never gates on the threshold — no confidence value in `default.yaml` can cause escalation. But all 2,514 genuine false-escalations were exactly the two `/dr-help` prompts (1,222 + 1,292; 0 resolved, 0 blocked): `/dr-help` was absent from the deployed rule set (added to `default.yaml` a month after the soak), hence also absent from the LLM classifier's closed action set — so the chain correctly refused and the catch-all escalate branch fired every time. |
| 2 | Traffic-driver corpus narrower than rules expect | **Refuted (inverted)** | Every prompt in the resolvable corpus substring-matches a bundled rule at HEAD. The real gap is routing: the unknown-prompt path (`resolve_and_route` → `subagent_resolver.resolve()`) never consulted the rule set at all — resolution of rule-matching text depended entirely on LLM backend availability/confidence. |
| 3 | schema_v2 outcome labelling drift | **Confirmed — dominant contributor** | Every schema-v2 record in the window has NO `expected_outcome` field (12,298 blocked + 7,237 escalated + 2,570 resolved, all unlabelled). The deployed measure script therefore counted all 4,721 designed escalations (20% escalated bucket) as false positives. Label emission + label-aware formula shipped 2026-06-14, after the soak. Already fixed on main. |

### Escalation-rate accounting

- Reported: 6,379 / 8,659 = **0.7367** — computed without the `expected_outcome` slice.
- Corrected for H3 (designed escalations removed): 2,514 / (2,514 + 2,557) = **0.4958** — still a real failure, 100% `/dr-help`-class (H1 partial rule-set).
- After this PR (rule-first path; synthetic reference corpus, all LLM backends absent): **1.0000 → 0.0000**, measured by `measure-orchestrator-soak.sh` itself.

### The fix

`resolve_and_route` (cmd_run.sh) now consults the deterministic rule set **first**: a trusted-rule hit at/above the confidence threshold resolves locally (`backend_used=rule`, `reason=rule_first_hit`, zero LLM cost). Rule miss or sub-threshold hit falls through to the subagent chain unchanged. This removes the LLM-availability dependency for all rule-matching input (prose-wrapped slash commands included) and makes escalation on the resolvable reference corpus zero by mechanism.

### Threshold re-design

0.15 retained — not a silent bump. Derivation recorded in the measure-script header: with rule-first, the expected false-escalate contribution from the PRD-canonical resolvable corpus is 0; the threshold now budgets only organic phrasings lacking a rule substring, and the header records the label-emission prerequisite without which any measured rate is invalid.

### Tests

- New `plugins/dr-orchestrate/tests/test_rule_first_resolution.bats` (4 tests): rule-first resolution without backends; corpus-level rate 0.0000 via the real verdict script; no over-resolution regression; sub-threshold fall-through.
- Mutation-tested: reverting the fix flips T1/T2 red with `rate=1.0000 (resolved=0 escalated=14)`; restoring flips green.
- Adjacent suites green: semantic_parser, action_gate, subagent_resolver, rules_loader, escalation_backend (46), contract sync-shortcut + orchestrator-input-migration (11), dev-tools soak bats (16).
- `shellcheck -S warning` clean on both edited scripts; `task-id-gate.sh --diff-only origin/main` PASS.

### Data-gated remainder

A live re-soak on the ops host is required to confirm the rate under real traffic with the label-aware formula actually deployed (`/opt/datarim` copy must be current — the May failure partly came from a stale deployed verdict script predating the `expected_outcome` slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115RceXgSzqMmyFXjuyHHFu