### PR TITLE
feat(gates): VERSION↔tag parity + runtime drift checks (TUNE-0564/0565)

### DIFF
--- a/.github/workflows/framework-gates.yml
+++ b/.github/workflows/framework-gates.yml
@@ -28,6 +28,24 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  version-tag-parity:
+    name: VERSION has a matching release tag (blocking on main)
+    # A release that never shipped must not look shipped: a release PR that
+    # bumps VERSION+CHANGELOG and merges without the post-merge tag leaves the
+    # repo advertising a version with no tag, no release workflow, no artefacts.
+    # Runs ONLY on the main-push event — on a release PR the bumped VERSION
+    # legitimately precedes the tag, so a pull_request run would always fail.
+    # --wait-seconds tolerates the normal merge→tag window before going red.
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: VERSION ↔ remote tag parity (waits up to 15 min for the tag)
+        run: bash dev-tools/check-version-tag-parity.sh --check --wait-seconds 900 --report
+
   component-counts:
     name: component counts vs disk (blocking)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,30 @@ All notable changes to the Datarim framework are documented here. Format follows
 
 ## [Unreleased]
 
-_Nothing yet._
+### Added
+
+- **TUNE-0564 VERSION↔tag parity gate.** `dev-tools/check-version-tag-parity.sh`
+  fails when the version declared in `VERSION` has no matching `v<VERSION>` tag
+  on origin — the silent half-release (bumped manifest, never-pushed tag, no
+  release workflow, no artefacts) that both v2.62.0 and, initially, v2.64.0
+  fell into. Wired as a blocking `framework-gates` job on the main-push event
+  only (a release PR legitimately bumps VERSION before the tag exists), with a
+  15-minute wait window for the normal merge→tag gap. Mutation-tested
+  regression: `tests/check-version-tag-parity.bats`.
+- **TUNE-0565 runtime drift check.** `dev-tools/check-runtime-drift.sh` fails
+  when the agent runtime (`$CLAUDE_DIR/{skills,commands,agents}`) symlinks into
+  a git checkout sitting on a feature branch (or detached off any release tag),
+  or when scopes resolve into different checkouts — the state where every agent
+  on a host silently serves stale rules. Skips copy-mode installs; accepts a
+  release-tag pin. Wired as a blocking step in `validate.sh`. Mutation-tested
+  regression: `tests/check-runtime-drift.bats`.
+
+### Fixed
+
+- **v2.64.0 release completed.** The v2.64.0 cut merged without its annotated
+  tag, so no release pipeline ran; the tag was created on the release commit
+  and the signed release (tarball + SBOM + cosign bundles + provenance) is now
+  published. Audit record: `documentation/release-audit/release-2.64.0.md`.
 
 ## [2.64.0] — 2026-08-05
 

--- a/dev-tools/check-runtime-drift.sh
+++ b/dev-tools/check-runtime-drift.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# check-runtime-drift.sh — a runtime pinned to a feature-worktree must not
+# silently serve stale rules.
+#
+# Scope: under symlink-mode the agent runtime (`$CLAUDE_DIR/{skills,commands,
+# agents,...}`) points into a git checkout of the framework. When that checkout
+# sits on a feature branch — e.g. a bugfix worktree that was never retargeted —
+# every agent on the host quietly runs old skills, old commands and an old
+# VERSION while the repo, the fleet and the release notes have moved on. This
+# check makes that state loud.
+#
+# Drift conditions (any → FAIL):
+#   D1 a runtime scope symlink resolves into a git checkout whose HEAD branch
+#      is not `main` (detached HEAD counts as drift unless it sits exactly on
+#      a `v*` release tag — a tag-pinned runtime is a legitimate deployment);
+#   D2 runtime scopes resolve into DIFFERENT checkouts (mixed runtime).
+#
+# Not drift: copy-mode installs (scope is a real directory, not a symlink) —
+# copy-mode currency is the installer's business, not a symlink-target property.
+#
+# Contract (per CLAUDE.md § Validation Discipline):
+#   pure shell; --check mode; exit 0 = PASS, exit 1 = FAIL, exit 2 = usage.
+#
+# Usage:
+#   check-runtime-drift.sh --check [--claude-dir <path>] [--branch main]
+set -euo pipefail
+
+claude_dir="${CLAUDE_DIR:-$HOME/.claude}" ; expect_branch="main" ; mode=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --check) mode=check; shift ;;
+        --claude-dir) claude_dir="${2:-}"; shift 2 ;;
+        --branch) expect_branch="${2:-main}"; shift 2 ;;
+        -h|--help) sed -n '2,26p' "$0"; exit 0 ;;
+        *) echo "ERROR: unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+[ "$mode" = check ] || { echo "ERROR: --check is required" >&2; exit 2; }
+[ -d "$claude_dir" ] || { echo "ERROR: claude dir '$claude_dir' not found" >&2; exit 2; }
+
+drift=0
+seen_root=""
+for scope in skills commands agents; do
+    link="$claude_dir/$scope"
+    # -e follows symlinks, so a BROKEN symlink would be skipped as "absent" —
+    # exactly the silent state this check exists to catch. Test -L separately.
+    [ -e "$link" ] || [ -L "$link" ] || continue
+    [ -L "$link" ] || { echo "INFO: $scope is a real directory (copy-mode) — skipped"; continue; }
+    target="$(readlink -f "$link" || true)"
+    [ -n "$target" ] && [ -d "$target" ] || { echo "FAIL: $scope symlink is broken ($link)"; drift=1; continue; }
+    root="$(git -C "$target" rev-parse --show-toplevel 2>/dev/null || true)"
+    if [ -z "$root" ]; then
+        echo "INFO: $scope target is not a git checkout — skipped"
+        continue
+    fi
+    branch="$(git -C "$root" symbolic-ref --short -q HEAD || echo DETACHED)"
+    version="$( [ -f "$root/VERSION" ] && tr -d ' \t\n' < "$root/VERSION" || echo '?' )"
+    if [ -n "$seen_root" ] && [ "$root" != "$seen_root" ]; then
+        echo "FAIL: mixed runtime — $scope resolves into '$root' but an earlier scope resolved into '$seen_root'"
+        drift=1
+    fi
+    seen_root="$root"
+    if [ "$branch" = "$expect_branch" ]; then
+        echo "OK: $scope -> $root (branch $branch, VERSION $version)"
+    elif [ "$branch" = DETACHED ] && git -C "$root" describe --tags --exact-match --match 'v*' >/dev/null 2>&1; then
+        echo "OK: $scope -> $root (detached on release tag $(git -C "$root" describe --tags --exact-match --match 'v*'), VERSION $version)"
+    else
+        echo "FAIL: runtime drift — $scope resolves into '$root' on branch '$branch' (VERSION $version), expected '$expect_branch'. Agents on this host are serving a feature-worktree's rules."
+        drift=1
+    fi
+done
+
+if [ "$drift" -ne 0 ]; then
+    echo "RESULT: FAIL — repoint the runtime symlinks at a current '$expect_branch' checkout (see documentation/tutorials/getting-started.md § installation modes)." >&2
+    exit 1
+fi
+echo "RESULT: PASS — runtime symlinks resolve to a '$expect_branch' checkout"
+exit 0

--- a/dev-tools/check-version-tag-parity.sh
+++ b/dev-tools/check-version-tag-parity.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# check-version-tag-parity.sh — a release that never shipped must not look shipped.
+#
+# Scope: verifies that the version declared in <repo>/VERSION has a matching
+# annotated tag v<VERSION> on the `origin` remote. The failure mode this guards
+# against is the silent half-release: a release PR bumps VERSION + CHANGELOG and
+# merges, the post-merge tagging step never runs, and from then on the repo
+# *looks* released (manifest says X.Y.Z) while no tag, no release workflow, no
+# tarball, no SBOM, no signature and no GitHub Release exist.
+#
+# Contract (per CLAUDE.md § Validation Discipline):
+#   pure shell; --check mode; exit 0 = PASS, exit 1 = FAIL, exit 2 = usage/setup.
+#
+# The merge→tag window is legitimate: the tag is created by the operator or the
+# release gate minutes after the release PR merges. --wait-seconds N polls the
+# remote for up to N seconds before declaring FAIL, so a CI job on the main-push
+# event tolerates the normal window and still fails loudly when the tag never
+# arrives.
+#
+# Usage:
+#   check-version-tag-parity.sh --check [--repo <path>] [--wait-seconds N] [--report]
+set -euo pipefail
+
+repo="." ; wait_seconds=0 ; mode="" ; report=false
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --check) mode=check; shift ;;
+        --repo) repo="${2:-}"; shift 2 ;;
+        --wait-seconds) wait_seconds="${2:-0}"; shift 2 ;;
+        --report) report=true; shift ;;
+        -h|--help)
+            sed -n '2,21p' "$0"; exit 0 ;;
+        *) echo "ERROR: unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+[ "$mode" = check ] || { echo "ERROR: --check is required" >&2; exit 2; }
+[[ "$wait_seconds" =~ ^[0-9]+$ ]] || { echo "ERROR: --wait-seconds must be an integer" >&2; exit 2; }
+git -C "$repo" rev-parse --is-inside-work-tree >/dev/null 2>&1 || { echo "ERROR: --repo '$repo' is not a git work tree" >&2; exit 2; }
+[ -f "$repo/VERSION" ] || { echo "ERROR: $repo/VERSION not found" >&2; exit 2; }
+
+version="$(tr -d ' \t\n' < "$repo/VERSION")"
+[[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] || { echo "ERROR: VERSION content '$version' is not X.Y.Z" >&2; exit 2; }
+tag_ref="refs/tags/v${version}"
+
+probe() {
+    # ls-remote hits the authoritative remote — a locally created but unpushed
+    # tag must NOT pass (the release workflow triggers on the remote push).
+    # Output capture, not exit code, decides: empty stdout = tag absent.
+    local out
+    out="$(git -C "$repo" ls-remote --tags origin "$tag_ref" 2>/dev/null || true)"
+    [ -n "$out" ]
+}
+
+deadline=$(( $(date +%s) + wait_seconds ))
+while :; do
+    if probe; then
+        echo "PASS: VERSION ${version} has matching remote tag v${version}"
+        exit 0
+    fi
+    [ "$(date +%s)" -lt "$deadline" ] || break
+    sleep 30
+done
+
+echo "FAIL: VERSION is ${version} but tag v${version} does not exist on origin — the release was never tagged/shipped (waited ${wait_seconds}s)." >&2
+if [ "$report" = true ]; then
+    echo "Newest remote tags:" >&2
+    git -C "$repo" ls-remote --tags origin 'refs/tags/v*' 2>/dev/null | tail -5 >&2 || true
+    echo "Remedy: run dev-tools/release-gate.sh (tags + pushes on all-green), or create the annotated tag per documentation/how-to/ release procedure." >&2
+fi
+exit 1

--- a/documentation/release-audit/release-2.64.0.md
+++ b/documentation/release-audit/release-2.64.0.md
@@ -1,0 +1,10 @@
+- release: 2.64.0
+  registry: gh
+  bump_level: minor
+  gates_passed: G0,G1,G2,G3,G4,G5,G6
+  rationale: bump_level=minor
+api_diff=unavailable
+zero_x=false
+escalate=false
+rationale=range v2.63.0..HEAD: highest Conventional-Commits bump=minor, api_diff=unavailable, zero_x=false
+  timestamp: 2026-08-05T10:32:11Z

--- a/tests/check-runtime-drift.bats
+++ b/tests/check-runtime-drift.bats
@@ -1,0 +1,83 @@
+#!/usr/bin/env bats
+# Regression contract for dev-tools/check-runtime-drift.sh — a runtime symlinked
+# into a feature-worktree (stale rules) must FAIL loudly; a main checkout, a
+# release-tag pin, and copy-mode must PASS.
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    GATE="$REPO_ROOT/dev-tools/check-runtime-drift.sh"
+    WORK="$(mktemp -d "${BATS_TMPDIR}/drift.XXXXXX")"
+
+    # Fixture framework checkout with the three runtime scopes.
+    git init -q -b main "$WORK/framework"
+    (
+        cd "$WORK/framework"
+        git config user.email t@example.invalid; git config user.name t
+        mkdir -p skills commands agents
+        echo "9.9.9" > VERSION
+        touch skills/.keep commands/.keep agents/.keep
+        git add -A && git commit -qm base
+    )
+    mkdir -p "$WORK/claude"
+    for s in skills commands agents; do
+        ln -s "$WORK/framework/$s" "$WORK/claude/$s"
+    done
+}
+
+teardown() { rm -rf "$WORK"; }
+
+@test "D1 PASS when the runtime resolves into a main checkout" {
+    run bash "$GATE" --check --claude-dir "$WORK/claude"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"RESULT: PASS"* ]]
+}
+
+@test "D2 FAIL when the checkout sits on a feature branch" {
+    (cd "$WORK/framework" && git checkout -q -b fix/some-feature-worktree)
+    run bash "$GATE" --check --claude-dir "$WORK/claude"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"runtime drift"*"fix/some-feature-worktree"* ]]
+}
+
+@test "D3 PASS when detached exactly on a v* release tag (tag-pinned deployment)" {
+    (cd "$WORK/framework" && git tag -a v9.9.9 -m r && git checkout -q --detach v9.9.9)
+    run bash "$GATE" --check --claude-dir "$WORK/claude"
+    [ "$status" -eq 0 ]
+}
+
+@test "D4 FAIL when detached NOT on a release tag" {
+    (cd "$WORK/framework" && git checkout -q --detach HEAD)
+    run bash "$GATE" --check --claude-dir "$WORK/claude"
+    [ "$status" -eq 1 ]
+}
+
+@test "D5 copy-mode (real directories) is skipped, not failed" {
+    rm "$WORK/claude/skills" && mkdir "$WORK/claude/skills"
+    (cd "$WORK/framework" && git checkout -q -b fix/other)   # other scopes still drift
+    run bash "$GATE" --check --claude-dir "$WORK/claude"
+    [ "$status" -eq 1 ]                                       # commands/agents still fail
+    [[ "$output" == *"copy-mode"* ]]
+    # All-copy-mode passes:
+    for s in commands agents; do rm "$WORK/claude/$s" && mkdir "$WORK/claude/$s"; done
+    run bash "$GATE" --check --claude-dir "$WORK/claude"
+    [ "$status" -eq 0 ]
+}
+
+@test "D6 FAIL on mixed runtime (scopes resolving into different checkouts)" {
+    git init -q -b main "$WORK/framework2"
+    (cd "$WORK/framework2" && git config user.email t@e.invalid && git config user.name t && mkdir -p agents && echo 1.0.0 > VERSION && git add -A && git commit -qm b)
+    rm "$WORK/claude/agents" && ln -s "$WORK/framework2/agents" "$WORK/claude/agents"
+    run bash "$GATE" --check --claude-dir "$WORK/claude"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"mixed runtime"* ]]
+}
+
+@test "D7 broken symlink is a FAIL, and usage errors are exit 2" {
+    rm "$WORK/claude/skills" && ln -s "$WORK/nonexistent" "$WORK/claude/skills"
+    run bash "$GATE" --check --claude-dir "$WORK/claude"
+    [ "$status" -eq 1 ]
+    run bash "$GATE" --claude-dir "$WORK/claude"
+    [ "$status" -eq 2 ]
+    run bash "$GATE" --check --claude-dir "$WORK/no-such-dir"
+    [ "$status" -eq 2 ]
+}

--- a/tests/check-version-tag-parity.bats
+++ b/tests/check-version-tag-parity.bats
@@ -1,0 +1,73 @@
+#!/usr/bin/env bats
+# Regression contract for dev-tools/check-version-tag-parity.sh — the gate that
+# fails when VERSION on main has no matching v<VERSION> tag on origin (the
+# silent half-release: bumped manifest, never-pushed tag, no release artefacts).
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    GATE="$REPO_ROOT/dev-tools/check-version-tag-parity.sh"
+    WORK="$(mktemp -d "${BATS_TMPDIR}/vtp.XXXXXX")"
+
+    # Bare "origin" + a clone declaring VERSION, so ls-remote hits a real remote.
+    git init -q --bare "$WORK/origin.git"
+    git init -q "$WORK/clone"
+    (
+        cd "$WORK/clone"
+        git config user.email t@example.invalid; git config user.name t
+        echo "3.5.7" > VERSION
+        git add VERSION && git commit -qm "bump to 3.5.7"
+        git remote add origin "$WORK/origin.git"
+        git push -q origin HEAD:main
+    )
+}
+
+teardown() { rm -rf "$WORK"; }
+
+@test "V1 PASS when the remote carries the matching tag" {
+    (cd "$WORK/clone" && git tag -a v3.5.7 -m "release 3.5.7" && git push -q origin v3.5.7)
+    run bash "$GATE" --check --repo "$WORK/clone"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PASS"*"v3.5.7"* ]]
+}
+
+@test "V2 FAIL when no tag exists for VERSION (the half-release)" {
+    run bash "$GATE" --check --repo "$WORK/clone"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"FAIL"*"v3.5.7"*"never tagged"* ]]
+}
+
+@test "V3 a LOCAL-only tag must NOT pass — the release workflow fires on the remote push" {
+    (cd "$WORK/clone" && git tag -a v3.5.7 -m "release 3.5.7")   # not pushed
+    run bash "$GATE" --check --repo "$WORK/clone"
+    [ "$status" -eq 1 ]
+}
+
+@test "V4 FAIL when only a DIFFERENT version is tagged" {
+    (cd "$WORK/clone" && git tag -a v3.5.6 -m "release 3.5.6" && git push -q origin v3.5.6)
+    run bash "$GATE" --check --repo "$WORK/clone"
+    [ "$status" -eq 1 ]
+}
+
+@test "V5 --wait-seconds picks up a tag that arrives inside the window" {
+    ( sleep 2; cd "$WORK/clone" && git tag -a v3.5.7 -m "release 3.5.7" && git push -q origin v3.5.7 ) &
+    run bash "$GATE" --check --repo "$WORK/clone" --wait-seconds 40
+    wait
+    [ "$status" -eq 0 ]
+}
+
+@test "V6 usage errors are exit 2, not silent passes" {
+    run bash "$GATE" --repo "$WORK/clone"          # missing --check
+    [ "$status" -eq 2 ]
+    run bash "$GATE" --check --repo "$WORK"        # not a work tree
+    [ "$status" -eq 2 ]
+    (cd "$WORK/clone" && echo "not-a-version" > VERSION)
+    run bash "$GATE" --check --repo "$WORK/clone"  # malformed VERSION
+    [ "$status" -eq 2 ]
+}
+
+@test "V7 wiring: framework-gates workflow runs the gate on the main-push event only" {
+    wf="$REPO_ROOT/.github/workflows/framework-gates.yml"
+    grep -q "check-version-tag-parity.sh --check" "$wf"
+    # The job must be fenced off pull_request runs (release PRs bump VERSION pre-tag).
+    awk '/version-tag-parity:/,/component-counts:/' "$wf" | grep -q "github.event_name == 'push'"
+}

--- a/validate.sh
+++ b/validate.sh
@@ -128,6 +128,18 @@ if [ -d "$LOCAL_DIR" ]; then
     fi
 fi
 
+# Runtime drift check: a runtime symlinked into a feature-worktree serves
+# stale rules to every agent on the host. Blocking — that state must be loud.
+if [ -f "$SCRIPT_DIR/dev-tools/check-runtime-drift.sh" ]; then
+    echo ""
+    echo "Runtime Drift Check:"
+    if bash "$SCRIPT_DIR/dev-tools/check-runtime-drift.sh" --check --claude-dir "${CLAUDE_DIR:-$HOME/.claude}"; then
+        :
+    else
+        ERRORS=$((ERRORS + 1))
+    fi
+fi
+
 # Summary counts
 echo ""
 # Counting rules — one shipped component per unit, NOT every .md on disk:


### PR DESCRIPTION
Round-7 closeout defects (cross-machine audit 2026-08-05).

## TUNE-0564 — v2.64.0 was never tagged (fixed + gated)
The v2.64.0 release PR (#348) merged but the post-merge tag never happened: no tag, no release.yml run, no artefacts, while VERSION said 2.64.0. Fixed first (annotated tag `v2.64.0` on `b078827`, v2.63.0 shape, classifier-verified minor; release run 30997813470 SUCCESS; GH release live with tarball + sha256 + SBOM + 2 cosign bundles). This PR ships the structural gate: `dev-tools/check-version-tag-parity.sh` — FAIL when VERSION on main has no matching remote tag; blocking `framework-gates` job on the **main-push event only** (release PRs legitimately bump VERSION pre-tag) with a 15-minute wait for the normal merge→tag window. Mutation-tested (`tests/check-version-tag-parity.bats`: always-pass probe, wrong ref, unwired job — all killed). A local-only unpushed tag deliberately does NOT pass (release workflow fires on the remote push).

## TUNE-0565 — runtime drift check
The `dev` runtime on the build host symlinked into a stale 2.61.0 feature worktree (68 skills, rotation-runbook missing) — every tmux-orchestrated agent ran old rules. Runtime repointed host-side to the current-main checkout (matches root's layout; verified 69/28/19 + rotation-runbook + VERSION 2.64.0). This PR ships `dev-tools/check-runtime-drift.sh`: FAIL when a runtime scope resolves into a feature-branch or detached-non-tag checkout, or scopes resolve into different checkouts; copy-mode skipped; release-tag pins accepted. Wired blocking into `validate.sh`. Mutation-tested (`tests/check-runtime-drift.bats`); TDD caught a real silent-skip bug (broken symlink passed `-e` and was skipped).

Also: `documentation/release-audit/release-2.64.0.md` (gate audit record) + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0115RceXgSzqMmyFXjuyHHFu