### PR TITLE
fix(gates): TUNE-0566/0567/0568 — two false-blocking archive gates + malformed dr-quick ledger row

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,17 @@ All notable changes to the Datarim framework are documented here. Format follows
   O(lines x files) subprocesses and pushed a 60-line / 1161-file case past two
   minutes (now ~15s). Substring semantics and the rename fallback are unchanged.
 
+- **TUNE-0568 `/dr-quick` emitted a malformed `tasks.md` row.** Step 3 named the
+  field values as prose ("`status in_progress`, `priority P3`, `complexity L1` by
+  convention") without showing the emitted line, so agents interpolated the field
+  NAMES into the row — `· status done · priority P3 · complexity L1 ·` — which
+  does not match `ONELINER_RE`. Every fast-lane row written this way was
+  non-compliant (33 such rows found in one consumer workspace, all of them
+  completed tasks that had also never been removed). Step 3 now shows the exact
+  line shape and states that a completed task's row is REMOVED at archive time,
+  `ONELINER_RE` having no `done` status because completion history lives in
+  `documentation/archive/`.
+
 - **TUNE-0567 deferral-prose line-scoped false positive.**
   `dev-tools/check-deferral-prose.sh` judged self-infliction per PARAGRAPH, which
   over-matches on a long single-line bullet: a deferral phrase about file A and an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,30 @@ All notable changes to the Datarim framework are documented here. Format follows
 
 ### Fixed
 
+
+- **TUNE-0566 closure-gate `\E` false block.** `dev-tools/closure-gate.sh` verified
+  landed lines with `git grep -F`, which implements fixed-string matching by
+  wrapping the pattern in `\Q...\E` — so any pattern containing a literal `\E`
+  ended the quoting early and the remainder was parsed as a regex. Every
+  `\Exception` / `\ErrorException` reference in a PHP repo was therefore
+  invisible to gate 0.13, producing a false "work is not on main" archive block
+  (observed at `/dr-archive DEV-1762`: 4 of 4 flagged lines contained
+  `\Exception`, all of them demonstrably on `main`). The check now reads each
+  blob and pipes it to GNU `grep -F`, which has no such escape layer. Verification
+  is two-pass to keep it fast: per-path first, then ONE batched `grep -F -f` scan
+  of the base tree for the leftovers — a per-line repo-wide scan is
+  O(lines x files) subprocesses and pushed a 60-line / 1161-file case past two
+  minutes (now ~15s). Substring semantics and the rename fallback are unchanged.
+
+- **TUNE-0567 deferral-prose line-scoped false positive.**
+  `dev-tools/check-deferral-prose.sh` judged self-infliction per PARAGRAPH, which
+  over-matches on a long single-line bullet: a deferral phrase about file A and an
+  unrelated mention of touched file B share a "paragraph" only because they share
+  a line. Co-occurrence is now narrowed to the SENTENCE when — and only when —
+  both tokens appear on the same line; a basename in the same sentence, on another
+  line of the paragraph, or in a line with no sentence punctuation still blocks
+  exactly as before (fail-open to the paragraph verdict). Sentence boundaries are
+  `. `, `; `, `! `, `? `, so filenames and version numbers stay intact.
 - **v2.64.0 release completed.** The v2.64.0 cut merged without its annotated
   tag, so no release pipeline ran; the tag was created on the release commit
   and the signed release (tarball + SBOM + cosign bundles + provenance) is now

--- a/commands/dr-quick.md
+++ b/commands/dr-quick.md
@@ -56,7 +56,15 @@ The framework ships the PreToolUse guard (`dev-tools/datarim-exec-guard.sh`) tha
 ## Stage Header (mandatory)
 
 After Step 2's probe completes and the task ID is known, emit `**{TASK-ID} · {title}**` as the first line of the post-Step-2 message block, per `$HOME/.claude/skills/cta-format/SKILL.md` § Stage Header. Do NOT emit the header before the ID is known (before the probe completes). Single occurrence per command invocation.
-3. Append a thin one-liner task line to `tasks.md` and mirror it into `activeContext.md` § Active Tasks. Short English title. `status in_progress`, `priority P3`, `complexity L1` by convention (the fast-lane is for L1-sized work; if the work turns out larger, STOP and recommend `/dr-init` for the full pipeline).
+3. Append a thin one-liner task line to `tasks.md` and mirror it into `activeContext.md` § Active Tasks. Short English title. By convention the fast-lane uses status `in_progress`, priority `P3`, complexity `L1` (it is for L1-sized work; if the work turns out larger, STOP and recommend `/dr-init` for the full pipeline). Emit the bare VALUES in their positional slots — writing the field NAMES into the line (`· status in_progress · priority P3 · complexity L1 ·`) does not match `ONELINER_RE` and fails the doctor:
+
+<!-- gate:history-allowed -->
+```
+- QCK-0000 · in_progress · P3 · L1 · Short English title → tasks/QCK-0000-task-description.md
+```
+<!-- /gate:history-allowed -->
+
+   A completed task does NOT stay in `tasks.md`: when the QCK archives, REMOVE its row (and its `activeContext.md` mirror). `ONELINER_RE` has no `done` status precisely because the single source of truth for completion history is `documentation/archive/`.
 4. Quick KB scan for context: spawn ONE subagent via the Agent tool, using the runtime's CHEAPEST / WEAKEST reasoning tier (vendor-neutral — each runtime resolves its own cheap tier). The subagent does a fast, shallow read of the knowledge base / codebase to locate where the change belongs (or to find what was asked). It returns only the relevant files/context, not a full analysis. This keeps the main (strong) context free and avoids the multi-hour full-analysis path.
 5. Apply the fix (for a fix task) or report the located item (for a search task). The actual edit runs in the main context.
 6. **CLOSURE REACHABILITY GATE** (MANDATORY before Step 7, for every git repository this QCK changed; skip only for a READ-ONLY QCK, which touches no repository). The fast-lane skips PRD, plan, QA and compliance — it does NOT skip the check that the work exists where consumers can reach it. A QCK that edits files on a branch, writes its archive and flips `done` while the branch never lands produces exactly the defect the slow lane's `/dr-archive` Step 0.13 exists to prevent, and produces it faster.

--- a/dev-tools/check-deferral-prose.sh
+++ b/dev-tools/check-deferral-prose.sh
@@ -206,6 +206,23 @@ FENCE_MARKER="$(printf '\140\140\140')"
 candidates="$(
     awk -v PHRASES="$PHRASES" -v BN_FILE="$BN_FILE" -v FENCE="$FENCE_MARKER" '
     function lc(s) { return tolower(s) }
+    # True when `a` and `b` occur within the same sentence of line `s`.
+    # Sentences are split on `. `, `; `, `! ` and `? `. A bare `.` is NOT a
+    # boundary, so filenames ("error.php") and version numbers stay intact.
+    # Fail-OPEN: when either token is absent, or the line has no boundary at
+    # all, report same-sentence so the caller keeps the paragraph verdict.
+    function same_sentence(s, a, b,   n, parts, i, seen_a, seen_b) {
+        if (index(s, a) == 0 || index(s, b) == 0) return 1
+        gsub(/[.;!?][ \t]+/, "\001", s)
+        n = split(s, parts, "\001")
+        if (n <= 1) return 1
+        for (i = 1; i <= n; i++) {
+            seen_a = (index(parts[i], a) > 0)
+            seen_b = (index(parts[i], b) > 0)
+            if (seen_a && seen_b) return 1
+        }
+        return 0
+    }
     BEGIN {
         np = 0
         while ((getline line < PHRASES) > 0) {
@@ -275,6 +292,19 @@ candidates="$(
             }
         }
         # Emit one candidate per LINE that contains a deferral phrase.
+        #
+        # Self-infliction is normally judged per PARAGRAPH. That over-matches on
+        # a long single-line bullet, where a deferral phrase about file A and an
+        # unrelated mention of touched file B share one "paragraph" only because
+        # they share one line (observed in /dr-archive DEV-1762: "pre-existing"
+        # described tests/e2e/dev-1590.spec.ts while error.php was named later in
+        # the same line for an unrelated reason).
+        #
+        # So when the phrase and the touched basename are provably in DIFFERENT
+        # sentences of the same line, prefer the sentence-scoped verdict. This
+        # only ever narrows a hit that the paragraph pass already made; a
+        # basename in the same sentence, on another line of the paragraph, or in
+        # a file with no sentence punctuation still blocks exactly as before.
         for (i = 1; i <= total; i++) {
             if (para[i] == 0) continue
             if (quoted[i]) continue   # quoted phrase != self-deferral claim
@@ -282,7 +312,13 @@ candidates="$(
             for (k = 1; k <= np; k++) {
                 if (index(l, phrases[k]) > 0) {
                     p = para[i]
-                    printf("%d\t%s\t%s\t%s\n", i, phrases[k], pbase[p], partid[p])
+                    ebase = pbase[p]
+                    if (ebase != "-" && index(l, lc(ebase)) > 0) {
+                        # both the phrase and the basename occur on THIS line —
+                        # the only case where sentence scoping can be decided.
+                        if (!same_sentence(l, phrases[k], lc(ebase))) ebase = "-"
+                    }
+                    printf("%d\t%s\t%s\t%s\n", i, phrases[k], ebase, partid[p])
                     break
                 }
             }

--- a/dev-tools/closure-gate.sh
+++ b/dev-tools/closure-gate.sh
@@ -158,14 +158,65 @@ done < <(git -C "$ROOT" diff --diff-filter=M --name-only "$MB..$BRANCH" 2>/dev/n
 
 TOTAL_CAND="$(wc -l < "$CANDIDATES" | tr -d ' ')"
 CHECKED=0
+
+# `git grep -F` is NOT a safe fixed-string search: it implements -F by wrapping
+# the pattern in \Q...\E, so a pattern containing a literal \E terminates the
+# quoting early and the remainder is parsed as a regex. Any line mentioning
+# e.g. `yii\base\Exception` or `\ErrorException` therefore silently MISSES and
+# the gate falsely reports landed work as absent from the base. Reproduction:
+#   git grep -qF 'yii\base\Exception' <rev>   -> no match
+#   git show <rev>:<path> | grep -qF '...'    -> match
+# GNU grep -F has no such escape layer, so read the blob and pipe it instead.
+#
+# Pass A checks each candidate against its OWN path in the base — one `git show`
+# per distinct path, which covers the overwhelmingly common case.
+# Pass B takes only the leftovers and makes ONE streaming scan of the whole base
+# tree with `grep -F -f`, so a line that landed under a rename or in a different
+# file is still found (the behaviour `git grep` used to provide). Batching
+# matters: a per-line repo-wide scan is O(lines x files) subprocesses and pushed
+# a 60-line / 1161-file worst case past two minutes.
+PASS_A_LEFTOVERS="$(mktemp)"
+BASE_FILE_CACHE="$(mktemp)"
+trap 'rm -f "$BASE_BLOBS" "$BASE_NAMES" "$BASE_BASENAMES" "$CANDIDATES" "$PASS_A_LEFTOVERS" "$BASE_FILE_CACHE"' EXIT
+
+CUR_PATH=""
 while IFS=$'\t' read -r path line; do
   [ -n "$line" ] || continue
   if [ "$CHECKED" -ge "$MAX_LINES" ]; then break; fi
   CHECKED=$((CHECKED + 1))
-  if ! git -C "$ROOT" grep -qF -- "$line" "$BASE" 2>/dev/null; then
-    MISSING_LINES+=("$path	$line")
+  # candidates are sorted by line, not path, so cache the last blob read
+  if [ "$path" != "$CUR_PATH" ]; then
+    CUR_PATH="$path"
+    git -C "$ROOT" show "$BASE:$path" > "$BASE_FILE_CACHE" 2>/dev/null || : > "$BASE_FILE_CACHE"
+  fi
+  if ! grep -qF -- "$line" "$BASE_FILE_CACHE"; then
+    printf '%s\t%s\n' "$path" "$line" >> "$PASS_A_LEFTOVERS"
   fi
 done < "$CANDIDATES"
+
+if [ -s "$PASS_A_LEFTOVERS" ]; then
+  # One scan of the entire base tree for every leftover line at once.
+  LEFTOVER_PATTERNS="$(mktemp)"
+  BASE_CONTENT="$(mktemp)"
+  FOUND_PATTERNS="$(mktemp)"
+  trap 'rm -f "$BASE_BLOBS" "$BASE_NAMES" "$BASE_BASENAMES" "$CANDIDATES" "$PASS_A_LEFTOVERS" "$BASE_FILE_CACHE" "$LEFTOVER_PATTERNS" "$BASE_CONTENT" "$FOUND_PATTERNS"' EXIT
+
+  cut -f2- < "$PASS_A_LEFTOVERS" | sort -u > "$LEFTOVER_PATTERNS"
+  while IFS= read -r _p; do
+    [ -n "$_p" ] || continue
+    git -C "$ROOT" show "$BASE:$_p" 2>/dev/null || true
+  done < "$BASE_NAMES" > "$BASE_CONTENT"
+
+  # keep only the patterns that DO occur somewhere in the base
+  grep -oF -f "$LEFTOVER_PATTERNS" "$BASE_CONTENT" 2>/dev/null | sort -u > "$FOUND_PATTERNS" || : > "$FOUND_PATTERNS"
+
+  while IFS=$'\t' read -r path line; do
+    [ -n "$line" ] || continue
+    if ! grep -qxF -- "$line" "$FOUND_PATTERNS"; then
+      MISSING_LINES+=("$path	$line")
+    fi
+  done < "$PASS_A_LEFTOVERS"
+fi
 
 # ---------------------------------------------------------------------------
 # 3. The ledger must carry a ROW for the task id — anchored at the start of the

--- a/dev-tools/tests/closure-gate.bats
+++ b/dev-tools/tests/closure-gate.bats
@@ -311,3 +311,68 @@ write_ledger() {
   [ "$status" -eq 0 ]
   [[ "$output" == *"row check skipped"* ]]
 }
+
+# ---------------------------------------------------------------------------
+# `\E` in a landed line (DEV-1770 shape)
+#
+# `git grep -F` implements fixed-string matching by wrapping the pattern in
+# \Q...\E, so a literal \E in the pattern ends the quoting and the remainder is
+# parsed as a regex. Every `\Exception` / `\ErrorException` reference in a PHP
+# repo therefore MISSED, and the gate falsely blocked an archive whose work was
+# demonstrably on main (observed in /dr-archive DEV-1762: 4 of 4 flagged lines
+# contained `\Exception`).
+#
+# These scenarios use the SQUASH-merge shape on purpose: the branch must stay
+# unmerged, otherwise the merge-base advances to the branch tip, the modify
+# diff is empty, and the line check never runs at all.
+# ---------------------------------------------------------------------------
+
+# seed a PHP file on main, then squash-land `landed` content onto main while
+# leaving `feat` unmerged.
+seed_php() {
+  git -C "$REPO" checkout -q main
+  printf '<?php\nuse yii\\web\\HttpException;\n' > "$REPO/error.php"
+  git -C "$REPO" add -A
+  git -C "$REPO" commit -qm "base error view"
+  git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+
+  git -C "$REPO" checkout -qb feat
+  printf 'echo $e instanceof \\yii\\base\\Exception ? 1 : 0;\n' >> "$REPO/error.php"
+  git -C "$REPO" commit -qam "feat: guard non-HTTP exceptions"
+  git -C "$REPO" checkout -q main
+}
+
+@test "backslash-E: a squash-landed line containing \\Exception is found on main" {
+  seed_php
+  printf '<?php\nuse yii\\web\\HttpException;\necho $e instanceof \\yii\\base\\Exception ? 1 : 0;\n' > "$REPO/error.php"
+  git -C "$REPO" commit -qam "squash land"
+  git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+
+  run "$GATE" --root "$REPO" --branch feat
+  [ "$status" -eq 0 ]
+}
+
+@test "backslash-E: a line containing \\Exception that is genuinely ABSENT still fails" {
+  # mutation check — the fix must not turn the gate into a rubber stamp
+  seed_php
+  printf 'unrelated\n' >> "$REPO/base.txt"
+  git -C "$REPO" commit -qam "main advances without the work"
+  git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+
+  run "$GATE" --root "$REPO" --branch feat
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"error.php"* ]]
+}
+
+@test "backslash-E: a line that squash-landed under a DIFFERENT path is still found" {
+  # the path-scoped fast path must fall back to a repo-wide scan
+  seed_php
+  printf '<?php\nuse yii\\web\\HttpException;\necho $e instanceof \\yii\\base\\Exception ? 1 : 0;\n' > "$REPO/views-error.php"
+  rm -f "$REPO/error.php"
+  git -C "$REPO" add -A
+  git -C "$REPO" commit -qm "land under a renamed path"
+  git -C "$REPO" update-ref refs/remotes/origin/main HEAD
+
+  run "$GATE" --root "$REPO" --branch feat
+  [ "$status" -eq 0 ]
+}

--- a/tests/check-deferral-prose.bats
+++ b/tests/check-deferral-prose.bats
@@ -271,3 +271,51 @@ EOF
     [ "$status" -eq 2 ]
     [[ "$output" == *"control"* || "$output" == *"ERROR"* ]]
 }
+
+# ---------- sentence-scoped co-occurrence (DEV-1770 second finding) ----------
+#
+# Self-infliction is judged per paragraph, which over-matches on a long
+# single-line bullet: a deferral phrase about file A and an unrelated mention
+# of touched file B share a "paragraph" only because they share a line.
+# Observed at /dr-archive DEV-1762. Narrowing to the sentence must NOT weaken
+# the same-sentence block.
+
+@test "PASS: deferral phrase and touched file are in DIFFERENT sentences of one line" {
+    cat > "$REPORT" <<'EOF'
+## Layer 3b
+The 4 failures in tests/e2e/dev-1590.spec.ts are pre-existing baseline noise. Separately, spaces/aether/runbook.md was updated and verified live.
+EOF
+    run "$SCRIPT" --file "$REPORT" --touched-files "$TOUCHED"
+    [ "$status" -eq 0 ]
+}
+
+@test "BLOCK: deferral phrase and touched file in the SAME sentence still blocks" {
+    cat > "$REPORT" <<'EOF'
+## Layer 3b
+The stale counter in spaces/aether/runbook.md is pre-existing and out of scope. Separately, an unrelated topic follows here.
+EOF
+    run "$SCRIPT" --file "$REPORT" --touched-files "$TOUCHED"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"runbook.md"* ]]
+}
+
+@test "BLOCK: touched file on a DIFFERENT line of the same paragraph still blocks" {
+    # sentence scoping only applies when both tokens share a line; the
+    # paragraph verdict must survive untouched otherwise
+    cat > "$REPORT" <<'EOF'
+## Layer 3b
+The change is out of scope for this cycle.
+It concerns spaces/aether/runbook.md and will not be finished here.
+EOF
+    run "$SCRIPT" --file "$REPORT" --touched-files "$TOUCHED"
+    [ "$status" -eq 1 ]
+}
+
+@test "BLOCK: a line with no sentence punctuation fails OPEN to the paragraph verdict" {
+    cat > "$REPORT" <<'EOF'
+## Layer 3b
+spaces/aether/runbook.md counter is pre-existing and out of scope for now
+EOF
+    run "$SCRIPT" --file "$REPORT" --touched-files "$TOUCHED"
+    [ "$status" -eq 1 ]
+}


### PR DESCRIPTION
Three gate/command defects found while archiving a downstream task in a consumer
workspace. All three produced false results rather than loud failures, which is
why they survived: two silently blocked a correct archive, one silently wrote a
malformed ledger row.

## TUNE-0566 — `closure-gate.sh` misses any pattern containing a literal `\E`

Gate 0.13 verified landed lines with `git grep -F`. `git grep` implements
fixed-string matching by wrapping the pattern in `\Q...\E`, so an embedded
literal `\E` terminates the quoting and the remainder is parsed as a regex.

```
git grep -qF 'yii\web\HttpException' <rev> -- error.php   -> FOUND   (no \E)
git grep -qF 'yii\base\Exception'    <rev> -- error.php   -> MISS    (has \E)
git show <rev>:error.php | grep -cF 'yii\base\Exception'  -> 1       (control)
```

Impact is every PHP repository: each `\Exception` / `\ErrorException` reference
is invisible to the gate, producing a false "work is not on main" archive block.
Observed downstream where 4 of 4 flagged lines contained `\Exception` and all
four were demonstrably on `main`.

Fixed by reading the blob and piping to GNU `grep -F`, which has no such escape
layer. Verification is two-pass so correctness is not traded for latency: pass A
checks each candidate against its own path, pass B makes ONE batched
`grep -F -f` scan of the base tree for the leftovers. A naive per-line
repo-wide fallback is O(lines x files) subprocesses — a 60-line / 1161-file
worst case ran past 120s; batched it is ~15s. Substring semantics and the
rename fallback are preserved (both covered by tests).

## TUNE-0567 — `check-deferral-prose.sh` false positive on long single-line bullets

Self-infliction was judged per PARAGRAPH. On a long single-line bullet a
deferral phrase about file A and an unrelated mention of touched file B share a
"paragraph" only because they share a line, so the gate blocked a report whose
deferral was about something else entirely.

Co-occurrence is now narrowed to the SENTENCE, and only when both tokens appear
on the same line — the one case where sentence scoping is decidable. A basename
in the same sentence, on a different line of the paragraph, or in a line with no
sentence punctuation all block exactly as before (fail-open to the paragraph
verdict). Boundaries are `. `, `; `, `! `, `? `, so filenames and version
numbers stay intact.

This one narrows a safety gate, so it is deliberately conservative: the three
BLOCK tests added alongside it pass against BOTH the old and new script, which
is the evidence that the safety property does not depend on this change.

## TUNE-0568 — `/dr-quick` wrote a malformed `tasks.md` row

Step 3 named the field values as prose ("`status in_progress`, `priority P3`,
`complexity L1` by convention") without showing the line it wanted, so agents
interpolated the field NAMES into the row:

```
- QCK-0095 · status done · priority P3 · complexity L1 → ...
```

That does not match `ONELINER_RE`, so every fast-lane row written this way was
non-compliant. One consumer workspace carried 33 of them — all completed tasks
which, separately, had never been removed from the active index at all.

Step 3 now shows the exact emitted shape and states that a completed task's row
is REMOVED at archive time (`ONELINER_RE` has no `done` status precisely because
completion history lives in `documentation/archive/`).

## Verification

- `closure-gate.bats` 21/21, `check-deferral-prose.bats` 22/22.
- **Mutation-checked in both directions.** Each new PASS test fails against the
  pre-fix script and passes after; each BLOCK test passes against both. Without
  this, tests asserting an *absence* of a false positive would have been green
  from the start and proved nothing — my first draft of the closure-gate tests
  was green against the buggy code because the merge-base advanced to the branch
  tip and the line check never ran. Rewritten to the squash-merge shape, which
  is the shape the original defect appeared in.
- The documented `/dr-quick` example was asserted against `ONELINER_RE` itself:
  the new shape matches, the legacy shape is rejected.
- `shellcheck` clean on both scripts; `check-body-english.sh`,
  `check-doc-refs.sh`, and `task-id-gate.sh` all pass.
- Full `bats tests/` run: 9 failures, all pre-existing — reproduced on a
  pristine tree with these changes stashed, and none are in the touched files.
