### PR TITLE
fix(visual-maps): sync the derived command diagram with its YAML source

### DIFF
--- a/skills/visual-maps/command-dependencies.md
+++ b/skills/visual-maps/command-dependencies.md
@@ -28,6 +28,27 @@ graph LR
     dr-compliance -.->|"return-to-source<br>(v2.60.0+)"| dr-qa
 ```
 
+## Task-Spec Entry
+
+`dr-wizard` is an optional staged alternative to answering the discovery
+interview inline; it feeds the requirements stage.
+
+```mermaid
+graph LR
+    dr-wizard --> dr-prd
+```
+
+## Session Handoff
+
+`dr-save` captures the session before the context window is destroyed;
+`dr-continue` replays that artefact in a clean window and routes onward.
+
+```mermaid
+graph LR
+    dr-save --> dr-continue
+    dr-continue --> dr-next
+```
+
 ## Optional at Complexity Levels
 
 | Command | Optional at |
@@ -38,6 +59,7 @@ graph LR
 | `dr-qa` | L1, L2 |
 | `dr-compliance` | L1, L2 |
 | `dr-edit` | L1 |
+| `dr-wizard` | L1, L2 |
 
 ## Entry-Point Commands (no prerequisites)
 
@@ -55,6 +77,11 @@ These commands may be invoked at any time without a prior pipeline stage:
 | `dr-plugin` | extension | Manage plugin system |
 | `dr-orchestrate` | plugin | Self-driving pipeline runner (plugin) |
 | `dr-verify` | quality | Standalone tri-layer verification |
+| `dr-wizard` | requirements | Interactive task-spec wizard (feeds `dr-prd`) |
+| `dr-save` | utility | Capture the session before the context window is destroyed |
+| `dr-continue` | utility | Replay a session artefact in a clean context window |
+| `factcheck` | standalone | Fact-check articles and posts before publication |
+| `humanize` | standalone | Remove AI writing patterns from text |
 
 ## Content Pipeline
 

--- a/tests/command-graph.bats
+++ b/tests/command-graph.bats
@@ -49,3 +49,23 @@ print('ok: all core pipeline commands present')
     [ "$status" -eq 0 ]
     [ "$output" -ge 1 ]
 }
+
+# The Mermaid file is a DERIVED artefact; the YAML is the source of truth.
+# Without this test the pair drifts silently: dr-continue, dr-save and
+# dr-wizard were declared in the YAML with real edges and appeared nowhere in
+# the diagram, while the suite stayed green because the only diagram assertion
+# was a single hardcoded edge.
+@test "every command in command-graph.yaml appears in command-dependencies.md" {
+    run python3 -c "
+import re, yaml
+with open('$GRAPH') as f:
+    cmds = set(yaml.safe_load(f)['commands'])
+text = open('$MERMAID').read()
+# Not every command is dr-prefixed: the standalone content utilities
+# (factcheck, humanize) carry no prefix, so match each declared name.
+missing = sorted(c for c in cmds if not re.search(r'\b' + re.escape(c) + r'\b', text))
+assert not missing, 'declared in command-graph.yaml but absent from the diagram: ' + ', '.join(missing)
+print(f'ok: all {len(cmds)} graph commands present in the derived diagram')
+"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Problem

`dev-tools/command-graph.yaml` declares **28** commands. The derived Mermaid artefact rendered **24**.

Missing entirely — along with their declared edges:

| Command | Declared edges | Shown |
|---|---|---|
| `dr-save` | `precedes: [dr-continue]` | no |
| `dr-continue` | `requires: [dr-save]`, `precedes: [dr-next]` | no |
| `dr-wizard` | `precedes: [dr-prd]`, `optional_at: [L1, L2]` | no |
| `factcheck` / `humanize` | standalone entry points | no |

The file header says *"keep in sync with command-graph.yaml"*, but nothing enforced it.

## Root cause

The only assertion covering the diagram was:

```bash
run grep -c 'dr-do --> dr-qa' "$MERMAID"
```

One hardcoded edge. **No missing command can ever fail that check**, so the suite stayed green through the whole drift.

## Fix

- Diagram gains a *Task-Spec Entry* and a *Session Handoff* section carrying the real declared edges; the entry-point table gains `dr-wizard`, `dr-save`, `dr-continue`, `factcheck`, `humanize`; `dr-wizard` added to optional-at levels.
- New test walks **every** command in the YAML and asserts it appears in the derived file.

Note: the check matches each declared name rather than a `dr-`-prefixed pattern — `factcheck` and `humanize` carry no prefix, and a prefix-anchored regex silently skipped them (caught during authoring).

## Controls

| Control | Result |
|---|---|
| Pre-fix diagram | `dr-continue, dr-save, dr-wizard, humanize` → **fails** |
| After fix | 5/5 `ok` |

Gates on touched files: `task-id-gate` PASS, `stack-agnostic-gate` PASS, `check-body-english --scope skills` PASS (147 files).