### PR TITLE
fix(tune-0577): land the parked release-gate and publishing work

### DIFF
--- a/dev-tools/release-gate.sh
+++ b/dev-tools/release-gate.sh
@@ -90,7 +90,9 @@ write_audit() {
         printf -- '  registry: %s\n' "$registry"
         printf -- '  bump_level: %s\n' "$bump"
         printf -- '  gates_passed: %s\n' "$gates"
-        printf -- '  rationale: %s\n' "$rationale"
+        # Quote the rationale: it can contain a colon (range "vX..HEAD: ...") which
+        # breaks unquoted YAML. Escape any embedded double-quote for safety.
+        printf -- '  rationale: "%s"\n' "${rationale//\"/\\\"}"
         printf -- '  timestamp: %s\n' "$ts"
     } > "$file"
     echo "$file"
@@ -148,9 +150,12 @@ main() {
     # Side-effect crossing. Write the audit record, then create the ANNOTATED tag
     # carrying the classifier stamp, then push. Defensive invariant below binds
     # exit code to the tag actually existing.
-    local stamp audit_file
+    local stamp audit_file rationale_line
     stamp="$("$SCRIPT_DIR/release-classify.sh" --repo "$repo" --api-diff auto --stamp)"
-    audit_file="$(write_audit "${GATE_AUDIT_DIR:-$repo/documentation/release-audit}" "$version" "$bump" "$registry" "$gates" "$verdict")"
+    # Single-line rationale for the audit record (the full verdict is multi-line
+    # key=value and would break the record's YAML).
+    rationale_line="$(printf '%s\n' "$verdict" | sed -n 's/^rationale=//p' | head -1)"
+    audit_file="$(write_audit "${GATE_AUDIT_DIR:-$repo/documentation/release-audit}" "$version" "$bump" "$registry" "$gates" "$rationale_line")"
     git -C "$repo" tag -a "v${version}" -m "$(printf 'release %s\n\n%s' "$version" "$stamp")"
 
     # Defensive invariant: the tag MUST exist now (CLAUDE.md § Defensive Invariants).

--- a/skills/publishing/SKILL.md
+++ b/skills/publishing/SKILL.md
@@ -601,6 +601,27 @@ Required for proper link previews on all social platforms:
 
 ---
 
+## Per-platform language and Telegram cross-link
+
+- **Language is per-platform, not one language for all.** Russian-audience platforms (Telegram, Facebook, VKontakte) publish in **Russian**; international platforms (**LinkedIn, X/Twitter**) publish in **English**. Posting the wrong language costs a delete+repost cycle.
+- **Every post links back to Telegram in its first comment** (drives traffic to the channel from each platform). Add the canonical Telegram post URL to the first comment of every platform except Telegram itself. On English platforms, tag the language so readers know the linked content is Russian: `Telegram (in Russian): <url>`. On Russian platforms: `Telegram: <url>`.
+- **Image is mandatory** in every social post (a text-only post is a defect). Verify the image is attached BOTH before submit (composer snapshot) AND after (open the published post).
+- **First line = headline, separated by a blank line from the body** on Facebook and LinkedIn. The feed shows only the first line (rest folded under "see more"), so a run-on first line reads as no headline. Always `<headline>\n\n<body>`.
+
+## Browser-composer mechanics (when no API exists)
+
+When publishing via browser automation (Playwright) rather than an official API, the composers of FB / X / LinkedIn are fragile and mutate often. Hard-won mechanics:
+
+- **Use real `locator.click()`, not `element.click()` inside `page.evaluate`** — React composers (FB, LinkedIn) ignore synthetic DOM clicks; only emulated mouse events fire their handlers.
+- **Facebook clears the editor when an image is attached** (React re-render): attach the image FIRST, wait, THEN type the text.
+- **Facebook treats Enter / `\n` as submit.** For multi-line comments/posts, type each line then `Shift+Enter` between lines, and a final `Enter` to send — otherwise it submits on the first newline and only the first line is saved.
+- **Changing a comment's text = delete + add, not edit** on Facebook (the edit contenteditable collapses to the first line and rejects programmatic input). LinkedIn comment-edit works but needs scroll-to-load + the `View more options for <Name>'s comment` menu label + the `Save changes` button.
+- **Publish confirmation is the network response, not the DOM.** Wait for the GraphQL response (`page.waitForResponse`): FB `/api/graphql/` 200; X `CreateTweet` 200. The DOM caches and lies.
+- **Comment publish can take up to ~10 s** (a "publishing" indicator shows) — wait ≥12 s before verifying.
+- **Read before delete:** open and identify a post/comment by its content before deleting — never delete blindly by URL or feed position (a wrong-target delete on a public profile is irreversible).
+
+> Full selector tables and the per-platform recipes live in the operator's knowledge base; the universal-publisher product (Publisher / PUB) owns the durable implementation of these rules.
+
 ## Multi-Platform Workflow
 
 ### Adapting One Post for Multiple Platforms

--- a/tests/release-gate.bats
+++ b/tests/release-gate.bats
@@ -31,7 +31,9 @@ setup() {
     export GATE_QA_VERDICT=ALL_PASS        # G2
     export GATE_VERSION_PUBLISHED=false    # G5
     export GATE_SMOKE_STATUS=success       # G7
-    AUDIT_DIR="$REPO/docs/release-audit"
+    # Mirror the shipped default (documentation/release-audit) so the fixture
+    # cannot drift from the path release-gate.sh actually writes to.
+    AUDIT_DIR="$REPO/documentation/release-audit"
     export GATE_AUDIT_DIR="$AUDIT_DIR"
 }
 
@@ -48,6 +50,22 @@ _set_manifest_version() { echo "$1" > "$REPO/VERSION"; }
     [ -d "$AUDIT_DIR" ]
     run grep -rl "0.6.4" "$AUDIT_DIR"
     [ "$status" -eq 0 ]
+}
+
+@test "audit record is valid parseable YAML (single-line quoted rationale)" {
+    _run_gate 0.6.4
+    [ "$status" -eq 0 ]
+    # rationale must be exactly one line (no multi-line verdict spill).
+    run bash -c "grep -c '^  rationale:' '$AUDIT_DIR/release-0.6.4.md'"
+    [ "$output" = "1" ]
+    run bash -c "grep -cE '^(api_diff|zero_x|escalate)=' '$AUDIT_DIR/release-0.6.4.md'"
+    [ "$output" = "0" ]
+    # The record must parse as YAML even though the rationale contains a colon.
+    if command -v python3 >/dev/null 2>&1; then
+        run python3 -c "import yaml,sys; yaml.safe_load(open(sys.argv[1])); print('OK')" "$AUDIT_DIR/release-0.6.4.md"
+        [ "$status" -eq 0 ]
+        [ "$output" = "OK" ]
+    fi
 }
 
 @test "created tag is ANNOTATED (carries the stamped bump_level)" {


### PR DESCRIPTION
A stash labelled `TUNE-0351 WIP (foreign, parked by ARCA-0145 session)` held real work that never reached main. Rebased onto current main, conflict resolved, tested and gated.

### `dev-tools/release-gate.sh`
The audit record embedded the **full multi-line `key=value` verdict**, which breaks the record's YAML. It now extracts a single-line rationale first.

The conflict with main was a genuine two-sided change: main had renamed `docs/` → `documentation/`, while the parked work fixed the rationale. **Both are kept** — main's path plus the stash's fix.

### `skills/publishing/SKILL.md`
Browser-automation rules for composers with no official API: real `locator.click()` over `element.click()` inside `page.evaluate`, Facebook clearing the editor on image attach, Enter submitting, comment edit being delete+add, publish confirmed by the **network response rather than the DOM**, and read-before-delete.

### `tests/release-gate.bats`
The fixture pointed at `docs/release-audit` while the shipped default is `documentation/release-audit`. It passed either way because `GATE_AUDIT_DIR` is exported — so the stale path could have masked a real path regression. Now mirrors the shipped default.

### Verification
| Check | Result |
|---|---|
| `bats tests/release-gate.bats` | 17/17 |
| personal-id | rc=0 |
| task-id-gate (skills/commands/agents/templates) | rc=0 |
| english-only | rc=0 |
| shellcheck `release-gate.sh` | rc=0 |