### PR TITLE
docs(tune-0578): file the site-repo cleanup tasks

### DIFF
--- a/datarim/activeContext.md
+++ b/datarim/activeContext.md
@@ -1,3 +1,6 @@
 # Active Context
 
 ## Active Tasks
+- TUNE-0578 · pending · P2 · L3 · Retire every remaining branch on the datarim-club-site repo → tasks/TUNE-0578-task-description.md
+- TUNE-0579 · pending · P3 · L1 · Unblock the two stale-base PRs on the datarim-club-site repo → tasks/TUNE-0579-task-description.md
+- TUNE-0580 · pending · P3 · L1 · Return the shared site-repo working tree to a clean state → tasks/TUNE-0580-task-description.md

--- a/datarim/tasks.md
+++ b/datarim/tasks.md
@@ -1,3 +1,6 @@
 # Tasks
 
 ## Active
+- TUNE-0578 · pending · P2 · L3 · Retire every remaining branch on the datarim-club-site repo → tasks/TUNE-0578-task-description.md
+- TUNE-0579 · pending · P3 · L1 · Unblock the two stale-base PRs on the datarim-club-site repo → tasks/TUNE-0579-task-description.md
+- TUNE-0580 · pending · P3 · L1 · Return the shared site-repo working tree to a clean state → tasks/TUNE-0580-task-description.md

--- a/datarim/tasks/TUNE-0578-task-description.md
+++ b/datarim/tasks/TUNE-0578-task-description.md
@@ -1,0 +1,75 @@
+---
+id: TUNE-0578
+title: Retire every remaining branch on the datarim-club-site repo
+status: pending
+priority: P2
+complexity: L3
+type: maintenance
+project: Datarim
+started: 2026-08-09
+parent: null
+related: [TUNE-0574, TUNE-0575, TUNE-0576, TUNE-0577]
+---
+
+## Overview
+
+Retire every remaining branch on the site repo `Arcanada-one/datarim-club-site` so it ends with exactly one branch (`main`), zero open pull requests, and a clean working tree — with no work lost and no regression merged. `main` is currently healthy: 26 pages (13 × EN/RU) all HTTP 200, counters 19/28/69 matching the shipped catalogues, zero task IDs rendered, `npm audit` clean (0 vulnerabilities) on a clean `origin/main` worktree, and the deploy workflow green.
+
+Six branches remain. Each must be resolved by the decision rule below, working autonomously: decide every fork, record the reasoning in the task artefacts, and do not ask questions. One archive document must record, per branch, the outcome and the evidence.
+
+## Measured state
+
+State measured 2026-08-09; re-verify before acting. Per branch, `base = git merge-base origin/main origin/<branch>`, then each added line is checked with `git grep -Fq "$line" origin/main` to determine how many added lines are unlanded vs. already on main.
+
+| Branch | unlanded/total added lines | behind main | files |
+|---|---|---|---|
+| `fix/infra-0368-retarget-dead-runner-label` | 1/1 | 12 | `.github/workflows/verify.yml` |
+| `sec-0034/dependabot-config` (PR #12) | 9/11 | 2 | `.github/dependabot.yml` |
+| `sec-0034-dependabot-config` (no PR) | 28/30 | 2 | `.github/dependabot.yml` |
+| `sweep/TUNE-0352-about-localization` | 51/51 | 21 | `content/en.php`, `content/ru.php`, `pages/about.php` |
+| `tune-r5-site` | 8/73 | 5 | `config.php`, `content/{en,ru}.php`, `data/agents/optimizer.php`, `data/commands/dr-optimize.php`, `data/skills/context-window-self-clearing.php`, `pages/about.php`, `pages/changelog.php` |
+| `mac-handoff/2026-07-20` | 116/249 | 14 | 15 files incl. `.gitignore`, `config.php`, `content/{en,ru}.php`, several `data/**`, `pages/{about,changelog,features,docs/index}.php` |
+
+Two open PRs remain: **#12** (`sec-0034/dependabot-config`) and **#6** (`fix/infra-0368-retarget-dead-runner-label`). Both are `MERGEABLE` but report `site: FAILURE`. The failure is a stale base, not their content: their CI ran `npm audit --audit-level=high` against an old lockfile that still had `nanoid`/`postcss` high-severity advisories, while current `origin/main` audits clean. Rebase (or the `@dependabot rebase`-equivalent: push a rebased branch) should turn them green. Verify this claim before relying on it.
+
+The shared Mac clone has 15 modified files, verified byte-identical to `mac-handoff/2026-07-20`; that work is already committed to the branch and nothing is at risk. The Mac clone must not be touched — all work happens on the execution host from a fresh clone.
+
+## Acceptance Criteria
+
+- [ ] `git branch -r` on the site repo shows only `origin/main`.
+- [ ] Zero open PRs; anything deliberately not merged has a closed PR with a written reason.
+- [ ] Live site verified green after the final merge:
+  - [ ] all 26 routes (13 × EN/RU) return HTTP 200 with non-thin bodies, fetched with a real browser User-Agent (a default-UA request can return empty and read as a broken site);
+  - [ ] counters 19/28/69 still match the shipped catalogues;
+  - [ ] no task IDs render in page text.
+- [ ] `npm ci && npm test` (runs `tests/site-contract.sh`) green on each PR.
+- [ ] `npm audit --audit-level=high` clean.
+- [ ] `php -l` clean on every changed `.php`.
+- [ ] One archive document records, per branch, the outcome and the evidence.
+- [ ] No work lost and no regression merged.
+
+## Implementation Notes
+
+Decision rule per branch, applied to the evidence (the table above may be stale by the time of execution):
+
+1. **0 unlanded lines** → the work is already on main under a squash commit; delete the branch.
+2. **Unlanded lines that are real improvements** → rebase onto current `main`, run the tests and gates, open a PR, merge, then delete the branch.
+3. **Unlanded lines that would REGRESS main** → do not merge; delete the branch and record in the archive exactly what it would have removed. Precedent: `fix/content-0061-telegram-contract` was deleted because merging it would have stripped Telegram recipes main still carries (786 → 743 lines).
+4. **Genuinely ambiguous / operator-judgement content** → land what is safe and leave a precise follow-up backlog entry for the rest, rather than guessing.
+
+Branch-specific notes:
+
+- **Dependabot configs.** `sec-0034/dependabot-config` (11 lines, PR #12) and `sec-0034-dependabot-config` (30 lines, no PR) both write `.github/dependabot.yml`; they differ by 4 insertions / 23 deletions. Pick ONE on the merits (broader ecosystem coverage, correct schedule/labels, matches how the framework repo's own dependabot config is written), land it, delete the other. Do not land both — the second would overwrite the first.
+- **`mac-handoff/2026-07-20`.** 116 unlanded lines, 14 behind `main`; a July WIP snapshot, parts of which have since landed by other routes. Land only what is still a genuine improvement over current `main`, file-by-file. Two hazards: (a) it modifies `.gitignore` in a way that REMOVES `node_modules/` and `vendor/` exclusions — a regression, do not take it; (b) its framework-repo twin leaked an operator name into a public artefact — run the personal-data gate on anything you land.
+- **`sweep/TUNE-0352-about-localization`.** 51/51 unlanded, 21 behind; RU localisation of `pages/about.php`. Check whether `main`'s `about.php` has since been rewritten; if so, port the localisation rather than merging a stale page.
+- **`tune-r5-site`.** Only 8/73 unlanded; most already landed. Identify the 8 and decide.
+
+Process constraints:
+
+- Clone fresh on the execution host; do not use the shared Mac clone (it is a shared workspace with foreign uncommitted changes) and do not touch it.
+- Branch + PR workflow; rebase on `origin/main` immediately before every merge; never force-push or rebase shared `main`.
+- Push the branch — a local commit is not durability.
+- Deploy is push → main → CI only; never edit files on the server.
+- Commit as `Arcanada <dev@veritasarcana.ai>`, never under a personal identity.
+- The repo is public: no operator names, home paths, hostnames, IPs, or credentials in any artefact.
+- Beware gates that print usage and exit 0 (false PASS) and `RC=$?` after a pipe (captures the last pipeline element); confirm each gate with a positive control.

--- a/datarim/tasks/TUNE-0579-task-description.md
+++ b/datarim/tasks/TUNE-0579-task-description.md
@@ -1,0 +1,42 @@
+---
+id: TUNE-0579
+title: Unblock the two stale-base PRs on the datarim-club-site repo
+status: pending
+priority: P3
+complexity: L1
+type: maintenance
+project: Datarim
+started: 2026-08-09
+parent: null
+related: [TUNE-0578]
+---
+
+## Overview
+
+Two pull requests on Arcanada-one/datarim-club-site are MERGEABLE but show site: FAILURE. The failure comes from a stale base, not from their content: their CI ran `npm audit --audit-level=high` against an old lockfile carrying nanoid and postcss high-severity advisories. Current origin/main audits clean (0 vulnerabilities on a clean origin/main worktree), so a rebase should turn both green.
+
+- PR #6 (fix/infra-0368-retarget-dead-runner-label) retargets CI jobs off a dead runner label; contains 1 unlanded line in `.github/workflows/verify.yml`; is 12 commits behind main.
+- PR #12 (sec-0034/dependabot-config) adds `.github/dependabot.yml`; contains 9 unlanded lines of 11; is 2 commits behind main.
+
+Both PRs belong to other sessions (SEC-0034 and INFRA-0368), so this task coordinates with them: rebase and re-run CI, merge only what is unambiguously correct, and leave a comment on anything that needs its owner's judgement.
+
+TUNE-0578 also covers these two branches. If TUNE-0578 runs first and resolves them, close this task as already-done rather than duplicating the work.
+
+## Acceptance Criteria
+
+- [ ] PR #6 (fix/infra-0368-retarget-dead-runner-label) is rebased onto current origin/main.
+- [ ] PR #6 CI re-runs on the rebased branch and reports success (no site: FAILURE).
+- [ ] PR #12 (sec-0034/dependabot-config) is rebased onto current origin/main.
+- [ ] PR #12 CI re-runs on the rebased branch and reports success (no site: FAILURE).
+- [ ] Only changes that are unambiguously correct are merged; anything needing the owner's judgement has a comment left on the PR.
+- [ ] Coordination with the SEC-0034 and INFRA-0368 sessions is reflected in the PR conversation.
+- [ ] If TUNE-0578 resolved the branches first, this task is closed as already-done without duplicated work.
+
+## Implementation Notes
+
+- Root cause of the CI failure is the stale base: the PR branches' CI ran `npm audit --audit-level=high` against an old lockfile with nanoid and postcss high-severity advisories; the current origin/main worktree audits clean (0 vulnerabilities).
+- Rebase each PR onto current origin/main and re-run CI; a rebase should turn both green.
+- PR #6 is 12 commits behind main and carries 1 unlanded line in `.github/workflows/verify.yml`.
+- PR #12 is 2 commits behind main and carries 9 unlanded lines of 11, adding `.github/dependabot.yml`.
+- Coordinate with the owning sessions (SEC-0034 for PR #12, INFRA-0368 for PR #6) before merging; merge only what is unambiguously correct and leave a comment on anything requiring the owner's judgement.
+- Check TUNE-0578 status first: it also covers these two branches. If it has already resolved them, close this task as already-done.

--- a/datarim/tasks/TUNE-0580-task-description.md
+++ b/datarim/tasks/TUNE-0580-task-description.md
@@ -1,0 +1,31 @@
+---
+id: TUNE-0580
+title: Return the shared site-repo working tree to a clean state
+status: pending
+priority: P3
+complexity: L1
+type: maintenance
+project: Datarim
+started: 2026-08-09
+parent: null
+related: [TUNE-0578]
+---
+
+## Overview
+
+The shared Mac clone of the site repository (Projects/Websites/datarim.club) carries 15 modified files in its working tree. These files were verified byte-identical to the branch mac-handoff/2026-07-20, so the work is already committed to that branch and nothing is at risk.
+
+Once TUNE-0578 resolves that branch, the Mac working tree should be returned to a clean state by its owner. This task confirms the byte-identity still holds at that time, then has the tree cleaned, leaving git status empty.
+
+## Acceptance Criteria
+
+- [ ] Confirm the 15 working-tree modifications are still byte-identical to mac-handoff/2026-07-20 once TUNE-0578 resolves the branch.
+- [ ] Have the owner reset the shared working tree; do not run `git checkout --` or `git stash` on paths you did not modify.
+- [ ] `git status` on Projects/Websites/datarim.club is empty.
+
+## Implementation Notes
+
+- This is a shared multi-agent workspace. Never use `git checkout --` or `git stash` on paths you did not modify; the owner resets the tree.
+- Coordinate with TUNE-0578; the byte-identity check happens once that task resolves mac-handoff/2026-07-20.
+- The work is already committed to mac-handoff/2026-07-20, so no content is at risk; the only remaining action is returning the working tree to a clean state.
+- If TUNE-0578 is already resolved when this task starts, the check and cleanup can proceed immediately.


### PR DESCRIPTION
The framework repo now holds `main` alone. The site repo does not: six branches remain plus two open PRs. Filing that work as tasks rather than leaving it as prose.

| Task | P/L | Scope |
|---|---|---|
| **TUNE-0578** | P2 / L3 | Retire every remaining branch on `datarim-club-site` |
| **TUNE-0579** | P3 / L1 | Unblock PRs #6 and #12 (stale base, not content) |
| **TUNE-0580** | P3 / L1 | Return the shared Mac working tree to a clean state |

### TUNE-0578
Carries the per-branch measurement — unlanded/total added lines and distance behind main — and a four-way decision rule so the executor resolves by evidence rather than by title:

- **0 unlanded lines** → already on main under a squash commit → delete
- **real improvement** → rebase, test, PR, merge, delete
- **would regress main** → delete with a written reason (precedent: `fix/content-0061-telegram-contract` would have stripped Telegram recipes main still carries, 786 → 743 lines)
- **needs operator judgement** → land what is safe, file the rest

Two named hazards: the competing dependabot configs both write `.github/dependabot.yml` (landing both means the second overwrites the first), and `mac-handoff`'s `.gitignore` change *removes* the `node_modules/` and `vendor/` exclusions.

### TUNE-0579
PRs #6 and #12 are MERGEABLE but red. The failure is a **stale base** — their CI ran `npm audit --audit-level=high` against an old lockfile carrying `nanoid`/`postcss` advisories. Current `origin/main` audits clean. They belong to other sessions, so the task coordinates rather than merging unilaterally.

### TUNE-0580
The Mac clone's 15 modified files were verified **byte-identical** to `mac-handoff/2026-07-20` — the work is committed, nothing is at risk. Shared workspace, so the owner resets it; the task explicitly forbids `git checkout --`/`git stash` on foreign paths.

### Verification
Boards mirror (`tasks.md` and `activeContext.md` both 3 rows). doctor rc=0, task-id-gate rc=0, personal-id rc=0, doc-refs rc=0.