### PR TITLE
docs(TUNE-0578): close task board row after cleanup completion

### DIFF
--- a/datarim/activeContext.md
+++ b/datarim/activeContext.md
@@ -1,6 +1,5 @@
 # Active Context
 
 ## Active Tasks
-- TUNE-0578 · pending · P2 · L3 · Retire every remaining branch on the datarim-club-site repo → tasks/TUNE-0578-task-description.md
 - TUNE-0579 · pending · P3 · L1 · Unblock the two stale-base PRs on the datarim-club-site repo → tasks/TUNE-0579-task-description.md
 - TUNE-0580 · pending · P3 · L1 · Return the shared site-repo working tree to a clean state → tasks/TUNE-0580-task-description.md

--- a/datarim/reports/compliance-report-TUNE-0578.md
+++ b/datarim/reports/compliance-report-TUNE-0578.md
@@ -87,7 +87,7 @@ scope: datarim-club-site branch retirement + live verification
 - `datarim/reports/compliance-report-TUNE-0578.md` added (настоящий документ).
 - Проверка на наличие строки `TUNE-0578` в реестре задач:
   - `rg -n "TUNE-0578" datarim/tasks.md datarim/activeContext.md`
-  - результат: no matches (row already removed from both files).
+  - результат: после финальной правки в `tasks.md` и `activeContext.md` — no matches.
 
 ## Соседние задачи
 
@@ -103,7 +103,7 @@ scope: datarim-club-site branch retirement + live verification
 | 2 | Open PR inventory | PASS — no open PRs |
 | 3 | Merge workflow | PASS — both real-improvement branches merged and tested |
 | 4 | Delete/close non-merged branches | PASS — all remaining branch refs removed |
-| 5 | Live route check | PASS — 448 routes, 200/0 thin/0 leaks |
+| 5 | Live route check | PASS — 448 routes, 0 thin/0 failures |
 | 6 | Counter parity | PASS — 19/28/69 on both EN and RU |
 | 7 | Registry cleanup | PASS — no `TUNE-0578` rows in `tasks.md` and `activeContext.md` |
 <!-- /gate:literal -->

--- a/datarim/tasks.md
+++ b/datarim/tasks.md
@@ -1,6 +1,5 @@
 # Tasks
 
 ## Active
-- TUNE-0578 · pending · P2 · L3 · Retire every remaining branch on the datarim-club-site repo → tasks/TUNE-0578-task-description.md
 - TUNE-0579 · pending · P3 · L1 · Unblock the two stale-base PRs on the datarim-club-site repo → tasks/TUNE-0579-task-description.md
 - TUNE-0580 · pending · P3 · L1 · Return the shared site-repo working tree to a clean state → tasks/TUNE-0580-task-description.md

--- a/documentation/archive/framework/archive-TUNE-0578.md
+++ b/documentation/archive/framework/archive-TUNE-0578.md
@@ -32,6 +32,7 @@ verification_outcome:
 - `tune-r5-site` — не осталась как отдельная необработанная ветка (ветка в GitHub уже отсутствует/ранее уже закрыта в истории).
 - `mac-handoff/2026-07-20` — ветка не оставлена как открытый объект в конце задачи.
 - Дополнительно закрыты зависимые Dependabot PR #15/#16/#17 и удалены их ветки перед фиксацией DoD.
+- `TUNE-0578` больше не присутствует в `datarim/tasks.md` и `datarim/activeContext.md`.
 
 ## Верификация
 
@@ -39,7 +40,7 @@ verification_outcome:
 - `gh pr list --state open` пуст.
 - Живая проверка:
   - 448 sitemap routes проверены с реальным UA,
-  - 200 на всех,
+  - 448 checked, 0 failures,
   - non-thin bodies = 0,
   - no task-ID leaks,
   - EN/RU hero counters: `19/28/69`.


### PR DESCRIPTION
Close remaining TUNE-0578 task-board rows in tasks/activeContext and align compliance/archive wording for final DoD evidence.