### PR TITLE
fix(preflight): make clock observability explicit

### DIFF
--- a/dev-tools/preflight-check.sh
+++ b/dev-tools/preflight-check.sh
@@ -213,24 +213,33 @@ check_loadavg() {
 }
 
 check_time_skew() {
-    local out offset abs_offset
+    local out offset abs_offset synchronized
     out="$(chronyc tracking 2>/dev/null || true)"
-    if [[ -z "$out" ]]; then
-        append_finding "time_skew" "warning" "chrony_unavailable" "no_output" "stable"
-        return 0
-    fi
     offset="$(echo "$out" | awk '/^System time/ {print $4}')"
-    if [[ -z "$offset" ]]; then
-        append_finding "time_skew" "warning" "parse_failed" "no_match" "System time line"
+    if [[ "$offset" =~ ^-?[0-9]+([.][0-9]+)?$ ]]; then
+        abs_offset="$(awk -v o="$offset" 'BEGIN {if (o<0) o=-o; printf "%.6f", o}')"
+        if awk -v a="$abs_offset" -v t="$PREFLIGHT_TIME_SKEW_THRESHOLD_S" \
+            'BEGIN {exit !(a > t)}'; then
+            append_finding "time_skew" "warning" "offset_seconds" "$abs_offset" "$PREFLIGHT_TIME_SKEW_THRESHOLD_S"
+        else
+            append_finding "time_skew" "ok" "offset_seconds" "$abs_offset" "$PREFLIGHT_TIME_SKEW_THRESHOLD_S"
+        fi
         return 0
     fi
-    abs_offset="$(awk -v o="$offset" 'BEGIN {if (o<0) o=-o; printf "%.6f", o}')"
-    if awk -v a="$abs_offset" -v t="$PREFLIGHT_TIME_SKEW_THRESHOLD_S" \
-        'BEGIN {exit !(a > t)}'; then
-        append_finding "time_skew" "warning" "offset_seconds" "$abs_offset" "$PREFLIGHT_TIME_SKEW_THRESHOLD_S"
-    else
-        append_finding "time_skew" "ok" "offset_seconds" "$abs_offset" "$PREFLIGHT_TIME_SKEW_THRESHOLD_S"
-    fi
+
+    synchronized="$(timedatectl show --property=NTPSynchronized --value 2>/dev/null \
+        | tr '[:upper:]' '[:lower:]' | xargs || true)"
+    case "$synchronized" in
+        yes)
+            append_finding "time_skew" "ok" "ntp_synchronized" "yes" "yes"
+            ;;
+        no)
+            append_finding "time_skew" "warning" "ntp_synchronized" "no" "yes"
+            ;;
+        *)
+            append_finding "time_skew" "warning" "time_source" "unobservable" "observable"
+            ;;
+    esac
 }
 
 check_health_pre_probe() {

--- a/dev-tools/preflight-check.sh
+++ b/dev-tools/preflight-check.sh
@@ -212,34 +212,56 @@ check_loadavg() {
     fi
 }
 
+normalize_time_offset_seconds() {
+    local raw="$1" value unit factor
+    if [[ ! "$raw" =~ ^([+-]?[0-9]+([.][0-9]+)?)(ns|us|ms|s)$ ]]; then
+        return 1
+    fi
+    value="${BASH_REMATCH[1]}"
+    unit="${BASH_REMATCH[3]}"
+    case "$unit" in
+        ns) factor="0.000000001" ;;
+        us) factor="0.000001" ;;
+        ms) factor="0.001" ;;
+        s)  factor="1" ;;
+    esac
+    awk -v v="$value" -v f="$factor" \
+        'BEGIN {v*=f; if (v<0) v=-v; printf "%.6f", v}'
+}
+
+record_time_offset() {
+    local offset="$1" status="ok"
+    if awk -v a="$offset" -v t="$PREFLIGHT_TIME_SKEW_THRESHOLD_S" \
+        'BEGIN {exit !(a > t)}'; then
+        status="warning"
+    fi
+    append_finding "time_skew" "$status" "offset_seconds" "$offset" "$PREFLIGHT_TIME_SKEW_THRESHOLD_S"
+}
+
 check_time_skew() {
-    local out offset abs_offset synchronized
+    local out raw_offset offset synchronized
     out="$(chronyc tracking 2>/dev/null || true)"
-    offset="$(echo "$out" | awk '/^System time/ {print $4}')"
-    if [[ "$offset" =~ ^-?[0-9]+([.][0-9]+)?$ ]]; then
-        abs_offset="$(awk -v o="$offset" 'BEGIN {if (o<0) o=-o; printf "%.6f", o}')"
-        if awk -v a="$abs_offset" -v t="$PREFLIGHT_TIME_SKEW_THRESHOLD_S" \
-            'BEGIN {exit !(a > t)}'; then
-            append_finding "time_skew" "warning" "offset_seconds" "$abs_offset" "$PREFLIGHT_TIME_SKEW_THRESHOLD_S"
-        else
-            append_finding "time_skew" "ok" "offset_seconds" "$abs_offset" "$PREFLIGHT_TIME_SKEW_THRESHOLD_S"
-        fi
+    raw_offset="$(echo "$out" | awk '/^System time/ {print $4 "s"; exit}')"
+    if offset="$(normalize_time_offset_seconds "$raw_offset")"; then
+        record_time_offset "$offset"
         return 0
     fi
 
-    synchronized="$(timedatectl show --property=NTPSynchronized --value 2>/dev/null \
+    synchronized="$(LC_ALL=C timedatectl show --property=NTPSynchronized --value 2>/dev/null \
         | tr '[:upper:]' '[:lower:]' | xargs || true)"
-    case "$synchronized" in
-        yes)
-            append_finding "time_skew" "ok" "ntp_synchronized" "yes" "yes"
-            ;;
-        no)
-            append_finding "time_skew" "warning" "ntp_synchronized" "no" "yes"
-            ;;
-        *)
-            append_finding "time_skew" "warning" "time_source" "unobservable" "observable"
-            ;;
-    esac
+    if [[ "$synchronized" == "no" ]]; then
+        append_finding "time_skew" "warning" "ntp_synchronized" "no" "yes"
+        return 0
+    fi
+    if [[ "$synchronized" == "yes" ]]; then
+        out="$(LC_ALL=C timedatectl timesync-status --no-pager 2>/dev/null || true)"
+        raw_offset="$(echo "$out" | awk '$1 == "Offset:" {print $2; exit}')"
+        if offset="$(normalize_time_offset_seconds "$raw_offset")"; then
+            record_time_offset "$offset"
+            return 0
+        fi
+    fi
+    append_finding "time_skew" "warning" "time_sync_unobservable" "true" "false"
 }
 
 check_health_pre_probe() {

--- a/dev-tools/preflight-check.sh
+++ b/dev-tools/preflight-check.sh
@@ -226,7 +226,14 @@ normalize_time_offset_seconds() {
         s)  factor="1" ;;
     esac
     awk -v v="$value" -v f="$factor" \
-        'BEGIN {v*=f; if (v<0) v=-v; printf "%.6f", v}'
+        'BEGIN {
+            v*=f
+            if (v<0) v=-v
+            result=sprintf("%.9f", v)
+            sub(/0+$/, "", result)
+            sub(/[.]$/, "", result)
+            printf "%s", result
+        }'
 }
 
 record_time_offset() {

--- a/tests/preflight-check.bats
+++ b/tests/preflight-check.bats
@@ -284,14 +284,19 @@ EOF
     mock_cmd_fail chronyc 127
     cat > "$MOCK_BIN/timedatectl" <<'EOF'
 #!/usr/bin/env bash
-echo yes
+[[ "${LC_ALL:-}" == "C" ]] || exit 3
+case "$1" in
+    show) echo yes ;;
+    timesync-status) echo "       Offset: -613us" ;;
+    *) exit 2 ;;
+esac
 EOF
     chmod +x "$MOCK_BIN/timedatectl"
     prepend_path
     source_script
     run check_time_skew
     [ "$status" -eq 0 ]
-    ok=$(jq '[.[] | select(.name=="time_skew" and .status=="ok" and .metric=="ntp_synchronized" and .actual=="yes")] | length' "$REPORT_FILE")
+    ok=$(jq '[.[] | select(.name=="time_skew" and .status=="ok" and .metric=="offset_seconds" and .actual=="0.000613")] | length' "$REPORT_FILE")
     [ "$ok" -eq 1 ]
 }
 
@@ -319,10 +324,30 @@ EOF
     prepend_path
     source_script
     run check_time_skew
-    warning=$(jq '[.[] | select(.name=="time_skew" and .status=="warning" and .metric=="time_source" and .actual=="unobservable")] | length' "$REPORT_FILE")
+    warning=$(jq '[.[] | select(.name=="time_skew" and .status=="warning" and .metric=="time_sync_unobservable" and .actual=="true")] | length' "$REPORT_FILE")
     stable=$(jq '[.[] | select(.name=="time_skew" and .threshold=="stable")] | length' "$REPORT_FILE")
     [ "$warning" -eq 1 ]
     [ "$stable" -eq 0 ]
+}
+
+@test "T15d check_time_skew: synchronized timesyncd without parseable offset is unobservable" {
+    mock_cmd_fail chronyc 127
+    cat > "$MOCK_BIN/timedatectl" <<'EOF'
+#!/usr/bin/env bash
+case "$1" in
+    show) echo yes ;;
+    timesync-status) echo "Offset: unknown" ;;
+    *) exit 2 ;;
+esac
+EOF
+    chmod +x "$MOCK_BIN/timedatectl"
+    prepend_path
+    source_script
+    run check_time_skew
+    warning=$(jq '[.[] | select(.name=="time_skew" and .status=="warning" and .metric=="time_sync_unobservable" and .actual=="true")] | length' "$REPORT_FILE")
+    ok=$(jq '[.[] | select(.name=="time_skew" and .status=="ok")] | length' "$REPORT_FILE")
+    [ "$warning" -eq 1 ]
+    [ "$ok" -eq 0 ]
 }
 
 # ---------- check_health_pre_probe ----------

--- a/tests/preflight-check.bats
+++ b/tests/preflight-check.bats
@@ -280,6 +280,19 @@ EOF
     [ "$warn" -gt 0 ]
 }
 
+@test "T15e check_time_skew: preserves precision when offset is just above threshold" {
+    cat > "$MOCK_BIN/chronyc" <<'EOF'
+#!/usr/bin/env bash
+echo "System time     : 0.500000400 seconds fast of NTP time"
+EOF
+    chmod +x "$MOCK_BIN/chronyc"
+    prepend_path
+    source_script
+    run check_time_skew
+    warning=$(jq '[.[] | select(.name=="time_skew" and .status=="warning" and .actual=="0.5000004")] | length' "$REPORT_FILE")
+    [ "$warning" -eq 1 ]
+}
+
 @test "T15a check_time_skew: falls back to synchronized timesyncd state" {
     mock_cmd_fail chronyc 127
     cat > "$MOCK_BIN/timedatectl" <<'EOF'

--- a/tests/preflight-check.bats
+++ b/tests/preflight-check.bats
@@ -8,7 +8,7 @@
 #   T09-T10 check_docker       (ok / high reclaimable)
 #   T11-T12 check_ram          (ok / low free)
 #   T13-T14 check_loadavg      (ok / fatal)
-#   T15     check_time_skew    (warn — never blocks)
+#   T15     check_time_skew    (chrony + timesyncd fallback; never blocks)
 #   T16-T17 check_health       (ok / down)
 #   T18     append_finding     (json mutation + counters)
 #   T19     emit_ops_bot       (canonical DTO payload shape)
@@ -278,6 +278,51 @@ EOF
     warn=$(jq  '[.[] | select(.name=="time_skew" and .status=="warning")] | length' "$REPORT_FILE")
     [ "$fatal" -eq 0 ]
     [ "$warn" -gt 0 ]
+}
+
+@test "T15a check_time_skew: falls back to synchronized timesyncd state" {
+    mock_cmd_fail chronyc 127
+    cat > "$MOCK_BIN/timedatectl" <<'EOF'
+#!/usr/bin/env bash
+echo yes
+EOF
+    chmod +x "$MOCK_BIN/timedatectl"
+    prepend_path
+    source_script
+    run check_time_skew
+    [ "$status" -eq 0 ]
+    ok=$(jq '[.[] | select(.name=="time_skew" and .status=="ok" and .metric=="ntp_synchronized" and .actual=="yes")] | length' "$REPORT_FILE")
+    [ "$ok" -eq 1 ]
+}
+
+@test "T15b check_time_skew: warns when timesyncd reports unsynchronized" {
+    mock_cmd_fail chronyc 127
+    cat > "$MOCK_BIN/timedatectl" <<'EOF'
+#!/usr/bin/env bash
+echo no
+EOF
+    chmod +x "$MOCK_BIN/timedatectl"
+    prepend_path
+    source_script
+    run check_time_skew
+    warning=$(jq '[.[] | select(.name=="time_skew" and .status=="warning" and .metric=="ntp_synchronized" and .actual=="no")] | length' "$REPORT_FILE")
+    [ "$warning" -eq 1 ]
+}
+
+@test "T15c check_time_skew: reports unobservable when sources are unavailable or unparseable" {
+    mock_cmd_fail chronyc 127
+    cat > "$MOCK_BIN/timedatectl" <<'EOF'
+#!/usr/bin/env bash
+echo unknown
+EOF
+    chmod +x "$MOCK_BIN/timedatectl"
+    prepend_path
+    source_script
+    run check_time_skew
+    warning=$(jq '[.[] | select(.name=="time_skew" and .status=="warning" and .metric=="time_source" and .actual=="unobservable")] | length' "$REPORT_FILE")
+    stable=$(jq '[.[] | select(.name=="time_skew" and .threshold=="stable")] | length' "$REPORT_FILE")
+    [ "$warning" -eq 1 ]
+    [ "$stable" -eq 0 ]
 }
 
 # ---------- check_health_pre_probe ----------


### PR DESCRIPTION
## Summary
- retain chrony offset checks when parseable
- fall back to systemd NTPSynchronized state
- report unavailable or unparseable clock state as unobservable

## Verification
- bats tests/preflight-check.bats (38/38)
- shellcheck --severity=warning dev-tools/preflight-check.sh
- bash tests/run-bats-discovery.sh --check-registry
- ./validate.sh

ARCA-0194 R6-02 thin slice.