### PR TITLE
feat(preflight): expose notification outcome

### DIFF
--- a/.github/actions/preflight-check/action.yml
+++ b/.github/actions/preflight-check/action.yml
@@ -39,6 +39,10 @@ inputs:
     required: false
     default: ""
     description: Ops Bot Vault-issued API key. If empty, falls back to runner env OPSBOT_KEY. Explicit input eliminates the job-vs-step env-scope footgun.
+  ops-bot-agent:
+    required: false
+    default: preflight-check
+    description: Service-scoped agent identity included in the Ops Bot event payload.
   severity-overrides:
     required: false
     default: ""
@@ -60,6 +64,9 @@ outputs:
   failures:
     description: Number of FATAL failures
     value: ${{ steps.run.outputs.failures }}
+  notification-outcome:
+    description: disabled | not-needed | skipped-no-key | delivered | failed
+    value: ${{ steps.run.outputs.notification-outcome }}
 runs:
   using: composite
   steps:
@@ -99,6 +106,7 @@ runs:
         PREFLIGHT_EXTRA_CHECKS: ${{ inputs.extra-checks }}
         PREFLIGHT_OPS_BOT_EMIT: ${{ inputs.ops-bot-emit }}
         PREFLIGHT_OPS_BOT_URL: ${{ inputs.ops-bot-url }}
+        PREFLIGHT_OPS_BOT_AGENT: ${{ inputs.ops-bot-agent }}
         PREFLIGHT_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         OPSBOT_KEY: ${{ inputs.ops-bot-key != '' && inputs.ops-bot-key || env.OPSBOT_KEY }}
       run: |

--- a/dev-tools/preflight-check.sh
+++ b/dev-tools/preflight-check.sh
@@ -20,6 +20,7 @@ PREFLIGHT_DISK_FAIL_PERCENT="${PREFLIGHT_DISK_FAIL_PERCENT:-90}"
 PREFLIGHT_EXTRA_CHECKS="${PREFLIGHT_EXTRA_CHECKS:-}"
 PREFLIGHT_OPS_BOT_EMIT="${PREFLIGHT_OPS_BOT_EMIT:-true}"
 PREFLIGHT_OPS_BOT_URL="${PREFLIGHT_OPS_BOT_URL:-https://ops.arcanada.ai/events}"
+PREFLIGHT_OPS_BOT_AGENT="${PREFLIGHT_OPS_BOT_AGENT:-preflight-check}"
 PREFLIGHT_RUN_URL="${PREFLIGHT_RUN_URL:-unknown}"
 PREFLIGHT_DISK_PATHS="${PREFLIGHT_DISK_PATHS:-/ /var/lib/docker /srv/apps}"
 PREFLIGHT_HEALTH_URL="${PREFLIGHT_HEALTH_URL:-}"
@@ -31,6 +32,7 @@ PREFLIGHT_TIME_SKEW_THRESHOLD_S="${PREFLIGHT_TIME_SKEW_THRESHOLD_S:-0.5}"
 
 WARN_COUNT=0
 FATAL_COUNT=0
+NOTIFICATION_OUTCOME="not-needed"
 REPORT_FILE="${REPORT_FILE:-}"
 
 # === HELPERS ===
@@ -299,6 +301,7 @@ emit_ops_bot() {
     local key="${OPSBOT_KEY:-}"
     if [[ -z "$key" ]]; then
         echo "WARN: OPSBOT_KEY unset; skipping Ops Bot emit (fail-soft)" >&2
+        NOTIFICATION_OUTCOME="skipped-no-key"
         return 0
     fi
     local category dedup_bucket payload status_upper body_text
@@ -312,7 +315,7 @@ emit_ops_bot() {
     body_text="$(jq -r '.[] | "\(.name): \(.status) (\(.actual) vs \(.threshold))"' \
                  "$report" | head -10 | tr '\n' '|' )"
     payload="$(jq -cn \
-        --arg agent     "preflight-check" \
+        --arg agent     "$PREFLIGHT_OPS_BOT_AGENT" \
         --arg title     "Pre-deploy preflight: ${PREFLIGHT_SERVICE_NAME} on ${PREFLIGHT_TARGET_HOST} [${status_upper}]" \
         --arg body      "$body_text" \
         --arg category  "$category" \
@@ -336,16 +339,21 @@ emit_ops_bot() {
         --output "$resp_file" \
         --write-out '%{http_code}' 2>/dev/null || echo "000")"
     if [[ ! "$http_code" =~ ^2[0-9]{2}$ ]]; then
+        NOTIFICATION_OUTCOME="failed"
         resp_body="$(head -c 200 "$resp_file" 2>/dev/null | tr -d '\0\r' || true)"
         echo "WARN: Ops Bot emit failed (HTTP ${http_code}); body: ${resp_body:-<empty>}; not blocking deploy" >&2
+    else
+        NOTIFICATION_OUTCOME="delivered"
     fi
     rm -f "$resp_file"
+    return 0
 }
 
 # === MAIN ===
 
 preflight_main() {
     set -e
+    NOTIFICATION_OUTCOME="not-needed"
 
     : "${PREFLIGHT_TARGET_HOST:?required}"
     : "${PREFLIGHT_SERVICE_NAME:?required}"
@@ -356,6 +364,10 @@ preflight_main() {
     fi
     if [[ ! "$PREFLIGHT_SERVICE_NAME" =~ ^[a-z0-9-]+$ ]]; then
         echo "ERR: invalid service-name (must match [a-z0-9-]+): $PREFLIGHT_SERVICE_NAME" >&2
+        exit 3
+    fi
+    if [[ ! "$PREFLIGHT_OPS_BOT_AGENT" =~ ^[a-z0-9-]+$ ]]; then
+        echo "ERR: invalid ops-bot-agent (must match [a-z0-9-]+): $PREFLIGHT_OPS_BOT_AGENT" >&2
         exit 3
     fi
 
@@ -393,8 +405,14 @@ preflight_main() {
         } >> "$GITHUB_OUTPUT"
     fi
 
-    if [[ "$PREFLIGHT_OPS_BOT_EMIT" == "true" && "$status" != "ok" ]]; then
+    if [[ "$PREFLIGHT_OPS_BOT_EMIT" != "true" ]]; then
+        NOTIFICATION_OUTCOME="disabled"
+    elif [[ "$status" != "ok" ]]; then
         emit_ops_bot "$status" "$REPORT_FILE"
+    fi
+
+    if [[ -n "${GITHUB_OUTPUT:-}" ]]; then
+        echo "notification-outcome=$NOTIFICATION_OUTCOME" >> "$GITHUB_OUTPUT"
     fi
 
     [[ "$status" == "fail" ]] && exit 2

--- a/tests/preflight-check.bats
+++ b/tests/preflight-check.bats
@@ -440,6 +440,19 @@ EOF
     [ "$checks_len" -ge 1 ]
 }
 
+@test "T19c emit_ops_bot: service-scoped agent reaches canonical DTO" {
+    mock_curl
+    prepend_path
+    export OPSBOT_KEY="testkey"
+    export PREFLIGHT_OPS_BOT_AGENT="muneral"
+    source_script
+    append_finding "disk" "warning" "used_pct" "85" "80"
+    run emit_ops_bot "warn" "$REPORT_FILE"
+    payload_line=$(grep "^PAYLOAD:" "$CURL_LOG" | head -1)
+    payload="${payload_line#PAYLOAD: }"
+    [ "$(echo "$payload" | jq -r '.agent')" = "muneral" ]
+}
+
 @test "T19a emit_ops_bot: WARN logs HTTP code + body excerpt on 4xx" {
     mock_curl 401 '{"error":"invalid_api_key"}'
     prepend_path
@@ -538,9 +551,26 @@ EOF
         PREFLIGHT_OPS_BOT_EMIT=false \
         GITHUB_OUTPUT="$GITHUB_OUTPUT" \
         bash "$SCRIPT"
-    [ "$status" -eq 0 ]
-    grep -q "^status=ok$" "$GITHUB_OUTPUT"
-    grep -q "^failures=0$" "$GITHUB_OUTPUT"
+    [ "$status" -eq 0 ] &&
+        grep -q "^status=ok$" "$GITHUB_OUTPUT" &&
+        grep -q "^failures=0$" "$GITHUB_OUTPUT" &&
+        grep -q "^notification-outcome=disabled$" "$GITHUB_OUTPUT"
+}
+
+@test "T24a e2e: healthy preflight needs no notification" {
+    mock_cmd_file df "$FIX/df-ok.txt"
+    prepend_path
+    unset OPSBOT_KEY
+    run env PATH="$PATH" \
+        PREFLIGHT_TARGET_HOST=arcana-prod \
+        PREFLIGHT_SERVICE_NAME=opsbot \
+        PREFLIGHT_EXTRA_CHECKS="" \
+        PREFLIGHT_OPS_BOT_EMIT=true \
+        GITHUB_OUTPUT="$GITHUB_OUTPUT" \
+        bash "$SCRIPT"
+    [ "$status" -eq 0 ] &&
+        grep -q "^status=ok$" "$GITHUB_OUTPUT" &&
+        grep -q "^notification-outcome=not-needed$" "$GITHUB_OUTPUT"
 }
 
 @test "T25 e2e: disk-fatal exits 2, status=fail" {
@@ -578,6 +608,73 @@ EOF
     grep -q "^failures=0$" "$GITHUB_OUTPUT"
     warns=$(grep "^warnings=" "$GITHUB_OUTPUT" | cut -d= -f2)
     [ "$warns" -gt 0 ]
+}
+
+@test "T35 e2e: warn with no key exposes skipped notification independently" {
+    mock_cmd_file df "$FIX/df-warn.txt"
+    prepend_path
+    unset OPSBOT_KEY
+    run env PATH="$PATH" \
+        PREFLIGHT_TARGET_HOST=arcana-prod \
+        PREFLIGHT_SERVICE_NAME=opsbot \
+        PREFLIGHT_EXTRA_CHECKS="" \
+        PREFLIGHT_OPS_BOT_EMIT=true \
+        GITHUB_OUTPUT="$GITHUB_OUTPUT" \
+        bash "$SCRIPT"
+    [ "$status" -eq 0 ] &&
+        grep -q "^status=warn$" "$GITHUB_OUTPUT" &&
+        grep -q "^notification-outcome=skipped-no-key$" "$GITHUB_OUTPUT"
+}
+
+@test "T36 e2e: warn with HTTP 200 exposes delivered notification" {
+    mock_cmd_file df "$FIX/df-warn.txt"
+    mock_curl 200
+    prepend_path
+    run env PATH="$PATH" \
+        PREFLIGHT_TARGET_HOST=arcana-prod \
+        PREFLIGHT_SERVICE_NAME=opsbot \
+        PREFLIGHT_EXTRA_CHECKS="" \
+        PREFLIGHT_OPS_BOT_EMIT=true \
+        OPSBOT_KEY=testkey \
+        GITHUB_OUTPUT="$GITHUB_OUTPUT" \
+        bash "$SCRIPT"
+    [ "$status" -eq 0 ] &&
+        grep -q "^status=warn$" "$GITHUB_OUTPUT" &&
+        grep -q "^notification-outcome=delivered$" "$GITHUB_OUTPUT"
+}
+
+@test "T37 e2e: fatal with HTTP 500 preserves health failure and exposes notification failure" {
+    mock_cmd_file df "$FIX/df-fatal.txt"
+    mock_curl 500 '{"error":"unavailable"}'
+    prepend_path
+    run env PATH="$PATH" \
+        PREFLIGHT_TARGET_HOST=arcana-prod \
+        PREFLIGHT_SERVICE_NAME=opsbot \
+        PREFLIGHT_EXTRA_CHECKS="" \
+        PREFLIGHT_OPS_BOT_EMIT=true \
+        OPSBOT_KEY=testkey \
+        GITHUB_OUTPUT="$GITHUB_OUTPUT" \
+        bash "$SCRIPT"
+    [ "$status" -eq 2 ] &&
+        grep -q "^status=fail$" "$GITHUB_OUTPUT" &&
+        grep -q "^notification-outcome=failed$" "$GITHUB_OUTPUT"
+}
+
+@test "T38 e2e: curl network failure exposes failed notification" {
+    mock_cmd_file df "$FIX/df-warn.txt"
+    mock_cmd_fail curl 6
+    prepend_path
+    run env PATH="$PATH" \
+        PREFLIGHT_TARGET_HOST=arcana-prod \
+        PREFLIGHT_SERVICE_NAME=opsbot \
+        PREFLIGHT_EXTRA_CHECKS="" \
+        PREFLIGHT_OPS_BOT_EMIT=true \
+        OPSBOT_KEY=testkey \
+        GITHUB_OUTPUT="$GITHUB_OUTPUT" \
+        bash "$SCRIPT"
+    [ "$status" -eq 0 ] &&
+        grep -q "^status=warn$" "$GITHUB_OUTPUT" &&
+        grep -q "^notification-outcome=failed$" "$GITHUB_OUTPUT"
 }
 
 # ---------- INFRA-0201: action.yml input-validation hardening ----------
@@ -654,4 +751,27 @@ ACTION_YML="$BATS_TEST_DIRNAME/../.github/actions/preflight-check/action.yml"
     [ -f "$ACTION_YML" ]
     grep -qE '^  ops-bot-key:' "$ACTION_YML"
     grep -qE 'OPSBOT_KEY: \$\{\{ inputs\.ops-bot-key != .. && inputs\.ops-bot-key \|\| env\.OPSBOT_KEY \}\}' "$ACTION_YML"
+}
+
+@test "T31 ops-bot-agent: action declares default and run-step wiring" {
+    agent_block="$(grep -A3 -E '^  ops-bot-agent:$' "$ACTION_YML")"
+    [[ "$agent_block" == *"default: preflight-check"* ]] &&
+        grep -qE '^        PREFLIGHT_OPS_BOT_AGENT: \$\{\{ inputs\.ops-bot-agent \}\}$' "$ACTION_YML"
+}
+
+@test "T32 notification outcome: action exposes the run-step output" {
+    grep -A2 -qE '^  notification-outcome:$' "$ACTION_YML" &&
+        grep -qF 'value: ${{ steps.run.outputs.notification-outcome }}' "$ACTION_YML"
+}
+
+@test "T33 ops-bot-agent: invalid service identity exits 3 before checks" {
+    run env \
+        PREFLIGHT_TARGET_HOST=arcana-prod \
+        PREFLIGHT_SERVICE_NAME=opsbot \
+        PREFLIGHT_OPS_BOT_AGENT='Muneral;invalid' \
+        PREFLIGHT_EXTRA_CHECKS="" \
+        PREFLIGHT_OPS_BOT_EMIT=false \
+        GITHUB_OUTPUT="$GITHUB_OUTPUT" \
+        bash "$SCRIPT"
+    [ "$status" -eq 3 ] && [[ "$output" == *"invalid ops-bot-agent"* ]]
 }


### PR DESCRIPTION
## Summary
- add an optional service-scoped Ops Bot agent identity with the existing identity as the compatibility default
- expose notification delivery outcome separately from host health
- preserve fail-soft notification behavior and existing health outputs/exit codes

## Verification
- bats tests/preflight-check.bats (49/49)
- shellcheck --severity=warning dev-tools/preflight-check.sh
- bash -n dev-tools/preflight-check.sh
- ./validate.sh
- independent bounded review: no remaining findings

ARCA-0194 R6-02 Datarim-only thin slice; consumer migration and live proof remain OPEN.