### PR TITLE
feat(preflight): enforce caller contract

### DIFF
--- a/.github/actions/preflight-caller-contract/action.yml
+++ b/.github/actions/preflight-caller-contract/action.yml
@@ -1,0 +1,42 @@
+name: Preflight Caller Contract
+description: Semantically validate a registered consumer deploy workflow before secret-bearing preflight execution
+author: Arcanada-one
+inputs:
+  vault-addr:
+    required: true
+    description: Resolved non-secret repository VAULT_ADDR variable to validate.
+runs:
+  using: composite
+  steps:
+    - name: Provision pinned yq
+      shell: bash
+      env:
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        YQ_VERSION: v4.44.3
+        YQ_SHA256: a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7
+      run: |
+        set -euo pipefail
+        [ "${RUNNER_OS:-}" = Linux ] && [ "$(uname -m)" = x86_64 ] || {
+          echo "ERROR: preflight caller contract supports Linux x86_64 runners only" >&2
+          exit 1
+        }
+        yq_dir="${RUNNER_TEMP}/datarim-preflight-caller-contract"
+        mkdir -p "$yq_dir"
+        curl -fsSL --proto '=https' --tlsv1.2 --retry 3 --retry-all-errors \
+          --retry-max-time 45 --connect-timeout 10 \
+          -o "${yq_dir}/yq" \
+          "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64"
+        echo "${YQ_SHA256}  ${yq_dir}/yq" | sha256sum --check --strict
+        chmod 0755 "${yq_dir}/yq"
+    - name: Validate caller workflow contract
+      shell: bash
+      env:
+        PATH: /usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+        PREFLIGHT_CALLER_ACTION_REPOSITORY: ${{ github.action_repository }}
+        PREFLIGHT_CALLER_ACTION_REF: ${{ github.action_ref }}
+        PREFLIGHT_CALLER_GITHUB_REPOSITORY: ${{ github.repository }}
+        PREFLIGHT_CALLER_WORKFLOW_REF: ${{ github.workflow_ref }}
+        PREFLIGHT_CALLER_WORKFLOW_SHA: ${{ github.workflow_sha }}
+        PREFLIGHT_CALLER_VAULT_ADDR: ${{ inputs.vault-addr }}
+        PREFLIGHT_CALLER_YQ_BIN: ${{ runner.temp }}/datarim-preflight-caller-contract/yq
+      run: '"${{ github.action_path }}/../../../dev-tools/preflight-caller-contract.sh"'

--- a/.github/actions/preflight-caller-contract/consumers.yml
+++ b/.github/actions/preflight-caller-contract/consumers.yml
@@ -1,0 +1,7 @@
+schema-version: 1
+consumers:
+  Arcanada-one/muneral:
+    service-name: muneral
+    ops-bot-agent: muneral
+    ops-bot-key-secret-name: OPSBOT_API_KEY
+    deploy-if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/dev-tools/preflight-caller-contract.sh
+++ b/dev-tools/preflight-caller-contract.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# Fail-closed structural validation for registered preflight-check consumers.
+# The caller job is intentionally capability-free: checkout plus this immutable
+# action only. Vault, Ops Bot, Docker, and the deploy broker are never contacted.
+
+set -euo pipefail
+IFS=$'\n\t'
+
+readonly REQUIRED_YQ_VERSION="v4.44.3"
+readonly DATARIM_REPOSITORY="Arcanada-one/datarim"
+readonly CONTRACT_JOB="preflight-caller-contract"
+readonly DEPLOY_JOB="deploy"
+readonly CONTRACT_ACTION="Arcanada-one/datarim/.github/actions/preflight-caller-contract"
+readonly PREFLIGHT_ACTION="Arcanada-one/datarim/.github/actions/preflight-check"
+readonly CHECKOUT_ACTION="actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1"
+# shellcheck disable=SC2016 # GitHub expressions are intentionally literal.
+readonly VAULT_ADDR_EXPRESSION='${{ vars.VAULT_ADDR }}'
+# shellcheck disable=SC2016 # GitHub expressions are intentionally literal.
+readonly WORKFLOW_SHA_EXPRESSION='${{ github.workflow_sha }}'
+readonly OPS_BOT_URL="https://ops.arcanada.ai/events"
+
+fail() {
+    printf 'ERROR: %s\n' "$1" >&2
+    exit 1
+}
+
+require_env() {
+    local name="$1"
+    [ "${!name+x}" = x ] || fail "runtime.${name}: missing"
+}
+
+yaml_true() {
+    local expression="$1"
+    local field="$2"
+    if ! "$yq_bin" eval -e "$expression" "$workflow_file" >/dev/null 2>&1; then
+        fail "${field}: contract violation"
+    fi
+}
+
+yaml_read() {
+    local expression="$1"
+    local field="$2"
+    if ! YAML_VALUE="$("$yq_bin" eval -r "$expression" "$workflow_file" 2>/dev/null)"; then
+        fail "${field}: invalid query target"
+    fi
+}
+
+registry_read() {
+    local expression="$1"
+    local field="$2"
+    if ! REGISTRY_VALUE="$("$yq_bin" eval -er "$expression" "$registry_file" 2>/dev/null)"; then
+        fail "registry.${field}: missing consumer binding"
+    fi
+}
+
+for required_name in \
+    GITHUB_WORKSPACE \
+    PREFLIGHT_CALLER_ACTION_REPOSITORY \
+    PREFLIGHT_CALLER_ACTION_REF \
+    PREFLIGHT_CALLER_GITHUB_REPOSITORY \
+    PREFLIGHT_CALLER_WORKFLOW_REF \
+    PREFLIGHT_CALLER_WORKFLOW_SHA \
+    PREFLIGHT_CALLER_VAULT_ADDR \
+    PREFLIGHT_CALLER_YQ_BIN; do
+    require_env "$required_name"
+done
+
+yq_bin="$PREFLIGHT_CALLER_YQ_BIN"
+if [ ! -f "$yq_bin" ] || [ ! -x "$yq_bin" ] || [ -L "$yq_bin" ]; then
+    fail "tool.yq: required ${REQUIRED_YQ_VERSION} is unavailable"
+fi
+yq_version="$("$yq_bin" --version 2>/dev/null)"
+[[ "$yq_version" =~ version[[:space:]]${REQUIRED_YQ_VERSION//./\.}$ ]] || \
+    fail "tool.yq: required ${REQUIRED_YQ_VERSION} is unavailable"
+
+action_repository="$PREFLIGHT_CALLER_ACTION_REPOSITORY"
+action_ref="$PREFLIGHT_CALLER_ACTION_REF"
+github_repository="$PREFLIGHT_CALLER_GITHUB_REPOSITORY"
+workflow_ref="$PREFLIGHT_CALLER_WORKFLOW_REF"
+workflow_sha="$PREFLIGHT_CALLER_WORKFLOW_SHA"
+vault_addr="$PREFLIGHT_CALLER_VAULT_ADDR"
+
+[ "$action_repository" = "$DATARIM_REPOSITORY" ] || fail "runtime.github.action_repository: unexpected"
+[[ "$action_ref" =~ ^[0-9a-f]{40}$ ]] || fail "runtime.github.action_ref: immutable commit required"
+[[ "$github_repository" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || fail "runtime.github.repository: invalid"
+[[ "$workflow_sha" =~ ^[0-9a-f]{40}$ ]] || fail "runtime.github.workflow_sha: immutable commit required"
+
+script_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd -P)"
+registry_file="${script_root}/.github/actions/preflight-caller-contract/consumers.yml"
+"$yq_bin" eval -e '."schema-version" == 1 and (.consumers | type == "!!map")' "$registry_file" >/dev/null 2>&1 || \
+    fail "registry: invalid schema"
+export REGISTRY_REPOSITORY="$github_repository"
+registry_read '.consumers[strenv(REGISTRY_REPOSITORY)]."service-name"' "${github_repository}.service-name"
+service_name="$REGISTRY_VALUE"
+registry_read '.consumers[strenv(REGISTRY_REPOSITORY)]."ops-bot-agent"' "${github_repository}.ops-bot-agent"
+ops_bot_agent="$REGISTRY_VALUE"
+registry_read '.consumers[strenv(REGISTRY_REPOSITORY)]."ops-bot-key-secret-name"' "${github_repository}.ops-bot-key-secret-name"
+ops_bot_key_secret_name="$REGISTRY_VALUE"
+registry_read '.consumers[strenv(REGISTRY_REPOSITORY)]."deploy-if"' "${github_repository}.deploy-if"
+deploy_if="$REGISTRY_VALUE"
+
+[[ "$service_name" =~ ^[a-z0-9-]+$ ]] || fail "registry.${github_repository}.service-name: invalid"
+[[ "$ops_bot_agent" =~ ^[a-z0-9-]+$ ]] || fail "registry.${github_repository}.ops-bot-agent: invalid"
+[ "$ops_bot_agent" = "$service_name" ] || fail "registry.${github_repository}.ops-bot-agent: identity mismatch"
+[[ "$ops_bot_key_secret_name" =~ ^[A-Z_][A-Z0-9_]*$ ]] || \
+    fail "registry.${github_repository}.ops-bot-key-secret-name: invalid"
+if [ -z "$deploy_if" ]; then
+    fail "registry.${github_repository}: incomplete deploy binding"
+fi
+
+workflow_with_repository="${workflow_ref%@*}"
+[ "$workflow_with_repository" != "$workflow_ref" ] || fail "runtime.github.workflow_ref: invalid"
+case "$workflow_with_repository" in
+    "$github_repository"/*) workflow_path="${workflow_with_repository#"$github_repository"/}" ;;
+    *) fail "runtime.github.workflow_ref: repository mismatch" ;;
+esac
+[[ "$workflow_path" =~ ^\.github/workflows/[A-Za-z0-9_.-]+\.(yml|yaml)$ ]] || \
+    fail "runtime.github.workflow_ref: workflow path invalid"
+
+workflow_file="${GITHUB_WORKSPACE%/}/${workflow_path}"
+if [ ! -f "$workflow_file" ] || [ -L "$workflow_file" ]; then
+    fail "workflow: caller file unavailable"
+fi
+workspace_root="$(cd "$GITHUB_WORKSPACE" 2>/dev/null && pwd -P)" || fail "runtime.github.workspace: unavailable"
+git_root="$(git -C "$workspace_root" rev-parse --show-toplevel 2>/dev/null)" || fail "runtime.github.workspace: git checkout required"
+[ "$git_root" = "$workspace_root" ] || fail "runtime.github.workspace: checkout root mismatch"
+head_sha="$(git -C "$workspace_root" rev-parse HEAD 2>/dev/null)" || fail "runtime.github.workflow_sha: checkout unavailable"
+[ "$head_sha" = "$workflow_sha" ] || fail "runtime.github.workflow_sha: checkout mismatch"
+git -C "$workspace_root" cat-file -e "${workflow_sha}:${workflow_path}" 2>/dev/null || fail "workflow: caller commit path unavailable"
+committed_workflow_hash="$(git -C "$workspace_root" rev-parse "${workflow_sha}:${workflow_path}" 2>/dev/null)" || \
+    fail "workflow: caller commit path unavailable"
+working_workflow_hash="$(git -C "$workspace_root" hash-object "$workflow_file" 2>/dev/null)" || fail "workflow: caller file unreadable"
+[ "$working_workflow_hash" = "$committed_workflow_hash" ] || fail "workflow: caller file differs from workflow_sha"
+"$yq_bin" eval -e '.jobs | type == "!!map"' "$workflow_file" >/dev/null 2>&1 || fail "workflow: invalid YAML jobs map"
+
+[ -n "$vault_addr" ] || fail "inputs.vault-addr: empty"
+[[ ! "$vault_addr" =~ [[:space:]] ]] || fail "inputs.vault-addr: whitespace forbidden"
+[[ "$vault_addr" =~ ^https?://[^/[:space:]]+ ]] || fail "inputs.vault-addr: HTTP(S) URL required"
+authority="${vault_addr#*://}"
+authority="${authority%%[/?#]*}"
+[[ "$authority" != *"@"* ]] || fail "inputs.vault-addr: credentials forbidden"
+port=""
+if [[ "$authority" =~ ^\[[0-9A-Fa-f:.]+\](:([0-9]{1,5}))?$ ]]; then
+    port="${BASH_REMATCH[2]:-}"
+elif [[ "$authority" =~ ^[A-Za-z0-9]([A-Za-z0-9.-]*[A-Za-z0-9])?(:([0-9]{1,5}))?$ ]]; then
+    port="${BASH_REMATCH[3]:-}"
+else
+    fail "inputs.vault-addr: valid authority required"
+fi
+if [ -n "$port" ] && (( 10#$port < 1 || 10#$port > 65535 )); then
+    fail "inputs.vault-addr: valid port required"
+fi
+
+export EXPECTED_CONTRACT_USE="${CONTRACT_ACTION}@${action_ref}"
+export EXPECTED_PREFLIGHT_USE="${PREFLIGHT_ACTION}@${action_ref}"
+export EXPECTED_CHECKOUT_USE="$CHECKOUT_ACTION"
+export EXPECTED_SERVICE_NAME="$service_name"
+export EXPECTED_OPS_BOT_AGENT="$ops_bot_agent"
+export EXPECTED_SECRET_NAME="$ops_bot_key_secret_name"
+# shellcheck disable=SC2016 # GitHub expression delimiters are intentional.
+export EXPECTED_SECRET_EXPRESSION='${{ secrets.'"${ops_bot_key_secret_name}"' }}'
+export EXPECTED_VAULT_EXPRESSION="$VAULT_ADDR_EXPRESSION"
+export EXPECTED_WORKFLOW_SHA_EXPRESSION="$WORKFLOW_SHA_EXPRESSION"
+export EXPECTED_OPS_BOT_URL="$OPS_BOT_URL"
+export EXPECTED_DEPLOY_IF="$deploy_if"
+
+yaml_true '(.on | type) == "!!map" and (.on | has("pull_request")) and
+    (((.on.pull_request | type) == "!!null") or
+     (((.on.pull_request | type) == "!!map") and ((.on.pull_request | length) == 0)))' \
+    ".on.pull_request"
+yaml_true '.jobs."preflight-caller-contract" | type == "!!map"' ".jobs.${CONTRACT_JOB}"
+yaml_true '.jobs.deploy | type == "!!map"' ".jobs.${DEPLOY_JOB}"
+yaml_true '(.jobs."preflight-caller-contract" | keys | sort | join(",")) == "permissions,runs-on,steps,timeout-minutes"' \
+    ".jobs.${CONTRACT_JOB}.capabilities"
+yaml_true '.jobs."preflight-caller-contract"."runs-on" == "ubuntu-latest"' ".jobs.${CONTRACT_JOB}.runs-on"
+yaml_true '.jobs."preflight-caller-contract"."timeout-minutes" == 5' ".jobs.${CONTRACT_JOB}.timeout-minutes"
+yaml_true '(.jobs."preflight-caller-contract".permissions | keys | join(",")) == "contents" and
+    .jobs."preflight-caller-contract".permissions.contents == "read"' ".jobs.${CONTRACT_JOB}.permissions"
+yaml_true '.jobs."preflight-caller-contract".steps | length == 2' ".jobs.${CONTRACT_JOB}.steps"
+yaml_true '(.jobs."preflight-caller-contract".steps[0] | keys | sort | join(",")) == "uses,with" and
+    .jobs."preflight-caller-contract".steps[0].uses == strenv(EXPECTED_CHECKOUT_USE) and
+    (.jobs."preflight-caller-contract".steps[0].with | keys | sort | join(",")) == "persist-credentials,ref" and
+    (.jobs."preflight-caller-contract".steps[0].with."persist-credentials" | tostring) == "false" and
+    .jobs."preflight-caller-contract".steps[0].with.ref == strenv(EXPECTED_WORKFLOW_SHA_EXPRESSION)' \
+    ".jobs.${CONTRACT_JOB}.steps.checkout"
+yaml_true '(.jobs."preflight-caller-contract".steps[1] | keys | sort | join(",")) == "uses,with" and
+    .jobs."preflight-caller-contract".steps[1].uses == strenv(EXPECTED_CONTRACT_USE) and
+    (.jobs."preflight-caller-contract".steps[1].with | keys | join(",")) == "vault-addr" and
+    .jobs."preflight-caller-contract".steps[1].with."vault-addr" == strenv(EXPECTED_VAULT_EXPRESSION)' \
+    ".jobs.${CONTRACT_JOB}.steps.contract"
+
+yaml_true '([.jobs.deploy.needs] | flatten | map(select(. == "preflight-caller-contract")) | length) > 0' \
+    ".jobs.${DEPLOY_JOB}.needs"
+yaml_true '.jobs.deploy | has("continue-on-error") | not' ".jobs.${DEPLOY_JOB}.continue-on-error"
+yaml_true '(.jobs.deploy.if | tostring) == strenv(EXPECTED_DEPLOY_IF)' ".jobs.${DEPLOY_JOB}.if"
+yaml_true '.jobs.deploy.env.VAULT_ADDR == strenv(EXPECTED_VAULT_EXPRESSION)' ".jobs.${DEPLOY_JOB}.env.VAULT_ADDR"
+
+yaml_true '[.jobs[]?.steps[]? | select((.uses // "") |
+    test("^Arcanada-one/datarim/\\.github/actions/preflight-check@"))] | length == 1' \
+    ".jobs.${DEPLOY_JOB}.steps.uses"
+yaml_true '[.jobs.deploy.steps[]? | select(.uses == strenv(EXPECTED_PREFLIGHT_USE))] | length == 1' \
+    ".jobs.${DEPLOY_JOB}.steps.uses"
+yaml_true '[.jobs.deploy.steps[]? | select(.uses == strenv(EXPECTED_PREFLIGHT_USE))][0] |
+    ([keys[] | select(. != "id" and . != "name" and . != "uses" and . != "with")] | length) == 0' \
+    ".jobs.${DEPLOY_JOB}.steps.preflight-shape"
+yaml_true '[.jobs.deploy.steps[]? | select(.uses == strenv(EXPECTED_PREFLIGHT_USE))][0].id == "preflight"' \
+    ".jobs.${DEPLOY_JOB}.steps.id"
+yaml_true '[.jobs.deploy.steps[]? | select(.uses == strenv(EXPECTED_PREFLIGHT_USE))][0].with."service-name" == strenv(EXPECTED_SERVICE_NAME)' \
+    ".jobs.${DEPLOY_JOB}.steps.with.service-name"
+yaml_true '[.jobs.deploy.steps[]? | select(.uses == strenv(EXPECTED_PREFLIGHT_USE))][0].with."ops-bot-agent" == strenv(EXPECTED_OPS_BOT_AGENT)' \
+    ".jobs.${DEPLOY_JOB}.steps.with.ops-bot-agent"
+yaml_true '([.jobs.deploy.steps[]? | select(.uses == strenv(EXPECTED_PREFLIGHT_USE))][0].with."ops-bot-emit" | tostring) == "true"' \
+    ".jobs.${DEPLOY_JOB}.steps.with.ops-bot-emit"
+yaml_true '[.jobs.deploy.steps[]? | select(.uses == strenv(EXPECTED_PREFLIGHT_USE))][0].with."ops-bot-key" == strenv(EXPECTED_SECRET_EXPRESSION)' \
+    ".jobs.${DEPLOY_JOB}.steps.with.ops-bot-key"
+yaml_true '[.jobs.deploy.steps[]? | select(.uses == strenv(EXPECTED_PREFLIGHT_USE))][0].with."ops-bot-url" == strenv(EXPECTED_OPS_BOT_URL)' \
+    ".jobs.${DEPLOY_JOB}.steps.with.ops-bot-url"
+
+yaml_read '[.jobs.deploy.steps | to_entries[] | select(.value.uses == strenv(EXPECTED_PREFLIGHT_USE))][0].key' \
+    ".jobs.${DEPLOY_JOB}.steps.uses"
+preflight_step_index="$YAML_VALUE"
+[ "$preflight_step_index" = 0 ] || fail ".jobs.${DEPLOY_JOB}.steps.order: preflight must be first"
+yaml_true '[.jobs.deploy.steps[]? | select(has("continue-on-error"))] | length == 0' \
+    ".jobs.${DEPLOY_JOB}.steps.continue-on-error"
+yaml_true '[.jobs.deploy.steps | to_entries[] | select(.key > 0) |
+    select(((.value.if // "") | tostring) |
+      test("(?i)(always|failure|cancelled|success)[[:space:]]*\\("))] | length == 0' \
+    ".jobs.${DEPLOY_JOB}.steps.if"
+
+yaml_read '[.jobs.deploy.steps[]? | select(.uses == strenv(EXPECTED_PREFLIGHT_USE))][0].with."extra-checks" // ""' \
+    ".jobs.${DEPLOY_JOB}.steps.with.extra-checks"
+extra_checks="$YAML_VALUE"
+vault_enabled=false
+while IFS= read -r check_name; do
+    if [[ "$check_name" =~ ^[[:space:]]*vault[[:space:]]*$ ]]; then
+        vault_enabled=true
+        break
+    fi
+done <<< "$extra_checks"
+[ "$vault_enabled" = true ] || fail ".jobs.${DEPLOY_JOB}.steps.with.extra-checks: exact vault token required"
+
+printf '%s\n' "preflight caller contract: PASS"

--- a/tests/fixtures/preflight-caller-contract/legacy-legal.yml
+++ b/tests/fixtures/preflight-caller-contract/legacy-legal.yml
@@ -1,0 +1,34 @@
+name: deploy
+
+on:
+  pull_request:
+
+jobs:
+  preflight-caller-contract:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+      - uses: Arcanada-one/datarim/.github/actions/preflight-caller-contract@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        with:
+          vault-addr: ${{ vars.VAULT_ADDR }}
+
+  deploy:
+    needs: preflight-caller-contract
+    runs-on: self-hosted
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    env:
+      VAULT_ADDR: ${{ vars.VAULT_ADDR }}
+    steps:
+      - uses: Arcanada-one/datarim/.github/actions/preflight-check@fff2521000000000000000000000000000000000
+        with:
+          target-host: arcana-prod
+          service-name: legal
+          extra-checks: vault
+          ops-bot-emit: "true"
+          ops-bot-url: https://ops.arcanada.one/events

--- a/tests/fixtures/preflight-caller-contract/valid.yml
+++ b/tests/fixtures/preflight-caller-contract/valid.yml
@@ -1,0 +1,48 @@
+name: deploy
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build
+
+  preflight-caller-contract:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
+          ref: ${{ github.workflow_sha }}
+      - uses: Arcanada-one/datarim/.github/actions/preflight-caller-contract@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        with:
+          vault-addr: ${{ vars.VAULT_ADDR }}
+
+  deploy:
+    needs:
+      - build
+      - preflight-caller-contract
+    runs-on: self-hosted
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    env:
+      VAULT_ADDR: ${{ vars.VAULT_ADDR }}
+    steps:
+      - id: preflight
+        uses: Arcanada-one/datarim/.github/actions/preflight-check@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+        with:
+          target-host: arcana-prod
+          service-name: muneral
+          extra-checks: |
+            vault
+            time-skew
+          ops-bot-emit: "true"
+          ops-bot-agent: muneral
+          ops-bot-key: ${{ secrets.OPSBOT_API_KEY }}
+          ops-bot-url: https://ops.arcanada.ai/events
+      - if: steps.preflight.outputs.status != 'fail'
+        run: sudo -n /usr/local/sbin/arcanada-compose-broker muneral up

--- a/tests/preflight-caller-contract.bats
+++ b/tests/preflight-caller-contract.bats
@@ -1,0 +1,352 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    SCRIPT="$REPO_ROOT/dev-tools/preflight-caller-contract.sh"
+    ACTION="$REPO_ROOT/.github/actions/preflight-caller-contract/action.yml"
+    REGISTRY="$REPO_ROOT/.github/actions/preflight-caller-contract/consumers.yml"
+    FIXTURES="$REPO_ROOT/tests/fixtures/preflight-caller-contract"
+    TEST_ROOT="$BATS_TEST_TMPDIR/repository"
+    WORKFLOW_REL=".github/workflows/deploy.yml"
+    WORKFLOW="$TEST_ROOT/$WORKFLOW_REL"
+    ACTION_REF="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+    mkdir -p "$(dirname "$WORKFLOW")"
+    cp "$FIXTURES/valid.yml" "$WORKFLOW"
+    git -C "$TEST_ROOT" init -q
+    git -C "$TEST_ROOT" config user.name "Datarim Tests"
+    git -C "$TEST_ROOT" config user.email "tests@invalid.example"
+    git -C "$TEST_ROOT" add "$WORKFLOW_REL"
+    git -C "$TEST_ROOT" commit -qm fixture
+}
+
+run_contract() {
+    local action_repository="${CALLER_ACTION_REPOSITORY_OVERRIDE:-Arcanada-one/datarim}"
+    local action_ref="${CALLER_ACTION_REF_OVERRIDE:-$ACTION_REF}"
+    local caller_repository="${CALLER_REPOSITORY_OVERRIDE:-Arcanada-one/muneral}"
+    local vault_addr="${CALLER_VAULT_ADDR_OVERRIDE-https://vault.internal:8200}"
+    local yq_bin="${CALLER_YQ_BIN_OVERRIDE:-$(command -v yq)}"
+    local workflow_ref="${CALLER_WORKFLOW_REF_OVERRIDE:-$caller_repository/$WORKFLOW_REL@refs/pull/42/merge}"
+    if [ "${CALLER_SKIP_SYNC:-false}" != true ]; then
+        git -C "$TEST_ROOT" add "$WORKFLOW_REL"
+        git -C "$TEST_ROOT" commit --amend --no-edit -q
+    fi
+    local workflow_sha
+    workflow_sha="$(git -C "$TEST_ROOT" rev-parse HEAD)"
+    run env \
+        GITHUB_WORKSPACE="$TEST_ROOT" \
+        PREFLIGHT_CALLER_ACTION_REPOSITORY="$action_repository" \
+        PREFLIGHT_CALLER_ACTION_REF="$action_ref" \
+        PREFLIGHT_CALLER_GITHUB_REPOSITORY="$caller_repository" \
+        PREFLIGHT_CALLER_WORKFLOW_REF="$workflow_ref" \
+        PREFLIGHT_CALLER_WORKFLOW_SHA="$workflow_sha" \
+        PREFLIGHT_CALLER_VAULT_ADDR="$vault_addr" \
+        PREFLIGHT_CALLER_YQ_BIN="$yq_bin" \
+        "$SCRIPT"
+}
+
+mutate() {
+    yq -i "$1" "$WORKFLOW"
+}
+
+restore_fixture() {
+    cp "$FIXTURES/valid.yml" "$WORKFLOW"
+}
+
+assert_status_is() {
+    local expected="$1"
+    if [ "$status" -ne "$expected" ]; then
+        echo "expected status $expected, got $status; output: $output" >&2
+        return 1
+    fi
+}
+
+assert_output_has() {
+    local expected="$1"
+    if [[ "$output" != *"$expected"* ]]; then
+        echo "expected output to contain '$expected'; output: $output" >&2
+        return 1
+    fi
+}
+
+assert_rejected() {
+    local field="$1"
+    run_contract
+    assert_status_is 1 || return 1
+    assert_output_has "$field" || return 1
+}
+
+@test "composite action pins yq, exposes only vault-addr, and wires immutable contexts" {
+    run yq -er '
+      .runs.using == "composite" and
+      (.inputs | keys | join(",")) == "vault-addr" and
+      .inputs."vault-addr".required == true and
+      (.runs.steps | length) == 2 and
+      .runs.steps[0].env.YQ_VERSION == "v4.44.3" and
+      .runs.steps[0].env.YQ_SHA256 == "a2c097180dd884a8d50c956ee16a9cec070f30a7947cf4ebf87d5f36213e9ed7" and
+      ([.runs.steps[] | select(.run == "\"${{ github.action_path }}/../../../dev-tools/preflight-caller-contract.sh\"")] | length == 1)
+    ' "$ACTION"
+    assert_status_is 0 || return 1
+
+    for binding in \
+        'PREFLIGHT_CALLER_ACTION_REF: ${{ github.action_ref }}' \
+        'PREFLIGHT_CALLER_ACTION_REPOSITORY: ${{ github.action_repository }}' \
+        'PREFLIGHT_CALLER_WORKFLOW_REF: ${{ github.workflow_ref }}' \
+        'PREFLIGHT_CALLER_WORKFLOW_SHA: ${{ github.workflow_sha }}' \
+        'PREFLIGHT_CALLER_VAULT_ADDR: ${{ inputs.vault-addr }}' \
+        'PREFLIGHT_CALLER_YQ_BIN: ${{ runner.temp }}/datarim-preflight-caller-contract/yq'; do
+        run grep -F "$binding" "$ACTION"
+        assert_status_is 0 || return 1
+    done
+
+    run yq -er '."schema-version" == 1 and .consumers."Arcanada-one/muneral"."service-name" == "muneral"' "$REGISTRY"
+    assert_status_is 0
+}
+
+@test "valid registered Muneral workflow passes with list needs and multiline checks" {
+    run_contract
+    assert_status_is 0 || return 1
+    [ "$output" = "preflight caller contract: PASS" ]
+}
+
+@test "valid workflow passes with scalar needs and scalar vault check" {
+    mutate '.jobs.deploy.needs = "preflight-caller-contract" |
+            .jobs.deploy.steps[0].with."extra-checks" = "vault"'
+    run_contract
+    assert_status_is 0
+}
+
+@test "malformed YAML fails closed" {
+    printf '%s\n' '  malformed: [unterminated' >> "$WORKFLOW"
+    assert_rejected "workflow"
+}
+
+@test "missing contract and deploy jobs are independently rejected" {
+    mutate 'del(.jobs."preflight-caller-contract")'
+    assert_rejected ".jobs.preflight-caller-contract" || return 1
+
+    restore_fixture
+    mutate 'del(.jobs.deploy)'
+    assert_rejected ".jobs.deploy"
+}
+
+@test "workflow must keep an unfiltered pull_request admission trigger" {
+    mutate 'del(.on.pull_request)'
+    assert_rejected ".on.pull_request" || return 1
+
+    restore_fixture
+    mutate '.on.pull_request.paths = ["docs/**"]'
+    assert_rejected ".on.pull_request"
+}
+
+@test "contract job has an exact capability-free shape" {
+    mutate '.jobs."preflight-caller-contract".services.vault.image = "hashicorp/vault"'
+    assert_rejected ".jobs.preflight-caller-contract.capabilities" || return 1
+
+    restore_fixture
+    mutate '.jobs."preflight-caller-contract".env.KEY = "${{ secrets.OPSBOT_API_KEY }}"'
+    assert_rejected ".jobs.preflight-caller-contract.capabilities" || return 1
+
+    restore_fixture
+    mutate '.jobs."preflight-caller-contract".container = "ubuntu:latest"'
+    assert_rejected ".jobs.preflight-caller-contract.capabilities" || return 1
+
+    restore_fixture
+    mutate '.jobs."preflight-caller-contract".if = "always()"'
+    assert_rejected ".jobs.preflight-caller-contract.capabilities" || return 1
+
+    restore_fixture
+    mutate '.jobs."preflight-caller-contract".steps += [{"run":"docker ps && vault status && sudo broker"}]'
+    assert_rejected ".jobs.preflight-caller-contract.steps"
+}
+
+@test "contract checkout is immutable, credential-minimal, and bound to workflow_sha" {
+    mutate '.jobs."preflight-caller-contract".steps[0].uses = "actions/checkout@main"'
+    assert_rejected ".jobs.preflight-caller-contract.steps.checkout" || return 1
+
+    restore_fixture
+    mutate '.jobs."preflight-caller-contract".steps[0].with."persist-credentials" = true'
+    assert_rejected ".jobs.preflight-caller-contract.steps.checkout" || return 1
+
+    restore_fixture
+    mutate '.jobs."preflight-caller-contract".steps[0].with.ref = "${{ github.sha }}"'
+    assert_rejected ".jobs.preflight-caller-contract.steps.checkout"
+}
+
+@test "contract action is unique, self-bound, and accepts no identity override" {
+    mutate '.jobs."preflight-caller-contract".steps[1].uses = "Arcanada-one/datarim/.github/actions/preflight-caller-contract@main"'
+    assert_rejected ".jobs.preflight-caller-contract.steps.contract" || return 1
+
+    restore_fixture
+    mutate '.jobs."preflight-caller-contract".steps[1].with."service-name" = "legal"'
+    assert_rejected ".jobs.preflight-caller-contract.steps.contract" || return 1
+
+    restore_fixture
+    mutate '.jobs."preflight-caller-contract".steps += [.jobs."preflight-caller-contract".steps[1]]'
+    assert_rejected ".jobs.preflight-caller-contract.steps"
+}
+
+@test "deploy must depend on the fixed contract job" {
+    mutate '.jobs.deploy.needs = ["build"]'
+    assert_rejected ".jobs.deploy.needs"
+}
+
+@test "deploy condition is anchored in the immutable consumer registry" {
+    for bypass in 'always()' 'true' "needs.preflight-caller-contract.result == 'failure' || true"; do
+        VALUE="$bypass" yq -i '.jobs.deploy.if = strenv(VALUE)' "$WORKFLOW"
+        assert_rejected ".jobs.deploy.if" || return 1
+        restore_fixture
+    done
+}
+
+@test "deploy job cannot continue on error" {
+    mutate '.jobs.deploy."continue-on-error" = true'
+    assert_rejected ".jobs.deploy.continue-on-error"
+}
+
+@test "deploy VAULT_ADDR must map exactly to repository vars" {
+    mutate 'del(.jobs.deploy.env.VAULT_ADDR)'
+    assert_rejected ".jobs.deploy.env.VAULT_ADDR" || return 1
+
+    for replacement in '' '${{ env.VAULT_ADDR }}' 'https://vault.invalid'; do
+        restore_fixture
+        VALUE="$replacement" yq -i '.jobs.deploy.env.VAULT_ADDR = strenv(VALUE)' "$WORKFLOW"
+        assert_rejected ".jobs.deploy.env.VAULT_ADDR" || return 1
+    done
+}
+
+@test "resolved Vault address rejects malformed values without disclosure" {
+    local unsafe
+    for unsafe in '' 'ftp://vault.internal' 'https://:8200' 'https:///path' 'https://vault.internal:65536' 'https://vault.internal:99999' 'https://user:pass@vault.internal' 'https://vault.internal/path with-space'; do
+        CALLER_VAULT_ADDR_OVERRIDE="$unsafe" run_contract
+        if [ "$status" -ne 1 ]; then
+            echo "unsafe Vault case was accepted: $unsafe" >&2
+            return 1
+        fi
+        assert_output_has "vault-addr" || return 1
+        if [ -n "$unsafe" ] && [[ "$output" == *"$unsafe"* ]]; then
+            echo "unsafe Vault value was disclosed" >&2
+            return 1
+        fi
+    done
+
+    CALLER_VAULT_ADDR_OVERRIDE="https://vault.internal:65535" run_contract
+    assert_status_is 0
+}
+
+@test "preflight action is globally unique and pinned to the validator revision" {
+    for pin in main abcdef0 bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb; do
+        mutate ".jobs.deploy.steps[0].uses = \"Arcanada-one/datarim/.github/actions/preflight-check@${pin}\""
+        assert_rejected ".jobs.deploy.steps.uses" || return 1
+        restore_fixture
+    done
+
+    mutate '.jobs.build.steps += [{"uses":"Arcanada-one/datarim/.github/actions/preflight-check@aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"}]'
+    assert_rejected ".jobs.deploy.steps.uses"
+}
+
+@test "preflight step cannot be conditional, fail-soft, or lose its fixed id" {
+    mutate '.jobs.deploy.steps[0].if = "false"'
+    assert_rejected ".jobs.deploy.steps.preflight-shape" || return 1
+
+    restore_fixture
+    mutate '.jobs.deploy.steps[0]."continue-on-error" = true'
+    assert_rejected ".jobs.deploy.steps.preflight-shape" || return 1
+
+    restore_fixture
+    mutate '.jobs.deploy.steps[0].id = "other"'
+    assert_rejected ".jobs.deploy.steps.id"
+}
+
+@test "preflight is first and later deploy steps cannot override failure propagation" {
+    mutate '.jobs.deploy.steps = [.jobs.deploy.steps[1], .jobs.deploy.steps[0]]'
+    assert_rejected ".jobs.deploy.steps.order" || return 1
+
+    for bypass in 'always()' 'failure()' '!cancelled()' 'success() || true'; do
+        restore_fixture
+        VALUE="$bypass" yq -i '.jobs.deploy.steps[1].if = strenv(VALUE)' "$WORKFLOW"
+        assert_rejected ".jobs.deploy.steps.if" || return 1
+    done
+
+    restore_fixture
+    mutate '.jobs.deploy.steps[1]."continue-on-error" = true'
+    assert_rejected ".jobs.deploy.steps.continue-on-error"
+}
+
+@test "extra-checks requires an exact vault line token" {
+    for value in '' 'vaultish' 'time-skew'; do
+        VALUE="$value" yq -i '.jobs.deploy.steps[0].with."extra-checks" = strenv(VALUE)' "$WORKFLOW"
+        assert_rejected ".jobs.deploy.steps.with.extra-checks" || return 1
+        restore_fixture
+    done
+}
+
+@test "service identity and key name are bound by the immutable registry" {
+    mutate '.jobs.deploy.steps[0].with."service-name" = "legal"'
+    assert_rejected ".jobs.deploy.steps.with.service-name" || return 1
+
+    restore_fixture
+    mutate '.jobs.deploy.steps[0].with."ops-bot-agent" = "legal"'
+    assert_rejected ".jobs.deploy.steps.with.ops-bot-agent" || return 1
+
+    restore_fixture
+    mutate '.jobs.deploy.steps[0].with."ops-bot-key" = "${{ secrets.NONEXISTENT_KEY }}"'
+    assert_rejected ".jobs.deploy.steps.with.ops-bot-key"
+}
+
+@test "notification emission must be explicitly true" {
+    for value in '' 'false'; do
+        VALUE="$value" yq -i '.jobs.deploy.steps[0].with."ops-bot-emit" = strenv(VALUE)' "$WORKFLOW"
+        assert_rejected ".jobs.deploy.steps.with.ops-bot-emit" || return 1
+        restore_fixture
+    done
+}
+
+@test "Ops Bot endpoint must be the explicit canonical URL" {
+    local replacement
+    for replacement in '' 'https://ops.arcanada.one/events' '${{ vars.OPSBOT_URL }}'; do
+        VALUE="$replacement" yq -i '.jobs.deploy.steps[0].with."ops-bot-url" = strenv(VALUE)' "$WORKFLOW"
+        assert_rejected ".jobs.deploy.steps.with.ops-bot-url" || return 1
+        restore_fixture
+    done
+}
+
+@test "unregistered legacy Legal wiring fails closed" {
+    cp "$FIXTURES/legacy-legal.yml" "$WORKFLOW"
+    CALLER_REPOSITORY_OVERRIDE="Arcanada-one/legal-arcana" run_contract
+    assert_status_is 1 || return 1
+    assert_output_has "registry.Arcanada-one/legal-arcana"
+}
+
+@test "runtime provenance independently rejects repository, ref, and path substitution" {
+    CALLER_ACTION_REPOSITORY_OVERRIDE="evil/fork" run_contract
+    assert_status_is 1 || return 1
+    assert_output_has "action_repository" || return 1
+
+    CALLER_ACTION_REF_OVERRIDE="main" run_contract
+    assert_status_is 1 || return 1
+    assert_output_has "action_ref" || return 1
+
+    CALLER_WORKFLOW_REF_OVERRIDE="Arcanada-one/muneral/../../fixture.yml@refs/heads/main" run_contract
+    assert_status_is 1 || return 1
+    assert_output_has "workflow_ref"
+}
+
+@test "runtime provenance rejects a workflow changed after workflow_sha checkout" {
+    printf '%s\n' '# post-checkout substitution' >> "$WORKFLOW"
+    CALLER_SKIP_SYNC=true run_contract
+    assert_status_is 1 || return 1
+    assert_output_has "workflow"
+}
+
+@test "toolchain rejects an unpinned yq version" {
+    local fake_bin="$BATS_TEST_TMPDIR/fake-bin"
+    mkdir -p "$fake_bin"
+    for version in v4.45.1 v4.44.30; do
+        printf '%s\n' '#!/usr/bin/env bash' "echo \"yq version $version\"" > "$fake_bin/yq"
+        chmod +x "$fake_bin/yq"
+        CALLER_YQ_BIN_OVERRIDE="$fake_bin/yq" run_contract
+        assert_status_is 1 || return 1
+        assert_output_has "tool.yq" || return 1
+    done
+}


### PR DESCRIPTION
## Summary
- add an immutable, registry-bound caller contract for the Muneral preflight rollout
- require an unfiltered PR admission job with no Docker, Vault, broker, or service-secret capabilities
- bind workflow bytes to workflow_sha, require preflight as deploy step zero, and reject fail-soft/status-override bypasses
- validate Vault mapping, explicit service identity, canonical endpoint, and same-SHA action pins with a pinned yq parser

## Verification
- bats tests/preflight-caller-contract.bats (25/25)
- bash tests/run-bats-discovery.sh --shard 2/8 (47/47 suites)
- shellcheck dev-tools/preflight-caller-contract.sh
- bash -n dev-tools/preflight-caller-contract.sh
- ./validate.sh
- two independent adversarial reviews: no remaining concrete defect

ARCA-0194 R6-02 code/test slice only; the frozen completion audit is unchanged.