### PR TITLE
doctor: report reserved-prefix shadowing instead of ignoring it silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,25 @@ All notable changes to the Datarim framework are documented here. Format follows
 
 ## [Unreleased]
 
+### Fixed
+
+- **Reserved-prefix shadowing is reported instead of applied silently.** Universal
+  area prefixes (`DEV`, `QA`, `WEB`, `INFRA`, …) resolve before a consumer's
+  `## Task Prefix Registry`, so a project row repeating one of them was discarded
+  with no output. A project declaring `| DEV | My app | general |` therefore
+  believed its archives routed to `general/` while `--probe-prefix=DEV` kept
+  answering `development` — and because project instructions typically tell agents
+  to resolve the subdir via the probe «rather than assuming», an obedient agent
+  creates a stray `archive/development/` tree and strands the archive outside the
+  corpus later prior-art greps search. `prefix_to_area()` now emits a `WARN`
+  naming both the reserved value and the ignored project value; agreement between
+  the two tables stays quiet. **Resolution precedence is unchanged** — the
+  anti-shadowing guarantee (`T-PFX-10`) is deliberate and intact. Documented in
+  `skills/datarim-system/task-identity-and-context.md` § Project Prefix
+  Resolution, `skills/datarim-doctor/SKILL.md`, and the `CLAUDE.md` registry
+  section, all of which previously said «do not repeat them here» without stating
+  what happens if you do.
+
 ## [2.65.0] — 2026-08-09
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -640,3 +640,11 @@ Schema: `| Prefix | Project | Archive Subdir |`. Archive Subdir MUST match `^[a-
 | DATA | Datarim framework | framework |
 
 > `TUNE` is already a universal area prefix in the runtime (archive subdir `framework/`); no row needed. Adding a new project prefix here propagates automatically to `/dr-archive` routing — no Datarim framework change required.
+
+> **A row that repeats a universal area prefix is IGNORED, not applied.** Area
+> prefixes resolve first, so `| DEV | My app | general |` does not route `DEV-*`
+> to `general/` — the runtime's `development` wins. The doctor now emits a `WARN`
+> naming both values instead of discarding the row silently. Pick a prefix outside
+> the universal list for project-specific routing, and confirm with
+> `datarim-doctor.sh --probe-prefix=<P>` that the answer names a subdir that
+> exists on disk.

--- a/scripts/datarim-doctor.sh
+++ b/scripts/datarim-doctor.sh
@@ -160,6 +160,22 @@ fi
 #   2) project prefix — declared by caller in nearest CLAUDE.md (walk-up tree),
 #      under `## Task Prefix Registry` section with table | Prefix | Project | Archive Subdir |.
 # Falls back to `general` when neither matches. Path-traversal hardened.
+#
+# The tier order is deliberate (T-PFX-10, "area-prefix-wins-over-shadow"): the
+# runtime reserves a stack-agnostic namespace, so a project may ADD prefixes but
+# may not REDEFINE a reserved one. Do not invert this — it is an anti-shadowing
+# guarantee, not an oversight.
+#
+# DEV-1790 follow-up: the guarantee was enforced SILENTLY, which is the actual
+# defect. A consumer project declared DEV → general (where its entire archive
+# corpus already lived) and QA → general; both prefixes are reserved, so both
+# rows were discarded without a word while the probe answered `development` /
+# `qa` — subdirs that existed in no repo. Because a project CLAUDE.md typically
+# instructs agents to resolve the subdir via the probe «rather than assuming»,
+# an obedient agent creates a stray archive tree and strands the archive outside
+# the corpus later prior-art greps search. Resolution is unchanged; the shadowed
+# row is now reported so the project can rename its prefix (the real fix) instead
+# of silently believing a mapping that never applied.
 area_prefix_to_subdir() {
     case "${1%%-*}" in
         INFRA) echo "infrastructure" ;;
@@ -217,10 +233,20 @@ lookup_project_prefix_from_claude_md() {
 }
 
 prefix_to_area() {
-    local prefix="${1%%-*}" subdir
+    local prefix="${1%%-*}" subdir shadowed
+    # Tier 1: the reserved, stack-agnostic runtime namespace (anti-shadowing).
     if subdir="$(area_prefix_to_subdir "$prefix")"; then
+        # The project may not redefine a reserved prefix, but silently ignoring
+        # its declaration is what stranded DEV-1790's archive. Say so once.
+        # `|| true`: the lookup exits non-zero when the project declares nothing
+        # (the common case), and a bare assignment would abort under `set -e`.
+        shadowed="$(lookup_project_prefix_from_claude_md "$prefix" "${ROOT_ABS:-$PWD}" 2>/dev/null || true)"
+        if [ -n "$shadowed" ] && [ "$shadowed" != "$subdir" ]; then
+            warn "prefix $prefix is RESERVED by the Datarim runtime (→ $subdir); the project's Task Prefix Registry row '$prefix → $shadowed' is IGNORED. Rename the project prefix to a non-reserved one, or move the archives to $subdir."
+        fi
         echo "$subdir"; return 0
     fi
+    # Tier 2: project-declared prefix (the intended extension point).
     if subdir="$(lookup_project_prefix_from_claude_md "$prefix" "${ROOT_ABS:-$PWD}")"; then
         echo "$subdir"; return 0
     fi

--- a/skills/datarim-doctor/SKILL.md
+++ b/skills/datarim-doctor/SKILL.md
@@ -229,6 +229,15 @@ Per bullet:
 1. Validate task ID matches `^[A-Z]{2,10}-[0-9]{4}(-[A-Za-z0-9]+)*$`. Invalid → preserve in operational file with manual-migration marker.
 2. **Explicit-pointer dispatch:** if bullet body contains `→ documentation/archive/{path}.md`, prefer that path as canonical; otherwise fall back to `prefix_to_area()` (prefix→area mapping) → `documentation/archive/{area}/archive-{ID}.md`.
 3. Path-traversal safety: canonical path MUST stay under `documentation/archive/`; violation rejects explicit pointer and falls back to `prefix_to_area`. If fallback also escapes → preserve, warn.
+
+> `prefix_to_area()` resolves **universal area prefixes first**, so a consumer
+> `## Task Prefix Registry` row that repeats one of them (`DEV`, `QA`, `WEB`,
+> `INFRA`, …) is ignored rather than applied. The doctor emits a `WARN` naming
+> both the reserved value and the discarded project value. If a project's
+> archives already live under a different subdir than the probe reports, that
+> warning is the explanation — and step 5's defensive `find` is what still
+> locates them (`archive at unexpected area`). See
+> `skills/datarim-system/task-identity-and-context.md` § Project Prefix Resolution.
 4. **Verified case** — canonical archive exists with `{ID}` literal inside → strip bullet from operational file.
 5. **Missing case** — canonical absent at computed path → defensive `find documentation/archive/ -name "archive-{ID}.md"` (depth ≤ 3) checks every area subdir; if found with ID literal, strip bullet with warning `archive at unexpected area`. Otherwise synthesise stub with frontmatter (`id`, `title`, `status`, `{status}_at`, `source: synthesised from operational-file by datarim-doctor.sh Pass 6`, `original_block_sha`) + body = original bullet content; strip bullet.
 6. **Collision case** — canonical archive exists but does NOT contain `{ID}` literal → invoke `resolve_conflict()` (`--no-prompt` defaults to skip in non-TTY); on skip, preserve bullet in operational file with `<!-- bullets pending manual migration … -->` marker; on overwrite, synthesise stub.

--- a/skills/datarim-system/task-identity-and-context.md
+++ b/skills/datarim-system/task-identity-and-context.md
@@ -199,6 +199,25 @@ Resolution algorithm (implemented in `scripts/datarim-doctor.sh`):
 
 Each ecosystem (or each project that owns a registry) declares its own prefixes in its own `CLAUDE.md`. Adding a new project does not require a Datarim framework change.
 
+> **Area prefixes are RESERVED — a project row cannot redefine one.** Step 1 runs
+> before step 2, so a registry row naming a prefix from the Area Prefixes table
+> above (`DEV`, `QA`, `WEB`, `INFRA`, …) is **ignored**: resolution returns the
+> runtime's area subdir, not the project's `Archive Subdir`. This is deliberate —
+> it keeps the area namespace stack-agnostic — but it is an easy trap, because
+> `DEV` and `QA` read like natural project prefixes.
+>
+> The doctor now prints a `WARN` naming both values when it discards a shadowed
+> row. Previously the row was dropped with no output: a project declaring
+> `| DEV | My app | general |` believed its archives routed to `general/` while
+> `--probe-prefix=DEV` kept answering `development` — and an agent that trusts the
+> probe then creates a stray archive tree outside the corpus that later prior-art
+> greps search.
+>
+> **For project-specific routing, pick a prefix that is NOT in the Area Prefixes
+> table** (e.g. `OPS`, `FIX`, `INC`). Verify with
+> `datarim-doctor.sh --probe-prefix=<P>` and confirm the answer names a subdir
+> that actually exists on disk.
+
 ### Deprecated Namespace
 
 `BACKLOG-XXXX` is deprecated for new work. Historical references may remain in archives.

--- a/tests/datarim-doctor.bats
+++ b/tests/datarim-doctor.bats
@@ -1038,3 +1038,103 @@ EOF
     [ "$(grep -cE '^SCHEMA_TASKS_RE=' "$prearchive")" -eq 0 ]
     [ "$(grep -cE '^SCHEMA_BACKLOG_RE=' "$prearchive")" -eq 0 ]
 }
+
+# --- Reserved-prefix shadowing (DEV-1790 follow-up) --------------------------
+# The runtime reserves a stack-agnostic prefix namespace; a project may ADD
+# prefixes but may not REDEFINE a reserved one (T-PFX-10, anti-shadowing). That
+# guarantee is correct and stays. What was wrong is that it applied SILENTLY:
+# a consumer project declared DEV -> general (where its whole archive corpus
+# already lived) and QA -> general, both reserved, so both were discarded without
+# a word while --probe-prefix answered `development` / `qa` -- subdirs that
+# existed in no repo. Since a project CLAUDE.md typically tells agents to trust
+# the probe over their own assumption, the silence is what stranded the archive.
+# Resolution is unchanged; the shadowed row is now reported. These tests pin the
+# warning AND the untouched precedence.
+
+@test "T-SHADOW-WARN reserved prefix shadowed by a project row warns, resolution unchanged" {
+    cat > "$TMPROOT/CLAUDE.md" <<'EOF'
+# Test project
+
+## Task Prefix Registry
+
+| Prefix | Project | Archive Subdir |
+|--------|---------|----------------|
+| DEV | Test app | general |
+| QA | QA-only tasks | general |
+EOF
+    # Precedence is NOT inverted: the reserved runtime value still wins.
+    local stdout
+    stdout="$("$DOCTOR" --root="$TMPROOT" --probe-prefix=DEV 2>/dev/null)"
+    [ "$stdout" = "development" ]
+
+    # ...but the ignored project row is now surfaced, naming both sides.
+    run "$DOCTOR" --root="$TMPROOT" --probe-prefix=DEV
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"RESERVED"* ]]
+    [[ "$output" == *"IGNORED"* ]]
+    [[ "$output" == *"DEV"* ]]
+    [[ "$output" == *"general"* ]]
+
+    run "$DOCTOR" --root="$TMPROOT" --probe-prefix=QA
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"RESERVED"* ]]
+}
+
+@test "T-SHADOW-AGREE project row that agrees with the runtime warns nothing" {
+    # QCK -> quick in both tables. Agreement is not a conflict; stay quiet or the
+    # warning becomes noise every project learns to ignore.
+    cat > "$TMPROOT/CLAUDE.md" <<'EOF'
+## Task Prefix Registry
+
+| Prefix | Project | Archive Subdir |
+|--------|---------|----------------|
+| QCK | Fast lane | quick |
+EOF
+    run "$DOCTOR" --root="$TMPROOT" --probe-prefix=QCK
+    [ "$status" -eq 0 ]
+    [ "$output" = "quick" ]
+    [[ "$output" != *"RESERVED"* ]]
+}
+
+@test "T-SHADOW-NONRESERVED non-reserved project prefix resolves with no warning" {
+    # The intended extension point: a prefix the runtime does not reserve.
+    cat > "$TMPROOT/CLAUDE.md" <<'EOF'
+## Task Prefix Registry
+
+| Prefix | Project | Archive Subdir |
+|--------|---------|----------------|
+| OPS | Ops tasks | general |
+EOF
+    run "$DOCTOR" --root="$TMPROOT" --probe-prefix=OPS
+    [ "$status" -eq 0 ]
+    [ "$output" = "general" ]
+    [[ "$output" != *"RESERVED"* ]]
+}
+
+@test "T-SHADOW-QUIET no project registry at all → runtime value, no warning" {
+    run "$DOCTOR" --root="$TMPROOT" --probe-prefix=DEV
+    [ "$status" -eq 0 ]
+    [ "$output" = "development" ]
+    [[ "$output" != *"RESERVED"* ]]
+}
+
+@test "T-SHADOW-UNSAFE malformed shadow row is rejected, never echoed" {
+    cat > "$TMPROOT/CLAUDE.md" <<'EOF'
+## Task Prefix Registry
+
+| Prefix | Project | Archive Subdir |
+|--------|---------|----------------|
+| DEV | Evil | ../../etc |
+EOF
+    # bats `run` merges stderr into $output and the rejection WARN quotes the
+    # offending value, so assert on stdout alone.
+    local stdout
+    stdout="$("$DOCTOR" --root="$TMPROOT" --probe-prefix=DEV 2>/dev/null)"
+    [[ "$stdout" != *".."* ]]
+    [ "$stdout" = "development" ]
+    # No RESERVED warning here: the unsafe row is refused inside the lookup, so
+    # there is no surviving shadow value to report as ignored.
+    run "$DOCTOR" --root="$TMPROOT" --probe-prefix=DEV
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"../../etc"* ]]
+}

--- a/tests/test-prefix-claude-md-lookup.bats
+++ b/tests/test-prefix-claude-md-lookup.bats
@@ -151,7 +151,13 @@ EOF
 | INFRA | Trying to override | overridden |
 EOF
     cd "$TMPROOT"
+    # Resolution contract is unchanged: the reserved runtime prefix wins.
+    # DEV-1790 follow-up added a WARN naming the ignored row; bats `run` merges
+    # stderr into $output, so assert the resolved value on stdout alone.
+    local stdout
+    stdout="$("$DOCTOR" --probe-prefix=INFRA 2>/dev/null)"
+    [ "$stdout" = "infrastructure" ]
     run "$DOCTOR" --probe-prefix=INFRA
     [ "$status" -eq 0 ]
-    [ "$output" = "infrastructure" ]
+    [[ "$output" == *"IGNORED"* ]]
 }


### PR DESCRIPTION
## Problem

`datarim-doctor.sh --probe-prefix=DEV` answered `development` in a consumer workspace where `documentation/archive/development/` did not exist — the project's CLAUDE.md mapped `DEV → general`, and that is where its entire archive corpus already lived.

## Why the resolution itself was correct

TUNE-0030 deliberately reserves a stack-agnostic prefix namespace: a project may **add** prefixes but may not **redefine** a reserved one (`T-PFX-10`, "area-prefix-wins-over-shadow"). The consumer's registry declared three reserved prefixes, so `DEV → general` was correctly discarded.

**This PR does not change that precedence.**

## The actual defect: the discard was silent

A project CLAUDE.md typically instructs agents to resolve the archive subdir via the probe *"rather than assuming"*. So an obedient agent creates a stray `archive/development/` tree and strands the archive outside the corpus that later prior-art greps search. It was caught only because the archivist cross-checked the registry table against the filesystem instead of trusting the tool.

## Change

`prefix_to_area` now reports a shadowed row, naming both the reserved value and the ignored project value, so the project can rename its prefix (the real fix) rather than believe a mapping that never applied.

- Agreement between the two tables stays **quiet** — otherwise the warning becomes noise every project learns to ignore.
- The shadow lookup is guarded with `|| true`: it exits non-zero in the common no-registry case and would otherwise abort under `set -euo pipefail`.

## Tests

5 new cases in `datarim-doctor.bats` pinning the warning, the unchanged precedence, the quiet-on-agreement path, the non-reserved extension point, and path-traversal rejection.

- **Mutation-checked:** removing the warning fails a case in each suite.
- `T-PFX-10` keeps its contract — it now asserts the resolved value on stdout, since bats `run` merges the new stderr WARN into `$output`.
- Full suite: identical failure set before and after — none introduced, none masked.