### PR TITLE
pre-archive: make the schema gate reachable, and stop the indent bypass

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -12,6 +12,14 @@ description = "Synthetic secrets in security test fixtures (not real credentials
 # assert it is rejected. The fake key is part of the test contract, not a leak.
 paths = [
   '''tests/test-fleet-evolution-gates\.bats''',
+  # Audit-log fixture: a recorded CLI invocation carrying a placeholder
+  # `Authorization: Bearer` header against `svc.example.com` (RFC 2606
+  # documentation domain). The default `curl-auth-header` rule matches the
+  # header SHAPE regardless of the value, so the placeholder trips it. The file
+  # is not on main — it exists only on two abandoned `rescue/INFRA-0394/*`
+  # branches — but CI scans `--log-opts="--all"`, so every ref is in scope and
+  # any PR opened while those branches exist inherits the finding.
+  '''tests/fixtures/fleet-evolution/audit/cli-audit-fixture\.jsonl''',
 ]
 # Belt-and-suspenders: the specific synthetic key literal used in fixtures.
 regexes = [

--- a/scripts/datarim-doctor.sh
+++ b/scripts/datarim-doctor.sh
@@ -1518,7 +1518,10 @@ EMITTED_COUNT=0
 for f in "$ROOT_ABS/tasks.md" "$ROOT_ABS/backlog.md" "$ROOT_ABS/activeContext.md"; do
     [ -f "$f" ] || continue
     # count compound IDs too (PREFIX-NNNN-FOLLOWUP-slug shape).
-    n=$(grep -cE '^- [A-Z]{2,10}-[0-9]{4}(-[A-Za-z0-9]+)* · ' "$f" 2>/dev/null || true)
+    # Leading whitespace tolerated: indented bullets are real ledger rows, and a
+    # flush-left-only count under-reports EMITTED, which would fire the data-loss
+    # restore below on a migration that actually lost nothing.
+    n=$(grep -cE '^[[:space:]]*- [A-Z]{2,10}-[0-9]{4}(-[A-Za-z0-9]+)* · ' "$f" 2>/dev/null || true)
     EMITTED_COUNT=$((EMITTED_COUNT + n))
 done
 

--- a/scripts/pre-archive-check.sh
+++ b/scripts/pre-archive-check.sh
@@ -154,7 +154,14 @@ check_schema_compliance() {
         # anchor from $re when composing with the `N:` prefix from grep -n.
         local re_no_anchor="${re#^}"
         local bad
-        bad=$(grep -nE '^- [A-Z]+-[0-9]+' "$fp" 2>/dev/null \
+        # Anchor tolerates leading whitespace: an indented bullet is still a
+        # ledger row, and `^-` silently exempted it from the schema. That is a
+        # gate bypass, not a fix -- nudging rows right would turn the gate green
+        # while leaving them unvalidated. The canonical regex is applied to the
+        # line with its indent stripped, so indented rows are held to the same
+        # shape without being rewritten here.
+        bad=$(grep -nE '^[[:space:]]*- [A-Z]+-[0-9]+' "$fp" 2>/dev/null \
+              | sed -E 's/^([0-9]+):[[:space:]]+- /\1:- /' \
               | grep -vE "^[0-9]+:$re_no_anchor" || true)
         # Also flag legacy block-style headings (### TASK-ID:).
         local legacy_blocks
@@ -523,14 +530,24 @@ for repo in "$@"; do
     fi
 done
 
+# Schema-compliance gate (TUNE-0071): run on every repo that has datarim/,
+# BEFORE the dirty-repo branch and independent of it.
+#
+# This gate used to live inside the clean-case branch below, which made it
+# unreachable whenever ANY passed repo had uncommitted changes — the normal
+# state of a multi-repo workspace. A non-compliant ledger row therefore stayed
+# invisible indefinitely: the operator saw only "BLOCKED: N repo(s) have
+# uncommitted changes", a different and unrelated message, and concluded the
+# schema was fine. Ledger shape does not depend on worktree cleanliness, so
+# neither should the check.
+for repo in "$@"; do
+    if ! check_schema_compliance "$repo"; then
+        exit 1
+    fi
+done
+
 # Clean case → silent success.
 if [ "${#dirty_repos[@]}" -eq 0 ]; then
-    # Schema-compliance gate (TUNE-0071): run on every repo that has datarim/.
-    for repo in "$@"; do
-        if ! check_schema_compliance "$repo"; then
-            exit 1
-        fi
-    done
     echo "OK: $# repo(s) clean — archive may proceed" >&2
     exit 0
 fi

--- a/tests/pre-archive-check.bats
+++ b/tests/pre-archive-check.bats
@@ -839,3 +839,54 @@ EOF
     [ "$status" -eq 1 ]
     [[ "$output" == *"backlog-archive.md"* ]]
 }
+
+# ---------- schema gate reachability + indent anchor (DEV-1790 follow-up) ----
+
+# Two independent bypasses let non-compliant ledger rows accumulate unseen:
+#
+#  1. The schema gate lived INSIDE the clean-case branch, so any repo with
+#     uncommitted changes -- the normal state of a multi-repo workspace -- exited
+#     down the dirty path without ever calling it. The operator saw only
+#     "BLOCKED: N repo(s) have uncommitted changes", an unrelated message, and
+#     concluded the schema was fine.
+#  2. The violation scan anchored at `^-`, so an INDENTED bullet was exempt.
+#     That is a bypass, not a fix: nudging rows right turns the gate green while
+#     leaving them unvalidated.
+
+@test "schema gate runs even when the repo is dirty (gate reachability)" {
+    local repo="$BATS_TEST_TMPDIR/repo1"
+    make_clean_repo "$repo"
+    mkdir -p "$repo/datarim"
+    printf -- '- BADROW-9999 not a schema-compliant row\n' > "$repo/datarim/backlog.md"
+    git -C "$repo" add -A && git -C "$repo" commit --quiet -m ledger
+    make_dirty "$repo" untracked
+
+    run "$SCRIPT" "$repo"
+    [ "$status" -eq 1 ]
+    # The schema violation must surface, not be masked by the dirty-repo notice.
+    [[ "$output" == *"Schema-compliance gate failed"* ]]
+}
+
+@test "indented ledger row is held to the schema (no indent bypass)" {
+    local repo="$BATS_TEST_TMPDIR/repo1"
+    make_clean_repo "$repo"
+    mkdir -p "$repo/datarim"
+    printf -- '  - BADROW-8888 indented, still a ledger row\n' > "$repo/datarim/backlog.md"
+    git -C "$repo" add -A && git -C "$repo" commit --quiet -m ledger
+
+    run "$SCRIPT" "$repo"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Schema-compliance gate failed"* ]]
+}
+
+@test "valid indented ledger row still passes (no false positive)" {
+    local repo="$BATS_TEST_TMPDIR/repo1"
+    make_clean_repo "$repo"
+    mkdir -p "$repo/datarim"
+    printf -- '- DEV-1234 · pending · P2 · L1 · Flush-left row\n  - DEV-5678 · pending · P3 · L2 · Indented row\n' \
+        > "$repo/datarim/backlog.md"
+    git -C "$repo" add -A && git -C "$repo" commit --quiet -m ledger
+
+    run "$SCRIPT" "$repo"
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Problem

A workspace was found carrying **24 non-compliant ledger rows** while `pre-archive-check.sh` reported nothing. Two independent bypasses explain it.

### 1. The gate was unreachable in practice

`check_schema_compliance` was called only *inside* the `dirty_repos`-empty branch. Any repo with uncommitted changes — the normal state of a multi-repo workspace — exits down the dirty path and never reaches it.

The operator sees `BLOCKED: N repo(s) have uncommitted changes` — a different, unrelated message — and reasonably concludes the schema is fine.

Reproduced: identical bad row, clean repo → gate fires; add one untracked file → gate silently skipped.

Ledger shape does not depend on worktree cleanliness, so the check is hoisted ahead of the dirty-repo branch and now runs unconditionally.

### 2. `^-` exempted indented rows

The violation scan anchored at `^-`, so an indented bullet was invisible to it. That is a **gate bypass, not a fix** — nudging rows right would turn the gate green while leaving them unvalidated.

The scan now matches `^[[:space:]]*-` and strips the indent before applying the canonical regex, so indented rows are held to the same shape without being rewritten.

### Also

The doctor's `EMITTED_COUNT` data-loss counter carried the same flush-left-only anchor. There it *under-reports* rather than under-validates — which would fire the restore-from-backup path on a migration that lost nothing — so it is widened too.

## Tests

3 new cases: gate reachability under a dirty repo, the indent bypass, and **the absence of a false positive on a VALID indented row**.

Each fix mutation-tested **separately**:
- reverting the hoist → fails only the reachability case
- reverting the anchor → fails only the indent case

124 assertions green across `pre-archive-check`, `datarim-doctor`, `test-prefix-claude-md-lookup`.