### PR TITLE
fix(archive): keep shared-mode schema gate reachable

### DIFF
--- a/scripts/pre-archive-check.sh
+++ b/scripts/pre-archive-check.sh
@@ -465,11 +465,16 @@ if [ -n "$SHARED_REPO" ]; then
         printf '%s\t%s\t%s\n' "$file" "$klass" "$found_ids"
     done < <(git -C "$SHARED_REPO" status --porcelain --untracked-files=all 2>/dev/null)
 
+    # Schema-compliance is independent of hunk ownership. Run it before any
+    # shared-mode return so an own, mixed, or unattributed dirty file cannot
+    # hide a malformed tasks/backlog ledger. Keep classification first so a
+    # caller still receives the per-file disposition alongside the schema
+    # failure instead of losing a useful shared-workspace diagnostic.
+    if ! check_schema_compliance "$SHARED_REPO"; then
+        exit 1
+    fi
+
     if [ "$block" -eq 0 ]; then
-        # Schema-compliance gate (TUNE-0071) runs after clean-git success.
-        if ! check_schema_compliance "$SHARED_REPO"; then
-            exit 1
-        fi
         if [ "$saw_foreign" -eq 1 ]; then
             echo "OK: shared repo has foreign-only hunks — archive may proceed" >&2
         else

--- a/tests/pre-archive-check.bats
+++ b/tests/pre-archive-check.bats
@@ -224,6 +224,17 @@ modify_with_task_id() {
     [[ "$output" == *"unattributed"* ]]
 }
 
+@test "shared mode: own dirty hunk does not bypass schema-compliance gate" {
+    make_clean_repo "$BATS_TEST_TMPDIR/ws"
+    make_workflow_file "$BATS_TEST_TMPDIR/ws" "datarim/tasks.md" "- TUNE-0044 malformed row"
+    make_workflow_file "$BATS_TEST_TMPDIR/ws" "datarim/notes.md" "# notes"
+    echo "TUNE-0044 own dirty hunk" >> "$BATS_TEST_TMPDIR/ws/datarim/notes.md"
+    run "$SCRIPT" --task-id TUNE-0044 --shared "$BATS_TEST_TMPDIR/ws"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"Schema-compliance gate failed."* ]] \
+        && [[ "$output" == *"datarim/tasks.md"* ]]
+}
+
 # ---------- TUNE-0291 --allow-foreign-untracked (shared multi-agent workspace) ----------
 #
 # Founding incident: TUNE-0286 /dr-archive hit 23 foreign untracked files
@@ -683,12 +694,12 @@ EOF
 @test "shared mode: index-file body has many TASK-IDs + own diff line → column 3 = own only (TUNE-0084)" {
     make_marker_repo "$BATS_TEST_TMPDIR/fw"
     make_workflow_file "$BATS_TEST_TMPDIR/fw" "datarim/tasks.md" "# Tasks
-- TRANS-0021 · in_progress · P1 · L3 · Transcribator
-- LTM-0017 · in_progress · P2 · L2 · Long-Term Memory
-- VERD-0026 · in_progress · P1 · L3 · Verdicus
-- DEV-1212 · in_progress · P2 · L2 · Dev tooling
-- INFRA-0040 · in_progress · P1 · L3 · Infra"
-    echo "- TUNE-0084 · in_progress · P3 · L2 · diff-only classification" \
+- TRANS-0021 · in_progress · P1 · L3 · Transcribator → tasks/TRANS-0021-task-description.md
+- LTM-0017 · in_progress · P2 · L2 · Long-Term Memory → tasks/LTM-0017-task-description.md
+- VERD-0026 · in_progress · P1 · L3 · Verdicus → tasks/VERD-0026-task-description.md
+- DEV-1212 · in_progress · P2 · L2 · Dev tooling → tasks/DEV-1212-task-description.md
+- INFRA-0040 · in_progress · P1 · L3 · Infra → tasks/INFRA-0040-task-description.md"
+    echo "- TUNE-0084 · in_progress · P3 · L2 · diff-only classification → tasks/TUNE-0084-task-description.md" \
         >> "$BATS_TEST_TMPDIR/fw/datarim/tasks.md"
     run "$SCRIPT" --task-id TUNE-0084 --shared "$BATS_TEST_TMPDIR/fw"
     [ "$status" -eq 1 ]
@@ -726,8 +737,8 @@ EOF
     make_marker_repo "$BATS_TEST_TMPDIR/fw"
     make_workflow_file "$BATS_TEST_TMPDIR/fw" "datarim/backlog.md" "# Backlog"
     {
-        echo "- TUNE-0084 · pending · own line"
-        echo "- TRANS-0021 · pending · foreign line"
+        echo "- TUNE-0084 · pending · P3 · L2 · own line"
+        echo "- TRANS-0021 · pending · P1 · L2 · foreign line"
     } >> "$BATS_TEST_TMPDIR/fw/datarim/backlog.md"
     run "$SCRIPT" --task-id TUNE-0084 --shared "$BATS_TEST_TMPDIR/fw"
     [ "$status" -eq 1 ]


### PR DESCRIPTION
TUNE-0592 continuation: run the existing schema gate after shared-mode hunk classification and before every return. Explicit --no-schema-check remains. Verification: 56/56 Bats, bash -n, mutation red/green, diff-check.