### PR TITLE
docs: record v2.66.1 release audit

### DIFF
--- a/documentation/release-audit/release-2.66.1.md
+++ b/documentation/release-audit/release-2.66.1.md
@@ -1,0 +1,11 @@
+- release: 2.66.1
+  registry: gh
+  bump_level: patch
+  gates_passed: G0,G1,G2,G3,G4,G5,G6
+  rationale: |-
+    bump_level=patch
+    api_diff=unavailable
+    zero_x=false
+    escalate=false
+    rationale=range v2.66.0..HEAD: highest Conventional-Commits bump=patch, api_diff=unavailable, zero_x=false
+  timestamp: 2026-08-13T16:27:00Z


### PR DESCRIPTION
Persist the release-gate audit record for the signed, attested v2.66.1 publication.