### PR TITLE
fix(autonomy): enforce hard-gated actions in core resolver

### DIFF
--- a/dev-tools/lib/space-autonomy.sh
+++ b/dev-tools/lib/space-autonomy.sh
@@ -114,6 +114,8 @@ _autonomy_rules() {
   # plugin. Override by setting DR_AUTONOMY_RULES to an absolute path.
   local rules="${DR_AUTONOMY_RULES:-${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/rules/fb-rules.yaml}"
   [[ -n "$rules" && -s "$rules" ]] || return 1
+  yq eval -e '.hard_gated_actions | type == "!!seq" and length > 0' "$rules" >/dev/null 2>&1 \
+    || return 1
   yq eval -e '.always_gated_floor | type == "!!seq" and length > 0' "$rules" >/dev/null 2>&1 \
     || return 1
   yq eval -e '.action_autonomy_map | type == "!!map" and length > 0' "$rules" >/dev/null 2>&1 \
@@ -167,7 +169,7 @@ _autonomy_policy_decision() {
 }
 
 autonomy_decision() {
-  local action="$1" payload="${2:-"{}"}" rules effective floor_hit
+  local action="$1" payload="${2:-"{}"}" rules effective floor_hit hard_gate_hit
   jq -e 'type == "object"' <<<"$payload" >/dev/null 2>&1 || payload='{}'
   effective="$(_autonomy_effective_kind "$action" "$payload")"
   rules="$(_autonomy_rules 2>/dev/null || true)"
@@ -181,6 +183,16 @@ autonomy_decision() {
     | jq --arg kind "$effective" 'index($kind) != null')"
   if [[ "$floor_hit" == true ]]; then
     _autonomy_operator "$action" "$effective" always_gated_floor true
+    return 10
+  fi
+  hard_gate_hit="$(yq eval -o=json '.hard_gated_actions' "$rules" \
+    | jq --arg action "$action" --arg effective "$effective" \
+      'index($action) != null or index($effective) != null')"
+  if [[ "$hard_gate_hit" == true ]]; then
+    _autonomy_json --arg action "$action" --arg effective "$effective" \
+      '{schema_version:1,action_kind:$action,effective_action_kind:$effective,
+        decision:"operator",floor_hit:false,hard_gate_hit:true,
+        precedence_layer:"P1",reason_code:"hard_gated_action"}'
     return 10
   fi
   if [[ "$action" == public_package_release ]] \

--- a/plugins/dr-orchestrate/tests/test_action_gate.bats
+++ b/plugins/dr-orchestrate/tests/test_action_gate.bats
@@ -19,6 +19,7 @@ autonomy:
     cross_project_write: auto
 YAML
   cat > "$DR_AUTONOMY_RULES" <<'YAML'
+hard_gated_actions: [secret_rotation]
 always_gated_floor: [finance_action]
 action_autonomy_map:
   framework_command: cross_project_write

--- a/plugins/dr-orchestrate/tests/test_rule_first_resolution.bats
+++ b/plugins/dr-orchestrate/tests/test_rule_first_resolution.bats
@@ -52,6 +52,7 @@ autonomy:
     cross_project_write: auto
 YAML
   cat > "$DR_AUTONOMY_RULES" <<'YAML'
+hard_gated_actions: [secret_rotation]
 always_gated_floor: [finance_action]
 action_autonomy_map:
   framework_command: cross_project_write

--- a/tests/space-autonomy.bats
+++ b/tests/space-autonomy.bats
@@ -53,6 +53,8 @@ autonomy:
 YAML
 
   cat > "$RULES_FILE" <<'YAML'
+hard_gated_actions:
+  - secret_rotation
 always_gated_floor:
   - finance_action
   - legal_action
@@ -111,6 +113,14 @@ gate() {
     && [ "$(jq -r '.space' <<<"$output")" = arcanada ]
 }
 
+@test "secret rotation hard gate overrides an auto space policy" {
+  gate arcanada secret_rotation
+  [ "$status" -eq 10 ] \
+    && [ "$(jq -r '.decision' <<<"$output")" = operator ] \
+    && [ "$(jq -r '.hard_gate_hit' <<<"$output")" = true ] \
+    && [ "$(jq -r '.reason_code' <<<"$output")" = hard_gated_action ]
+}
+
 @test "commit-dropping force push is always gated" {
   gate arcanada force_push '{"drops_commits":true}'
   [ "$status" -eq 10 ] \
@@ -166,6 +176,13 @@ gate() {
 @test "missing immutable floor is an invariant error" {
   yq -i 'del(.always_gated_floor)' "$RULES_FILE"
   gate arcanada merge_main
+  [ "$status" -eq 2 ] \
+    && [ "$(jq -r '.reason_code' <<<"$output")" = invalid_rules ]
+}
+
+@test "missing hard-gate list is an invariant error" {
+  yq -i 'del(.hard_gated_actions)' "$RULES_FILE"
+  gate arcanada secret_rotation
   [ "$status" -eq 2 ] \
     && [ "$(jq -r '.reason_code' <<<"$output")" = invalid_rules ]
 }


### PR DESCRIPTION
## Summary
- enforce the tracked `hard_gated_actions` list before per-space autonomy policy
- fail closed when the hard-gate list is missing or malformed
- add regression coverage proving `secret_rotation` cannot resolve to `auto`

## Verification
- `bats tests/space-autonomy.bats tests/test-fb-policy-core-resolution.bats tests/check-dr-auto-cross-runtime.bats` (44/44)
- `shellcheck --severity=warning dev-tools/lib/space-autonomy.sh`
- `dev-tools/check-dr-auto-cross-runtime.sh --check`

Closes the resolver drift found while reconciling SEC-0041.