### PR TITLE
fix: preserve init task when source read fails

### DIFF
--- a/dev-tools/append-init-task-qa.sh
+++ b/dev-tools/append-init-task-qa.sh
@@ -20,7 +20,7 @@
 #   1 — validation / I/O error
 #   2 — usage error
 
-set -uo pipefail
+set -euo pipefail
 
 VERSION="1.0.0"
 SCRIPT_NAME="append-init-task-qa.sh"

--- a/dev-tools/append-init-task-qa.sh
+++ b/dev-tools/append-init-task-qa.sh
@@ -20,7 +20,7 @@
 #   1 — validation / I/O error
 #   2 — usage error
 
-set -euo pipefail
+set -uo pipefail
 
 VERSION="1.0.0"
 SCRIPT_NAME="append-init-task-qa.sh"
@@ -47,7 +47,7 @@ TMP_FILE=""
 
 cleanup() {
     if [ -n "$TMP_FILE" ] && [ -e "$TMP_FILE" ]; then
-        rm -f "$TMP_FILE"
+        rm -f "$TMP_FILE" || true
     fi
     if [ -n "$LOCK_DIR" ] && [ -d "$LOCK_DIR" ]; then
         rmdir "$LOCK_DIR" 2>/dev/null || true
@@ -222,13 +222,30 @@ fi
 
 TMP_FILE="$(mktemp "$TASKS_DIR_ABS/.${TASK_ID}.qa.append.XXXXXX")"
 
+if ! QUESTION_CONTENT="$(cat "$QUESTION_FILE")"; then
+    fail_io "failed to read --question-file: $QUESTION_FILE"
+fi
+if ! ANSWER_CONTENT="$(cat "$ANSWER_FILE")"; then
+    fail_io "failed to read --answer-file: $ANSWER_FILE"
+fi
+RATIONALE_CONTENT=""
+if [ -n "$RATIONALE_FILE" ] && ! RATIONALE_CONTENT="$(cat "$RATIONALE_FILE")"; then
+    fail_io "failed to read --rationale-file: $RATIONALE_FILE"
+fi
+CONFLICT_DETAIL_CONTENT=""
+if [ -n "$CONFLICT_DETAIL_FILE" ] && ! CONFLICT_DETAIL_CONTENT="$(cat "$CONFLICT_DETAIL_FILE")"; then
+    fail_io "failed to read --conflict-detail-file: $CONFLICT_DETAIL_FILE"
+fi
+
 {
-    cat "$INIT_FILE"
+    if ! cat "$INIT_FILE"; then
+        fail_io "failed to read init-task file: $INIT_FILE"
+    fi
     printf '\n### %s — Q&A by /dr-%s (round %s)\n\n' "$TIMESTAMP" "$STAGE" "$ROUND"
     printf '**Question (verbatim, asked by %s):**\n\n' "$ASKED_BY"
-    printf '%s\n\n' "$(cat "$QUESTION_FILE")"
+    printf '%s\n\n' "$QUESTION_CONTENT"
     printf '**Answer (verbatim, by %s):**\n\n' "$DECIDED_BY"
-    printf '%s\n\n' "$(cat "$ANSWER_FILE")"
+    printf '%s\n\n' "$ANSWER_CONTENT"
     printf '**Decided by:** %s\n\n' "$DECIDED_BY"
     if [ -n "$RATIONALE_FILE" ]; then
         if [ "$DECIDED_BY" = "process-rule-artefact" ]; then
@@ -236,14 +253,14 @@ TMP_FILE="$(mktemp "$TASKS_DIR_ABS/.${TASK_ID}.qa.append.XXXXXX")"
         else
             printf '**Decision rationale:**\n\n'
         fi
-        printf '%s\n\n' "$(cat "$RATIONALE_FILE")"
+        printf '%s\n\n' "$RATIONALE_CONTENT"
     fi
     printf '**Summary (how it changes initial conditions):**\n\n'
     printf '%s\n\n' "$SUMMARY"
     if [ -n "$CONFLICT_WITH" ]; then
         if [ -n "$CONFLICT_DETAIL_FILE" ]; then
             printf '**Conflict with existing wish:** %s — %s\n\n' \
-                "$CONFLICT_WITH" "$(cat "$CONFLICT_DETAIL_FILE")"
+                "$CONFLICT_WITH" "$CONFLICT_DETAIL_CONTENT"
         else
             printf '**Conflict with existing wish:** %s — (see Summary)\n\n' "$CONFLICT_WITH"
         fi

--- a/tests/tune-0216-qa-roundtrip.bats
+++ b/tests/tune-0216-qa-roundtrip.bats
@@ -352,6 +352,7 @@ EOF
 
     [ "$status" -ne 0 ] \
         && [[ "$output" == *"simulated init-task read failure"* ]] \
+        && [[ "$output" == *"failed to read init-task file"* ]] \
         && cmp -s "$original" "$init_file" \
         && [ ! -d "$tasks_dir/.TEST-0206.qa-lock" ] \
         && [ -z "$(find "$tasks_dir" -maxdepth 1 -name '.TEST-0206.qa.append.*' -print)" ]
@@ -363,7 +364,8 @@ EOF
     local init_file="$tasks_dir/TEST-0207-init-task.md"
     local original="$TMPROOT/TEST-0207-init-task.original.md"
     local q="$TMPROOT/q.txt" a="$TMPROOT/a.txt"
-    local fake_bin="$TMPROOT/fake-bin" rm_log="$TMPROOT/rm-calls.log"
+    local fake_bin="$TMPROOT/fake-bin"
+    local rm_log="$TMPROOT/rm-calls.log" rmdir_log="$TMPROOT/rmdir-calls.log"
     cp "$init_file" "$original"
     echo "Q whose append must fail." > "$q"
     echo "A whose append must fail." > "$a"
@@ -385,13 +387,19 @@ if [ "$#" -eq 2 ] && [ "$1" = "-f" ] && [[ "$2" == "${RM_FAIL_PREFIX:?}"* ]]; th
 fi
 exec /bin/rm "$@"
 EOF
-    chmod +x "$fake_bin/cat" "$fake_bin/rm"
+    cat > "$fake_bin/rmdir" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${RMDIR_CALL_LOG:?}"
+exec /bin/rmdir "$@"
+EOF
+    chmod +x "$fake_bin/cat" "$fake_bin/rm" "$fake_bin/rmdir"
 
     run env \
         PATH="$fake_bin:$PATH" \
         CAT_FAIL_PATH="$init_file" \
         RM_CALL_LOG="$rm_log" \
         RM_FAIL_PREFIX="$tasks_dir/.TEST-0207.qa.append." \
+        RMDIR_CALL_LOG="$rmdir_log" \
         "$APPEND" \
         --root "$TMPROOT" \
         --task TEST-0207 --stage do --round 1 \
@@ -403,6 +411,7 @@ EOF
         && [[ "$output" == *"simulated init-task read failure"* ]] \
         && [[ "$output" == *"simulated temp cleanup failure"* ]] \
         && grep -qF "$tasks_dir/.TEST-0207.qa.append." "$rm_log" \
+        && grep -qF "$tasks_dir/.TEST-0207.qa-lock" "$rmdir_log" \
         && cmp -s "$original" "$init_file" \
         && [ ! -d "$tasks_dir/.TEST-0207.qa-lock" ]
 }

--- a/tests/tune-0216-qa-roundtrip.bats
+++ b/tests/tune-0216-qa-roundtrip.bats
@@ -207,6 +207,21 @@ EOF
     [[ "$output" == *"Usage"* ]] || [[ "$output" == *"usage"* ]]
 }
 
+@test "P2.0c utility reports usage error when any option value is missing" {
+    local option
+    for option in \
+        --root --task --stage --round \
+        --question-file --answer-file --decided-by --rationale-file \
+        --summary --asked-by --conflict-with --conflict-detail-file \
+        --timestamp; do
+        run "$APPEND" "$option"
+        if [ "$status" -ne 2 ]; then
+            echo "$option without a value returned $status, expected 2" >&2
+            return 1
+        fi
+    done
+}
+
 @test "P2.1 utility writes a valid Q&A block and validator passes" {
     write_base_init_task "TEST-0201"
     local q="$TMPROOT/q.txt" a="$TMPROOT/a.txt"
@@ -340,6 +355,56 @@ EOF
         && cmp -s "$original" "$init_file" \
         && [ ! -d "$tasks_dir/.TEST-0206.qa-lock" ] \
         && [ -z "$(find "$tasks_dir" -maxdepth 1 -name '.TEST-0206.qa.append.*' -print)" ]
+}
+
+@test "P2.7 cleanup removes the lock after temp cleanup itself fails" {
+    write_base_init_task "TEST-0207"
+    local tasks_dir="$TMPROOT/datarim/tasks"
+    local init_file="$tasks_dir/TEST-0207-init-task.md"
+    local original="$TMPROOT/TEST-0207-init-task.original.md"
+    local q="$TMPROOT/q.txt" a="$TMPROOT/a.txt"
+    local fake_bin="$TMPROOT/fake-bin" rm_log="$TMPROOT/rm-calls.log"
+    cp "$init_file" "$original"
+    echo "Q whose append must fail." > "$q"
+    echo "A whose append must fail." > "$a"
+    mkdir -p "$fake_bin"
+    cat > "$fake_bin/cat" <<'EOF'
+#!/usr/bin/env bash
+if [ "$#" -eq 1 ] && [ "$1" = "${CAT_FAIL_PATH:?}" ]; then
+    echo "simulated init-task read failure" >&2
+    exit 74
+fi
+exec /bin/cat "$@"
+EOF
+    cat > "$fake_bin/rm" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >> "${RM_CALL_LOG:?}"
+if [ "$#" -eq 2 ] && [ "$1" = "-f" ] && [[ "$2" == "${RM_FAIL_PREFIX:?}"* ]]; then
+    echo "simulated temp cleanup failure" >&2
+    exit 75
+fi
+exec /bin/rm "$@"
+EOF
+    chmod +x "$fake_bin/cat" "$fake_bin/rm"
+
+    run env \
+        PATH="$fake_bin:$PATH" \
+        CAT_FAIL_PATH="$init_file" \
+        RM_CALL_LOG="$rm_log" \
+        RM_FAIL_PREFIX="$tasks_dir/.TEST-0207.qa.append." \
+        "$APPEND" \
+        --root "$TMPROOT" \
+        --task TEST-0207 --stage do --round 1 \
+        --question-file "$q" --answer-file "$a" \
+        --decided-by operator \
+        --summary "Cleanup must continue after a failed temp removal."
+
+    [ "$status" -ne 0 ] \
+        && [[ "$output" == *"simulated init-task read failure"* ]] \
+        && [[ "$output" == *"simulated temp cleanup failure"* ]] \
+        && grep -qF "$tasks_dir/.TEST-0207.qa.append." "$rm_log" \
+        && cmp -s "$original" "$init_file" \
+        && [ ! -d "$tasks_dir/.TEST-0207.qa-lock" ]
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/tune-0216-qa-roundtrip.bats
+++ b/tests/tune-0216-qa-roundtrip.bats
@@ -304,6 +304,44 @@ EOF
     [ "$status" -eq 0 ]
 }
 
+@test "P2.6 utility preserves init-task when its source read fails" {
+    write_base_init_task "TEST-0206"
+    local tasks_dir="$TMPROOT/datarim/tasks"
+    local init_file="$tasks_dir/TEST-0206-init-task.md"
+    local original="$TMPROOT/TEST-0206-init-task.original.md"
+    local q="$TMPROOT/q.txt" a="$TMPROOT/a.txt"
+    local fake_bin="$TMPROOT/fake-bin"
+    cp "$init_file" "$original"
+    echo "Q whose append must fail." > "$q"
+    echo "A whose append must fail." > "$a"
+    mkdir -p "$fake_bin"
+    cat > "$fake_bin/cat" <<'EOF'
+#!/usr/bin/env bash
+if [ "$#" -eq 1 ] && [ "$1" = "${CAT_FAIL_PATH:?}" ]; then
+    echo "simulated init-task read failure" >&2
+    exit 74
+fi
+exec /bin/cat "$@"
+EOF
+    chmod +x "$fake_bin/cat"
+
+    run env \
+        PATH="$fake_bin:$PATH" \
+        CAT_FAIL_PATH="$init_file" \
+        "$APPEND" \
+        --root "$TMPROOT" \
+        --task TEST-0206 --stage do --round 1 \
+        --question-file "$q" --answer-file "$a" \
+        --decided-by operator \
+        --summary "This append must not replace an unreadable source."
+
+    [ "$status" -ne 0 ] \
+        && [[ "$output" == *"simulated init-task read failure"* ]] \
+        && cmp -s "$original" "$init_file" \
+        && [ ! -d "$tasks_dir/.TEST-0206.qa-lock" ] \
+        && [ -z "$(find "$tasks_dir" -maxdepth 1 -name '.TEST-0206.qa.append.*' -print)" ]
+}
+
 # ---------------------------------------------------------------------------
 # Phase 3 — Wire six pipeline commands
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- fail fast when any source read fails during atomic Q&A append
- preserve the existing init-task instead of replacing it with a partial file
- add a root-safe PATH `cat` shim regression covering exit status, byte preservation, and cleanup residue

## Verification

- `bash -n dev-tools/append-init-task-qa.sh`
- `shellcheck --severity=warning` across all tracked shell scripts
- focused Bats: 33/33 passing
- `bash tests/run-bats-discovery.sh`: 383/383 suites passing, 0 failed, 0 timeout
- `./validate.sh`: ALL CHECKS PASSED
