### PR TITLE
docs(TUNE-0581): land the bookkeeping the merged fix left behind

### DIFF
--- a/datarim/activeContext.md
+++ b/datarim/activeContext.md
@@ -3,3 +3,4 @@
 ## Active Tasks
 - TUNE-0579 · pending · P3 · L1 · Unblock the two stale-base PRs on the datarim-club-site repo → tasks/TUNE-0579-task-description.md
 - TUNE-0580 · pending · P3 · L1 · Return the shared site-repo working tree to a clean state → tasks/TUNE-0580-task-description.md
+- TUNE-0581 · completed · P1 · L1 · Prevent provision-release-env Bats hang on open stdin → tasks/TUNE-0581-task-description.md

--- a/datarim/tasks.md
+++ b/datarim/tasks.md
@@ -3,3 +3,4 @@
 ## Active
 - TUNE-0579 · pending · P3 · L1 · Unblock the two stale-base PRs on the datarim-club-site repo → tasks/TUNE-0579-task-description.md
 - TUNE-0580 · pending · P3 · L1 · Return the shared site-repo working tree to a clean state → tasks/TUNE-0580-task-description.md
+- TUNE-0581 · completed · P1 · L1 · Prevent provision-release-env Bats hang on open stdin → tasks/TUNE-0581-task-description.md

--- a/datarim/tasks/TUNE-0581-expectations.md
+++ b/datarim/tasks/TUNE-0581-expectations.md
@@ -1,0 +1,24 @@
+---
+task_id: TUNE-0581
+artifact: expectations
+schema_version: 2
+captured_at: 2026-08-15T18:35:00+03:00
+captured_by: /dr-init
+agent: planner
+status: canonical
+parent_init_task: TUNE-0581-init-task.md
+---
+
+# Operator Expectations — TUNE-0581
+
+- **1. The repeatable full-discovery timeout is diagnosed and fixed without affecting production behavior.**
+  - wish_id: diagnose-and-fix-provision-release-timeout
+  - What I want to verify: The deterministic test defect is reproduced, fixed through RED to GREEN, and delivered through a reviewed PR.
+  - How to verify (success criterion): An open-stdin regression test fails on the old fixture and passes after the fixture-only fix; focused and relevant full tests pass, and the merged production script blob is unchanged.
+  - Related PRD AC: "—"
+  - evidence_type: empirical
+  - #### Status history
+    - 2026-08-15T18:35:00+03:00 / 18:35 TRT · /dr-init · pending → pending · reason: item created during task initialization
+    - 2026-08-15T18:44:00+03:00 / 18:44 TRT · /dr-do · pending → met · reason: deterministic RED to GREEN, clean independent review, all CI gates green, and PR 380 merged
+  - #### Current status
+    - met

--- a/datarim/tasks/TUNE-0581-task-description.md
+++ b/datarim/tasks/TUNE-0581-task-description.md
@@ -1,0 +1,55 @@
+---
+id: TUNE-0581
+title: Prevent provision-release-env Bats hang on open stdin
+status: completed
+priority: P1
+complexity: L1
+type: bugfix
+project: Datarim
+started: 2026-08-15
+parent: null
+related: []
+prd: null
+plan: null
+---
+
+## Overview
+
+`tests/provision-release-env.bats` mocks `gh` such that the mock reads stdin whenever stdin is non-TTY, even for read-only GH policy GET calls that pass no request body. When Bats inherits an open non-TTY stdin, the mock blocks waiting for input, and full discovery hits the 600-second per-suite ceiling.
+
+The required fix is test-fixture-only: the mock must read stdin only for calls carrying `--input -`. Production `provision-release-env.sh` behavior must remain unchanged.
+
+## Acceptance Criteria
+
+- [x] AC-1: A deterministic RED test using an open stdin reproduces the blocking behavior in the current fixture before the fix.
+- [x] AC-2: After the fix, the `gh` mock reads stdin only when the invocation includes `--input -`.
+- [x] AC-3: Read-only GH policy GET calls, which pass no request body, complete without reading stdin and without hanging.
+- [x] AC-4: Production `provision-release-env.sh` behavior is preserved.
+- [x] AC-5: Verification includes focused Bats, full discovery or shard, bash syntax/shellcheck as applicable, CI, independent review, PR, and merge.
+
+## Constraints
+
+- The fix is limited to test fixtures used by `tests/provision-release-env.bats`.
+- No production `provision-release-env.sh` changes are introduced.
+- The mock `gh` behavior for invocations with `--input -` remains compatible with existing tests.
+
+## Out of Scope
+
+- Modifying production `provision-release-env.sh`.
+- Changing GH API policy or request behavior.
+- General non-TTY stdin handling outside the relevant Bats fixture.
+- Unrelated discovery or performance changes beyond preventing the hang.
+
+## Related
+
+- Parent incident: none; discovered during the post-merge full-discovery run for PR #379.
+
+## Implementation Notes
+
+- Locate the stdin read path in the `gh` mock and guard it so it runs only when `--input -` is present.
+- Ensure mock calls without `--input -` do not read stdin and return immediately.
+- Use the deterministic open-stdin RED case first, then apply the fixture-only change and confirm green.
+- Validate with focused Bats tests, then full discovery or shard, syntax/shellcheck checks as applicable, CI, independent review, PR, and merge.
+- Delivered by PR #380, squash merge `f71490f283c067a796874a27fc5bd307e1ef4003`.
+- Evidence: RED regression failed at the bounded timeout; focused Bats 14/14; local discovery shard 7/8 passed 48/48 with zero timeouts; GitHub CI passed all eight shards and all required checks.
+- Exact blob verification: merged test blob `fdab7ac0bbd9380b9c29124595a87aad44995490`; production script blob remained `9152319daf670683b5dc8b885a436e67d7b334bb`.


### PR DESCRIPTION
Clears a stale tail found while cleaning the shared workspace before a new project starts.

## What landed vs what did not

The **fix** shipped on 2026-08-15 as PR #380 (squash `f71490f2`). The **bookkeeping** did not: the task description, the operator expectations, and the two ledger lines marking it completed have been sitting uncommitted in the working tree since.

## Verified against real blobs

An archived task is not proof of landing, so I checked the record's claims against the repository rather than trusting them:

| Claim | Result |
|---|---|
| merge commit `f71490f2` | present, ancestor of `main` |
| test blob `fdab7ac0` | matches `origin/main:tests/provision-release-env.bats` |
| production blob `9152319d` | matches `origin/main:dev-tools/provision-release-env.sh` |

All three verify. The production blob being **unchanged** is the substance of the task: the hang was a fixture defect. The `gh` mock read stdin on every non-TTY invocation, including read-only GET calls that carry no request body, so Bats blocked until the 600-second per-suite ceiling. The fix scoped the stdin read to invocations passing `--input -`.

## Notes

- No `init-task` file is included. `datarim/tasks/*-init-task.md` is gitignored (`.gitignore:93`), so its absence upstream is by design, not a missing artifact.
- Purely additive: `git diff --numstat` reports `1 0` on both ledgers, zero deletions.

## Also cleaned locally (no diff here)

The checkout was 5 commits behind, so 20 files read as local modifications while being byte-identical to `origin/main`, and 5 more read as untracked while already tracked upstream. Committing those in bulk would have reverted PRs #382–#384 — including `df791c0`, which deliberately stopped shipping the execution-host guard. Those were reset to origin rather than committed; only the four files above were genuinely new.