### PR TITLE
fix: fan out Flash-only coworker guidance

### DIFF
--- a/templates/coworker-delegation-fragment.md
+++ b/templates/coworker-delegation-fragment.md
@@ -104,8 +104,10 @@ extract-chat    [path/to/session.jsonl -o out.txt]   # default: newest for cwd
 
 Profiles: `doc-read` (literal documentation extraction/summarization,
 DeepSeek v4-flash), `classifier` (short routing/classification, DeepSeek
-v4-flash), `datarim-write` (schema-aware Datarim drafts, DeepSeek v4-pro),
-and `write` (generic meaningful file generation, DeepSeek v4-pro). Legacy
+v4-flash), `datarim-write` (schema-aware Datarim drafts, DeepSeek v4-flash),
+and `write` (generic meaningful file generation, DeepSeek v4-flash). Enabled
+automatic profiles have no cross-provider fallback: exhausted retries fail
+loud. Explicit CLI provider/model flags remain manual operator overrides. Legacy
 `code`, `codex`, `datarim`, and `social` profiles are fail-closed in Arcanada
 runtime config; do not use them as defaults.
 

--- a/templates/coworker-delegation.mdc
+++ b/templates/coworker-delegation.mdc
@@ -22,8 +22,10 @@ CLI binary: `~/.local/bin/coworker`. Four subcommands:
 
 Profiles: `doc-read` (literal documentation extraction/summarization,
 DeepSeek v4-flash), `classifier` (short routing/classification, DeepSeek
-v4-flash), `datarim-write` (schema-aware Datarim drafts, DeepSeek v4-pro),
-and `write` (generic meaningful file generation, DeepSeek v4-pro). Legacy
+v4-flash), `datarim-write` (schema-aware Datarim drafts, DeepSeek v4-flash),
+and `write` (generic meaningful file generation, DeepSeek v4-flash). Enabled
+automatic profiles have no cross-provider fallback: exhausted retries fail
+loud. Explicit CLI provider/model flags remain manual operator overrides. Legacy
 `code`, `codex`, `datarim`, and `social` profiles are fail-closed in Arcanada
 runtime config; do not use them as defaults.
 

--- a/tests/coworker-flash-only.bats
+++ b/tests/coworker-flash-only.bats
@@ -1,0 +1,20 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
+    FRAGMENT="$REPO_ROOT/templates/coworker-delegation-fragment.md"
+    CURSOR="$REPO_ROOT/templates/coworker-delegation.mdc"
+}
+
+@test "coworker fanout templates declare all enabled profiles Flash-only" {
+    for file in "$FRAGMENT" "$CURSOR"; do
+        run grep -F "DeepSeek v4-pro" "$file"
+        [ "$status" -eq 1 ]
+
+        run grep -F "automatic profiles have no cross-provider fallback" "$file"
+        [ "$status" -eq 0 ]
+
+        run grep -F "manual operator overrides" "$file"
+        [ "$status" -eq 0 ]
+    done
+}


### PR DESCRIPTION
Summary:
- document Flash for all enabled coworker profiles
- state fail-loud no-fallback behavior and manual override boundary
- add template regression coverage

Verification:
- validate.sh PASS
- 47 of 47 focused bats checks pass

Task: TUNE-0595