### PR TITLE
fix: retire expired AAL acceptance

### DIFF
--- a/accepted-risk-aal.yml
+++ b/accepted-risk-aal.yml
@@ -20,7 +20,8 @@
 #   entries[].mandate_overridden:  path to mandate file
 #   entries[].mandate_ceiling:     integer (AAL level enforced by mandate)
 #   entries[].declared_level:      integer (level operator is opting into)
-#   entries[].scope:               list of strings (prd refs, cli_subcommands, …)
+#   entries[].scope:               exact strings; CLI mutations require
+#                                  cli_subcommand:<operation> membership
 #   entries[].mitigations:         list of strings (V-AC names)
 #   entries[].risk_summary:        free-text
 #   entries[].rollback:            string (one-line restore procedure)

--- a/accepted-risk-aal.yml
+++ b/accepted-risk-aal.yml
@@ -13,6 +13,7 @@
 #   entries[].id:                  string, kebab-case, unique
 #   entries[].title:               string
 #   entries[].accepted_at:         ISO-8601 date
+#   entries:                       list (may be empty when no override is active)
 #   entries[].expires:             ISO-8601 date, >= today
 #   entries[].review_required_by:  ISO-8601 date, == expires
 #   entries[].operator:            string (human handle / agent id)
@@ -26,34 +27,6 @@
 #
 schema_version: 1
 
-entries:
-  - id: tune-0268-aal3-cli
-    title: "Datarim CLI AAL 3 full autonomous — mandate override"
-    accepted_at: 2026-05-23
-    expires: 2026-08-21
-    review_required_by: 2026-08-21
-    operator: <operator-id>
-    mandate_overridden: documentation/mandates/aal-mandate.md
-    mandate_ceiling: 2
-    declared_level: 3
-    scope:
-      - "prd:PRD-TUNE-0268"
-      - "prd:PRD-TUNE-0271"
-      - "cli_subcommand:run"
-      - "cli_subcommand:audit halt"
-      - "cli_subcommand:audit resume"
-      - "cli_subcommand:audit purge"
-    mitigations:
-      - dual_channel_notifier_fail_closed
-      - jsonl_audit_log_with_flock
-      - kill_switch_sentinel_file
-      - bilingual_install_warning
-      - retention_90d_aligned_with_review
-    risk_summary: >
-      External AI agents driving Datarim pipeline via `datarim` CLI may
-      trigger irreversible actions (`/dr-archive`, `git push`, `tmux kill`,
-      `config set aal_*`) without interactive confirmation. The five
-      mitigations above ensure all such actions are observable in real
-      time (notifier) and reconstructable post-hoc (JSONL audit) with an
-      instant operator-controlled freeze mechanism (kill-switch).
-    rollback: "Remove this entry → CLI's invocation-time gate refuses AAL 3 actions (exit 23)."
+# No active AAL mandate overrides. Expired approvals are removed rather than
+# silently renewed; their audit history remains available in Git history.
+entries: []

--- a/cli/datarim
+++ b/cli/datarim
@@ -115,7 +115,7 @@ cmd_version() {
 requires_aal3_acceptance() {
     local sub="${1:-}" op="${2:-}" arg
     case "$sub:$op" in
-        run:*|tasks:move|tmux:attach|tmux:new|tmux:kill|audit:resume|audit:purge|plugin:enable|plugin:disable|plugin:sync)
+        run:*|tasks:move|backlog:add|tmux:attach|tmux:new|tmux:kill|audit:resume|audit:purge|plugin:enable|plugin:disable|plugin:sync)
             return 0
             ;;
         plugin:doctor)

--- a/cli/datarim
+++ b/cli/datarim
@@ -57,6 +57,8 @@ SUBCMD_DIR="$CLI_DIR/subcommands"
 . "$LIB_DIR/kill-switch.sh"
 # shellcheck source=cli/lib/agent-id.sh
 . "$LIB_DIR/agent-id.sh"
+# shellcheck source=cli/lib/accepted-risk-check.sh
+. "$LIB_DIR/accepted-risk-check.sh"
 
 # --- Dispatch -------------------------------------------------------------
 
@@ -110,12 +112,32 @@ cmd_version() {
     fi
 }
 
+requires_aal3_acceptance() {
+    local sub="${1:-}" op="${2:-}" arg
+    case "$sub:$op" in
+        run:*|tasks:move|tmux:attach|tmux:new|tmux:kill|audit:resume|audit:purge|plugin:enable|plugin:disable|plugin:sync)
+            return 0
+            ;;
+        plugin:doctor)
+            shift 2 || true
+            for arg in "$@"; do
+                [ "$arg" = "--fix" ] && return 0
+            done
+            ;;
+    esac
+    return 1
+}
+
 main() {
     # First line of every subcommand: kill-switch check (V-AC-6).
     check_kill_switch || exit $?
 
     local sub="${1:-help}"
     shift || true
+
+    if requires_aal3_acceptance "$sub" "$@"; then
+        aal_check TUNE-0268 || exit $?
+    fi
 
     case "$sub" in
         version|--version|-V)

--- a/cli/datarim
+++ b/cli/datarim
@@ -137,7 +137,7 @@ effective_order_independent_operation() {
     printf '%s' "$op"
 }
 
-requires_aal3_acceptance() {
+required_aal3_scope() {
     local sub="${1:-}" op arg
     shift || true
     case "$sub" in
@@ -145,12 +145,23 @@ requires_aal3_acceptance() {
         *) op="${1:-}" ;;
     esac
     case "$sub:$op" in
-        run:*|tasks:move|backlog:add|tmux:attach|tmux:new|tmux:kill|audit:resume|audit:purge|plugin:enable|plugin:disable|plugin:sync)
-            return 0
-            ;;
+        run:*)          printf '%s\n' 'cli_subcommand:run'; return 0 ;;
+        tasks:move)     printf '%s\n' 'cli_subcommand:tasks move'; return 0 ;;
+        backlog:add)    printf '%s\n' 'cli_subcommand:backlog add'; return 0 ;;
+        tmux:attach)    printf '%s\n' 'cli_subcommand:tmux attach'; return 0 ;;
+        tmux:new)       printf '%s\n' 'cli_subcommand:tmux new'; return 0 ;;
+        tmux:kill)      printf '%s\n' 'cli_subcommand:tmux kill'; return 0 ;;
+        audit:resume)   printf '%s\n' 'cli_subcommand:audit resume'; return 0 ;;
+        audit:purge)    printf '%s\n' 'cli_subcommand:audit purge'; return 0 ;;
+        plugin:enable)  printf '%s\n' 'cli_subcommand:plugin enable'; return 0 ;;
+        plugin:disable) printf '%s\n' 'cli_subcommand:plugin disable'; return 0 ;;
+        plugin:sync)    printf '%s\n' 'cli_subcommand:plugin sync'; return 0 ;;
         plugin:doctor)
             for arg in "$@"; do
-                [ "$arg" = "--fix" ] && return 0
+                if [ "$arg" = "--fix" ]; then
+                    printf '%s\n' 'cli_subcommand:plugin doctor --fix'
+                    return 0
+                fi
             done
             ;;
     esac
@@ -161,11 +172,11 @@ main() {
     # First line of every subcommand: kill-switch check (V-AC-6).
     check_kill_switch || exit $?
 
-    local sub="${1:-help}"
+    local sub="${1:-help}" required_scope
     shift || true
 
-    if requires_aal3_acceptance "$sub" "$@"; then
-        aal_check TUNE-0268 || exit $?
+    if required_scope="$(required_aal3_scope "$sub" "$@")"; then
+        aal_check TUNE-0268 "$required_scope" || exit $?
     fi
 
     case "$sub" in

--- a/cli/datarim
+++ b/cli/datarim
@@ -112,14 +112,43 @@ cmd_version() {
     fi
 }
 
+effective_order_independent_operation() {
+    local family="${1:-}" op=""
+    shift || true
+
+    # tasks.sh and backlog.sh accept their operation token anywhere in the
+    # argument list. Mirror that parsing here, including option arity, so a
+    # leading global --json cannot hide a later mutating operation from the
+    # AAL gate. The last operation token wins, matching both subcommands.
+    while [ "$#" -gt 0 ]; do
+        case "$family:$1" in
+            tasks:list|tasks:show|tasks:move|backlog:list|backlog:add)
+                op="$1"
+                shift
+                ;;
+            tasks:--reason|backlog:--prefix|backlog:--id|backlog:--priority|backlog:--complexity|backlog:--title)
+                if [ "$#" -ge 2 ]; then shift 2; else shift; fi
+                ;;
+            *)
+                shift
+                ;;
+        esac
+    done
+    printf '%s' "$op"
+}
+
 requires_aal3_acceptance() {
-    local sub="${1:-}" op="${2:-}" arg
+    local sub="${1:-}" op arg
+    shift || true
+    case "$sub" in
+        tasks|backlog) op="$(effective_order_independent_operation "$sub" "$@")" ;;
+        *) op="${1:-}" ;;
+    esac
     case "$sub:$op" in
         run:*|tasks:move|backlog:add|tmux:attach|tmux:new|tmux:kill|audit:resume|audit:purge|plugin:enable|plugin:disable|plugin:sync)
             return 0
             ;;
         plugin:doctor)
-            shift 2 || true
             for arg in "$@"; do
                 [ "$arg" = "--fix" ] && return 0
             done

--- a/cli/install-warning.sh
+++ b/cli/install-warning.sh
@@ -9,17 +9,17 @@ print_aal3_warning() {
     cat <<'WARN'
 ─── Datarim CLI — AAL 3 autonomous-agent surface ───
 EN: This CLI lets external agents drive Datarim WITHOUT interactive
-EN: confirmation, including irreversible actions like /dr-archive,
-EN: git push, deploy, tmux kill, config set. AAL 3 mandate-override
-EN: was explicitly accepted by the operator on 2026-05-23 and
-EN: expires 2026-08-21 unless renewed in accepted-risk-aal.yml.
+EN: confirmation, including /dr-* dispatch, task moves, plugin changes,
+EN: and tmux new/kill. The AAL 3 mandate-override
+EN: has no active acceptance; install and mutating commands fail closed
+EN: until a current entry is approved in accepted-risk-aal.yml.
 EN: Kill-switch: `datarim audit halt` (sentinel file ~/.config/datarim-cli/HALT).
 
 RU: CLI позволяет внешним агентам управлять Datarim БЕЗ интерактивного
-RU: подтверждения, включая необратимые действия /dr-archive, git push,
-RU: deploy, tmux kill, config set. AAL 3 mandate-override явно принят
-RU: оператором 2026-05-23, истекает 2026-08-21 без продления
-RU: записи в accepted-risk-aal.yml.
+RU: подтверждения, включая /dr-* вызовы, смену стадий, плагины,
+RU: создание/удаление tmux. AAL 3 mandate-override действует
+RU: только при актуальной записи; сейчас нет действующего принятия риска,
+RU: поэтому установка и изменяющие команды блокируются.
 RU: Kill-switch: `datarim audit halt` (sentinel-файл ~/.config/datarim-cli/HALT).
 ─── audit log: datarim/audit/cli-audit-{YYYY-MM-DD}.jsonl (retention 90d) ───
 WARN

--- a/cli/install.sh
+++ b/cli/install.sh
@@ -74,7 +74,9 @@ if [ ! -x "$VALIDATOR" ]; then
     printf '[install] validator not found: %s\n' "$VALIDATOR" >&2
     exit 1
 fi
-if ! "$VALIDATOR" --task TUNE-0268; then
+if "$VALIDATOR" --task TUNE-0268; then
+    :
+else
     rc=$?
     printf '[install] accepted-risk-aal validation failed (exit %s); refusing install\n' "$rc" >&2
     exit "$rc"

--- a/cli/lib/accepted-risk-check.sh
+++ b/cli/lib/accepted-risk-check.sh
@@ -7,7 +7,7 @@
 # bytes bypass expiry enforcement.
 # Returns:
 #   0   entry valid, not expired
-#   23  entry missing/expired → caller MUST abort + critical notifier
+#   23  entry missing/out-of-scope/expired → caller MUST abort
 #   1   validator IO error
 
 set -u
@@ -16,6 +16,7 @@ CLI_AAL_EXIT_EXPIRED=23
 
 aal_check() {
     local task="${1:-TUNE-0268}"
+    local required_scope="${2:-}"
     local repo_root validator rc
     repo_root="$(_aal_find_root)"
     validator="$repo_root/dev-tools/check-accepted-risk-aal.sh"
@@ -23,7 +24,10 @@ aal_check() {
         printf '[aal-check] validator not found at %s\n' "$validator" >&2
         return 1
     fi
-    if "$validator" --task "$task"; then
+    if [ -n "$required_scope" ]; then
+        "$validator" --task "$task" --require-scope "$required_scope" && return 0
+        rc=$?
+    elif "$validator" --task "$task"; then
         return 0
     else
         rc=$?

--- a/cli/lib/accepted-risk-check.sh
+++ b/cli/lib/accepted-risk-check.sh
@@ -15,16 +15,22 @@ CLI_AAL_CACHE_TTL="${DATARIM_CLI_AAL_CACHE_TTL:-3600}"
 
 aal_check() {
     local task="${1:-TUNE-0268}"
-    local repo_root validator cache_dir cache_key cache_file age mtime
+    local repo_root validator risk_file cache_dir cache_key cache_file age mtime risk_hash
     repo_root="${DATARIM_ROOT:-$(_aal_find_root)}"
     validator="$repo_root/dev-tools/check-accepted-risk-aal.sh"
+    risk_file="$repo_root/accepted-risk-aal.yml"
     if [ ! -x "$validator" ]; then
         printf '[aal-check] validator not found at %s\n' "$validator" >&2
         return 1
     fi
     cache_dir="${TMPDIR:-/tmp}/datarim-cli-aal-cache"
     mkdir -p "$cache_dir"
-    cache_key=$(printf '%s' "$task-$validator" | shasum -a 256 | awk '{print $1}')
+    if [ -f "$risk_file" ]; then
+        risk_hash="$(shasum -a 256 "$risk_file" | awk '{print $1}')"
+    else
+        risk_hash="missing"
+    fi
+    cache_key=$(printf '%s' "$task-$validator-$risk_hash" | shasum -a 256 | awk '{print $1}')
     cache_file="$cache_dir/$cache_key"
     if [ -f "$cache_file" ]; then
         # GNU `stat -f %m` succeeds but prints filesystem prose, so probe the
@@ -36,11 +42,13 @@ aal_check() {
             return 0
         fi
     fi
+    local rc
     if "$validator" --task "$task"; then
         : > "$cache_file"
         return 0
+    else
+        rc=$?
     fi
-    local rc=$?
     if [ "$rc" -eq 23 ]; then
         return $CLI_AAL_EXIT_EXPIRED
     fi

--- a/cli/lib/accepted-risk-check.sh
+++ b/cli/lib/accepted-risk-check.sh
@@ -2,7 +2,9 @@
 # cli/lib/accepted-risk-check.sh — invocation-time AAL gate.
 # Source: TUNE-0271 plan § Detailed Design 4.4.
 #
-# Wraps dev-tools/check-accepted-risk-aal.sh with a 1-hour cache.
+# Wraps dev-tools/check-accepted-risk-aal.sh. The validator runs on every
+# invocation: a cross-process success cache would let caller-controlled cache
+# bytes bypass expiry enforcement.
 # Returns:
 #   0   entry valid, not expired
 #   23  entry missing/expired → caller MUST abort + critical notifier
@@ -11,40 +13,17 @@
 set -u
 
 CLI_AAL_EXIT_EXPIRED=23
-CLI_AAL_CACHE_TTL="${DATARIM_CLI_AAL_CACHE_TTL:-3600}"
 
 aal_check() {
     local task="${1:-TUNE-0268}"
-    local repo_root validator risk_file cache_dir cache_key cache_file age mtime risk_hash
+    local repo_root validator rc
     repo_root="${DATARIM_ROOT:-$(_aal_find_root)}"
     validator="$repo_root/dev-tools/check-accepted-risk-aal.sh"
-    risk_file="$repo_root/accepted-risk-aal.yml"
     if [ ! -x "$validator" ]; then
         printf '[aal-check] validator not found at %s\n' "$validator" >&2
         return 1
     fi
-    cache_dir="${TMPDIR:-/tmp}/datarim-cli-aal-cache"
-    mkdir -p "$cache_dir"
-    if [ -f "$risk_file" ]; then
-        risk_hash="$(shasum -a 256 "$risk_file" | awk '{print $1}')"
-    else
-        risk_hash="missing"
-    fi
-    cache_key=$(printf '%s' "$task-$validator-$risk_hash" | shasum -a 256 | awk '{print $1}')
-    cache_file="$cache_dir/$cache_key"
-    if [ -f "$cache_file" ]; then
-        # GNU `stat -f %m` succeeds but prints filesystem prose, so probe the
-        # GNU form first and fall back to the BSD/macOS form.
-        mtime="$(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null || printf '0')"
-        case "$mtime" in ''|*[!0-9]*) mtime=0 ;; esac
-        age=$(( $(date -u +%s) - mtime ))
-        if [ "$age" -lt "$CLI_AAL_CACHE_TTL" ]; then
-            return 0
-        fi
-    fi
-    local rc
     if "$validator" --task "$task"; then
-        : > "$cache_file"
         return 0
     else
         rc=$?

--- a/cli/lib/accepted-risk-check.sh
+++ b/cli/lib/accepted-risk-check.sh
@@ -17,7 +17,7 @@ CLI_AAL_EXIT_EXPIRED=23
 aal_check() {
     local task="${1:-TUNE-0268}"
     local repo_root validator rc
-    repo_root="${DATARIM_ROOT:-$(_aal_find_root)}"
+    repo_root="$(_aal_find_root)"
     validator="$repo_root/dev-tools/check-accepted-risk-aal.sh"
     if [ ! -x "$validator" ]; then
         printf '[aal-check] validator not found at %s\n' "$validator" >&2

--- a/cli/tests/accepted-risk-expiry.bats
+++ b/cli/tests/accepted-risk-expiry.bats
@@ -130,6 +130,34 @@ EOF
         && [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
 }
 
+@test "V-AC-15: task-id prefix collision is not an accepted-risk match" {
+    fixture="$(mktemp)"
+    accepted="$(date -u +%F)"
+    later="$(python3 -c "import datetime; print((datetime.date.today() + datetime.timedelta(days=30)).isoformat())")"
+    cat >"$fixture" <<EOF
+schema_version: 1
+entries:
+  - id: tune-02680-unrelated
+    title: "Prefix collision fixture"
+    accepted_at: $accepted
+    expires: $later
+    review_required_by: $later
+    operator: test
+    mandate_overridden: documentation/mandates/aal-mandate.md
+    mandate_ceiling: 2
+    declared_level: 3
+    scope: ["cli_subcommand:backlog add"]
+    mitigations: ["isolated fixture"]
+    risk_summary: "test"
+    rollback: "test"
+EOF
+    run "$VALIDATOR" --file "$fixture" --task TUNE-0268 \
+        --require-scope "cli_subcommand:backlog add"
+    rm -f "$fixture"
+    [ "$status" -eq 23 ] \
+        && [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
+}
+
 @test "V-AC-15: narrow active scope rejects an unrelated required scope" {
     fixture="$(mktemp)"
     accepted="$(date -u +%F)"
@@ -294,6 +322,26 @@ EOF
         && assert_scope_blocked "cli_subcommand:plugin disable" plugin disable example \
         && assert_scope_blocked "cli_subcommand:plugin sync" plugin sync \
         && assert_scope_blocked "cli_subcommand:plugin doctor --fix" plugin doctor --fix
+}
+
+@test "task-id prefix collision cannot authorize backlog writes" {
+    fixture_root="$BATS_TEST_TMPDIR/collision-install"
+    workspace="$BATS_TEST_TMPDIR/collision-workspace"
+    backlog="$workspace/datarim/backlog.md"
+    setup_active_aal_fixture "$REPO_ROOT" "$fixture_root" "cli_subcommand:backlog add"
+    sed -i 's/id: tune-0268-aal3-cli/id: tune-02680-unrelated/' \
+        "$fixture_root/accepted-risk-aal.yml"
+    mkdir -p "$(dirname "$backlog")"
+    printf '# Backlog\n' > "$backlog"
+    before="$(shasum -a 256 "$backlog" | awk '{print $1}')"
+
+    run env HOME="$BATS_TEST_TMPDIR/home" DATARIM_WORKSPACE_ROOT="$workspace" \
+        DATARIM_CLI_AUDIT_DIR="$BATS_TEST_TMPDIR/audit" "$DATARIM_BIN" backlog add \
+        --id TUNE-9998 --priority P4 --complexity L1 --title collision
+    [ "$status" -eq 23 ] \
+        && [[ "$output" == *"no active entry matching task TUNE-0268"* ]] \
+        && [ "$before" = "$(shasum -a 256 "$backlog" | awk '{print $1}')" ] \
+        && ! grep -q 'TUNE-9998' "$backlog"
 }
 
 @test "retired acceptance blocks mutations for global option permutations" {

--- a/cli/tests/accepted-risk-expiry.bats
+++ b/cli/tests/accepted-risk-expiry.bats
@@ -228,6 +228,33 @@ EOF
     ! grep -q 'TUNE-9999' "$backlog"
 }
 
+@test "retired acceptance blocks mutations for global option permutations" {
+    workspace="$BATS_TEST_TMPDIR/option-workspace"
+    backlog="$workspace/datarim/backlog.md"
+    tasks="$workspace/datarim/tasks.md"
+    mkdir -p "$(dirname "$backlog")"
+    printf '# Backlog\n' > "$backlog"
+    printf '# Tasks\n- TUNE-9999 · pending · P4 · L1 · probe → tasks/TUNE-9999-task-description.md\n' > "$tasks"
+    backlog_before="$(shasum -a 256 "$backlog" | awk '{print $1}')"
+    tasks_before="$(shasum -a 256 "$tasks" | awk '{print $1}')"
+
+    assert_blocked_without_writes() {
+        run env HOME="$BATS_TEST_TMPDIR/home" DATARIM_WORKSPACE_ROOT="$workspace" \
+            DATARIM_CLI_AUDIT_DIR="$BATS_TEST_TMPDIR/audit" "$CLI_DIR/datarim" "$@"
+        [ "$status" -eq 23 ]
+        [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
+        [ "$backlog_before" = "$(shasum -a 256 "$backlog" | awk '{print $1}')" ]
+        [ "$tasks_before" = "$(shasum -a 256 "$tasks" | awk '{print $1}')" ]
+    }
+
+    assert_blocked_without_writes backlog --json add \
+        --id TUNE-9998 --priority P4 --complexity L1 --title probe
+    assert_blocked_without_writes backlog add \
+        --id TUNE-9998 --priority P4 --complexity L1 --title probe --json
+    assert_blocked_without_writes tasks --json move TUNE-9999 do
+    assert_blocked_without_writes tasks move TUNE-9999 do --json
+}
+
 @test "caller-controlled DATARIM_ROOT cannot replace validator provenance" {
     spoof_root="$BATS_TEST_TMPDIR/spoof-root"
     workspace="$BATS_TEST_TMPDIR/spoof-workspace"

--- a/cli/tests/accepted-risk-expiry.bats
+++ b/cli/tests/accepted-risk-expiry.bats
@@ -13,9 +13,16 @@ setup() {
     [ -f "$REAL_FILE" ] || skip "real accepted-risk-aal.yml missing"
 }
 
-@test "V-AC-15: real accepted-risk-aal.yml passes validator for TUNE-0268" {
+@test "V-AC-15: retired real register blocks TUNE-0268 with exit 23" {
     run "$VALIDATOR" --task TUNE-0268
+    [ "$status" -eq 23 ]
+    [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
+}
+
+@test "V-AC-15: real accepted-risk-aal.yml is a valid empty register" {
+    run "$VALIDATOR" --file "$REAL_FILE"
     [ "$status" -eq 0 ]
+    ! grep -q '^  - id:' "$REAL_FILE"
 }
 
 @test "V-AC-26: backdated entry (expires yesterday) → exit 23" {
@@ -96,7 +103,7 @@ EOF
     rm -f "$fixture"
 }
 
-@test "V-AC-26: missing entry for task → exit 1" {
+@test "V-AC-26: missing entry for task → exit 23" {
     fixture="$(mktemp)"
     cat >"$fixture" <<EOF
 schema_version: 1
@@ -116,19 +123,95 @@ entries:
     rollback: "x"
 EOF
     run "$VALIDATOR" --file "$fixture" --task TUNE-0268
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 23 ]
+    [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
     rm -f "$fixture"
 }
 
-@test "V-AC-15: cli/lib/accepted-risk-check.sh caches successful check" {
+@test "V-AC-15: accepted-risk cache invalidates when the register changes" {
     [ -f "$LIB" ] || skip "lib missing"
+    fixture_root="$BATS_TEST_TMPDIR/fixture-root"
+    mkdir -p "$fixture_root/dev-tools" "$BATS_TEST_TMPDIR/cache"
+    cp "$VALIDATOR" "$fixture_root/dev-tools/check-accepted-risk-aal.sh"
+    accepted=$(date -u +%F)
+    later=$(python3 -c "import datetime; print((datetime.date.today() + datetime.timedelta(days=30)).isoformat())")
+    cat >"$fixture_root/accepted-risk-aal.yml" <<EOF
+schema_version: 1
+entries:
+  - id: tune-0268-aal3-cli
+    title: "Active test entry"
+    accepted_at: $accepted
+    expires: $later
+    review_required_by: $later
+    operator: test
+    mandate_overridden: documentation/mandates/aal-mandate.md
+    mandate_ceiling: 2
+    declared_level: 3
+    scope: ["test"]
+    mitigations: ["test"]
+    risk_summary: "test"
+    rollback: "test"
+EOF
     # First call populates cache; second short-circuits.
-    cache_dir="${TMPDIR:-/tmp}/datarim-cli-aal-cache"
-    rm -rf "$cache_dir"
-    run bash -c "DATARIM_ROOT='$REPO_ROOT' . '$LIB'; aal_check TUNE-0268"
+    run bash -c "export TMPDIR='$BATS_TEST_TMPDIR/cache' DATARIM_ROOT='$fixture_root'; . '$LIB'; aal_check TUNE-0268"
     [ "$status" -eq 0 ]
-    [ -d "$cache_dir" ]
+    [ -d "$BATS_TEST_TMPDIR/cache/datarim-cli-aal-cache" ]
     # Second invocation is silent + 0.
-    run bash -c "DATARIM_ROOT='$REPO_ROOT' . '$LIB'; aal_check TUNE-0268"
+    run bash -c "export TMPDIR='$BATS_TEST_TMPDIR/cache' DATARIM_ROOT='$fixture_root'; . '$LIB'; aal_check TUNE-0268"
+    [ "$status" -eq 0 ]
+    cat >"$fixture_root/accepted-risk-aal.yml" <<'EOF'
+schema_version: 1
+entries: []
+EOF
+    run bash -c "export TMPDIR='$BATS_TEST_TMPDIR/cache' DATARIM_ROOT='$fixture_root'; . '$LIB'; aal_check TUNE-0268"
+    [ "$status" -eq 23 ]
+}
+
+@test "expired acceptance makes installer fail closed with exit 23" {
+    target="$BATS_TEST_TMPDIR/bin"
+    mkdir -p "$target"
+    run env HOME="$BATS_TEST_TMPDIR/home" "$CLI_DIR/install.sh" --dry-run --target-bin "$target"
+    [ "$status" -eq 23 ]
+    [[ "$output" == *"accepted-risk-aal validation failed (exit 23)"* ]]
+    [ ! -e "$target/datarim" ]
+}
+
+@test "retired acceptance blocks mutation before external dispatch" {
+    run env HOME="$BATS_TEST_TMPDIR/home" DATARIM_ROOT="$REPO_ROOT" \
+        "$CLI_DIR/datarim" run /dr-status
+    [ "$status" -eq 23 ]
+    [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
+    [[ "$output" != *"connect-failed-after-retries"* ]]
+}
+
+@test "retired acceptance blocks every mutation-capable CLI family" {
+    assert_blocked() {
+        run env HOME="$BATS_TEST_TMPDIR/home" DATARIM_ROOT="$REPO_ROOT" \
+            "$CLI_DIR/datarim" "$@"
+        [ "$status" -eq 23 ] \
+            && [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
+    }
+    assert_blocked tasks move TUNE-9999 "do" \
+        && assert_blocked tmux kill %0 \
+        && assert_blocked audit resume \
+        && assert_blocked audit purge \
+        && assert_blocked plugin enable /tmp/example \
+        && assert_blocked plugin disable example \
+        && assert_blocked plugin sync \
+        && assert_blocked plugin doctor --fix
+}
+
+@test "retired acceptance keeps protective audit halt available" {
+    halt="$BATS_TEST_TMPDIR/HALT"
+    agent_id="$($CLI_DIR/lib/uuid7-gen.sh)"
+    run env HOME="$BATS_TEST_TMPDIR/home" DATARIM_ROOT="$REPO_ROOT" \
+        DATARIM_CLI_AGENT_ID="$agent_id" DATARIM_CLI_HALT_PATH="$halt" \
+        "$CLI_DIR/datarim" audit halt
+    [ "$status" -eq 0 ] && [ -f "$halt" ]
+}
+
+@test "retired acceptance keeps version available" {
+    run env HOME="$BATS_TEST_TMPDIR/home" DATARIM_ROOT="$REPO_ROOT" \
+        "$CLI_DIR/datarim" version
     [ "$status" -eq 0 ]
 }

--- a/cli/tests/accepted-risk-expiry.bats
+++ b/cli/tests/accepted-risk-expiry.bats
@@ -3,6 +3,8 @@
 # V-AC-27           — 7-day pre-expiry stderr warning.
 # Source: TUNE-0271 plan § Detailed Design 4.4.
 
+load helpers/active-aal-fixture
+
 setup() {
     CLI_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
     REPO_ROOT="$(cd "$CLI_DIR/.." && pwd)"
@@ -15,14 +17,14 @@ setup() {
 
 @test "V-AC-15: retired real register blocks TUNE-0268 with exit 23" {
     run "$VALIDATOR" --task TUNE-0268
-    [ "$status" -eq 23 ]
-    [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
+    [ "$status" -eq 23 ] \
+        && [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
 }
 
 @test "V-AC-15: real accepted-risk-aal.yml is a valid empty register" {
     run "$VALIDATOR" --file "$REAL_FILE"
-    [ "$status" -eq 0 ]
-    ! grep -q '^  - id:' "$REAL_FILE"
+    [ "$status" -eq 0 ] \
+        && ! grep -q '^  - id:' "$REAL_FILE"
 }
 
 @test "V-AC-26: backdated entry (expires yesterday) → exit 23" {
@@ -46,9 +48,9 @@ entries:
     rollback: "test"
 EOF
     run "$VALIDATOR" --file "$fixture" --task TUNE-0268
-    [ "$status" -eq 23 ]
-    [[ "$output" == *"EXPIRED"* ]]
     rm -f "$fixture"
+    [ "$status" -eq 23 ] \
+        && [[ "$output" == *"EXPIRED"* ]]
 }
 
 @test "V-AC-27: entry expiring in 6 days → exit 0 with warning on stderr" {
@@ -72,9 +74,9 @@ entries:
     rollback: "test"
 EOF
     run "$VALIDATOR" --file "$fixture" --task TUNE-0268
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"expires in 6 days"* ]]
     rm -f "$fixture"
+    [ "$status" -eq 0 ] \
+        && [[ "$output" == *"expires in 6 days"* ]]
 }
 
 @test "V-AC-27: entry expiring in 30 days → exit 0, no warning" {
@@ -98,9 +100,9 @@ entries:
     rollback: "test"
 EOF
     run "$VALIDATOR" --file "$fixture" --task TUNE-0268
-    [ "$status" -eq 0 ]
-    [[ "$output" != *"expires in"* ]]
     rm -f "$fixture"
+    [ "$status" -eq 0 ] \
+        && [[ "$output" != *"expires in"* ]]
 }
 
 @test "V-AC-26: missing entry for task → exit 23" {
@@ -123,9 +125,37 @@ entries:
     rollback: "x"
 EOF
     run "$VALIDATOR" --file "$fixture" --task TUNE-0268
-    [ "$status" -eq 23 ]
-    [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
     rm -f "$fixture"
+    [ "$status" -eq 23 ] \
+        && [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
+}
+
+@test "V-AC-15: narrow active scope rejects an unrelated required scope" {
+    fixture="$(mktemp)"
+    accepted="$(date -u +%F)"
+    later="$(python3 -c "import datetime; print((datetime.date.today() + datetime.timedelta(days=30)).isoformat())")"
+    cat >"$fixture" <<EOF
+schema_version: 1
+entries:
+  - id: tune-0268-aal3-cli
+    title: "Narrow test entry"
+    accepted_at: $accepted
+    expires: $later
+    review_required_by: $later
+    operator: test
+    mandate_overridden: documentation/mandates/aal-mandate.md
+    mandate_ceiling: 2
+    declared_level: 3
+    scope: ["cli_subcommand:run"]
+    mitigations: ["isolated fixture"]
+    risk_summary: "test"
+    rollback: "test"
+EOF
+    run "$VALIDATOR" --file "$fixture" --task TUNE-0268 \
+        --require-scope "cli_subcommand:backlog add"
+    rm -f "$fixture"
+    [ "$status" -eq 23 ] \
+        && [[ "$output" == *"does not authorize scope cli_subcommand:backlog add"* ]]
 }
 
 @test "V-AC-15: accepted-risk gate revalidates when the register changes" {
@@ -155,7 +185,7 @@ entries:
     rollback: "test"
 EOF
     run bash -c ". '$fixture_lib'; aal_check TUNE-0268"
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 0 ] || return 1
     cat >"$fixture_root/accepted-risk-aal.yml" <<'EOF'
 schema_version: 1
 entries: []
@@ -173,25 +203,25 @@ EOF
     : > "$cache_root/datarim-cli-aal-cache/$cache_key"
 
     run bash -c "export TMPDIR='$cache_root'; . '$LIB'; aal_check TUNE-0268"
-    [ "$status" -eq 23 ]
-    [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
+    [ "$status" -eq 23 ] \
+        && [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
 }
 
 @test "expired acceptance makes installer fail closed with exit 23" {
     target="$BATS_TEST_TMPDIR/bin"
     mkdir -p "$target"
     run env HOME="$BATS_TEST_TMPDIR/home" "$CLI_DIR/install.sh" --dry-run --target-bin "$target"
-    [ "$status" -eq 23 ]
-    [[ "$output" == *"accepted-risk-aal validation failed (exit 23)"* ]]
-    [ ! -e "$target/datarim" ]
+    [ "$status" -eq 23 ] \
+        && [[ "$output" == *"accepted-risk-aal validation failed (exit 23)"* ]] \
+        && [ ! -e "$target/datarim" ]
 }
 
 @test "retired acceptance blocks mutation before external dispatch" {
     run env HOME="$BATS_TEST_TMPDIR/home" DATARIM_ROOT="$REPO_ROOT" \
         "$CLI_DIR/datarim" run /dr-status
-    [ "$status" -eq 23 ]
-    [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
-    [[ "$output" != *"connect-failed-after-retries"* ]]
+    [ "$status" -eq 23 ] \
+        && [[ "$output" == *"no active entry matching task TUNE-0268"* ]] \
+        && [[ "$output" != *"connect-failed-after-retries"* ]]
 }
 
 @test "retired acceptance blocks every mutation-capable CLI family" {
@@ -222,10 +252,48 @@ EOF
     run env HOME="$BATS_TEST_TMPDIR/home" DATARIM_ROOT="$REPO_ROOT" \
         DATARIM_WORKSPACE_ROOT="$workspace" "$CLI_DIR/datarim" backlog add \
         --id TUNE-9999 --priority P4 --complexity L1 --title probe
-    [ "$status" -eq 23 ]
-    [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
-    [ "$before" = "$(shasum -a 256 "$backlog" | awk '{print $1}')" ]
-    ! grep -q 'TUNE-9999' "$backlog"
+    [ "$status" -eq 23 ] \
+        && [[ "$output" == *"no active entry matching task TUNE-0268"* ]] \
+        && [ "$before" = "$(shasum -a 256 "$backlog" | awk '{print $1}')" ] \
+        && ! grep -q 'TUNE-9999' "$backlog"
+}
+
+@test "narrow active scope blocks every unrelated mutation family without writing" {
+    fixture_root="$BATS_TEST_TMPDIR/narrow-install"
+    workspace="$BATS_TEST_TMPDIR/narrow-workspace"
+    backlog="$workspace/datarim/backlog.md"
+    tasks="$workspace/datarim/tasks.md"
+    setup_active_aal_fixture "$REPO_ROOT" "$fixture_root" "test-only mutation paths"
+    mkdir -p "$(dirname "$backlog")"
+    printf '# Backlog\n' > "$backlog"
+    printf '# Tasks\n- TUNE-9999 · pending · P4 · L1 · probe → tasks/TUNE-9999-task-description.md\n' > "$tasks"
+    backlog_before="$(shasum -a 256 "$backlog" | awk '{print $1}')"
+    tasks_before="$(shasum -a 256 "$tasks" | awk '{print $1}')"
+
+    assert_scope_blocked() {
+        required_scope="$1"
+        shift
+        run env HOME="$BATS_TEST_TMPDIR/home" DATARIM_WORKSPACE_ROOT="$workspace" \
+            DATARIM_CLI_AUDIT_DIR="$BATS_TEST_TMPDIR/audit" "$DATARIM_BIN" "$@"
+        [ "$status" -eq 23 ] \
+            && [[ "$output" == *"does not authorize scope $required_scope"* ]] \
+            && [ "$backlog_before" = "$(shasum -a 256 "$backlog" | awk '{print $1}')" ] \
+            && [ "$tasks_before" = "$(shasum -a 256 "$tasks" | awk '{print $1}')" ]
+    }
+
+    assert_scope_blocked "cli_subcommand:run" run /dr-status \
+        && assert_scope_blocked "cli_subcommand:tasks move" tasks move TUNE-9999 do \
+        && assert_scope_blocked "cli_subcommand:backlog add" backlog add \
+            --id TUNE-9998 --priority P4 --complexity L1 --title narrow \
+        && assert_scope_blocked "cli_subcommand:tmux attach" tmux attach %0 \
+        && assert_scope_blocked "cli_subcommand:tmux new" tmux new --task TUNE-9999 --cmd /dr-status \
+        && assert_scope_blocked "cli_subcommand:tmux kill" tmux kill %0 \
+        && assert_scope_blocked "cli_subcommand:audit resume" audit resume \
+        && assert_scope_blocked "cli_subcommand:audit purge" audit purge \
+        && assert_scope_blocked "cli_subcommand:plugin enable" plugin enable /tmp/example \
+        && assert_scope_blocked "cli_subcommand:plugin disable" plugin disable example \
+        && assert_scope_blocked "cli_subcommand:plugin sync" plugin sync \
+        && assert_scope_blocked "cli_subcommand:plugin doctor --fix" plugin doctor --fix
 }
 
 @test "retired acceptance blocks mutations for global option permutations" {
@@ -241,18 +309,18 @@ EOF
     assert_blocked_without_writes() {
         run env HOME="$BATS_TEST_TMPDIR/home" DATARIM_WORKSPACE_ROOT="$workspace" \
             DATARIM_CLI_AUDIT_DIR="$BATS_TEST_TMPDIR/audit" "$CLI_DIR/datarim" "$@"
-        [ "$status" -eq 23 ]
-        [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
-        [ "$backlog_before" = "$(shasum -a 256 "$backlog" | awk '{print $1}')" ]
-        [ "$tasks_before" = "$(shasum -a 256 "$tasks" | awk '{print $1}')" ]
+        [ "$status" -eq 23 ] \
+            && [[ "$output" == *"no active entry matching task TUNE-0268"* ]] \
+            && [ "$backlog_before" = "$(shasum -a 256 "$backlog" | awk '{print $1}')" ] \
+            && [ "$tasks_before" = "$(shasum -a 256 "$tasks" | awk '{print $1}')" ]
     }
 
     assert_blocked_without_writes backlog --json add \
-        --id TUNE-9998 --priority P4 --complexity L1 --title probe
-    assert_blocked_without_writes backlog add \
-        --id TUNE-9998 --priority P4 --complexity L1 --title probe --json
-    assert_blocked_without_writes tasks --json move TUNE-9999 do
-    assert_blocked_without_writes tasks move TUNE-9999 do --json
+        --id TUNE-9998 --priority P4 --complexity L1 --title probe \
+        && assert_blocked_without_writes backlog add \
+            --id TUNE-9998 --priority P4 --complexity L1 --title probe --json \
+        && assert_blocked_without_writes tasks --json move TUNE-9999 do \
+        && assert_blocked_without_writes tasks move TUNE-9999 do --json
 }
 
 @test "caller-controlled DATARIM_ROOT cannot replace validator provenance" {
@@ -268,10 +336,10 @@ EOF
     run env HOME="$BATS_TEST_TMPDIR/home" DATARIM_ROOT="$spoof_root" \
         DATARIM_WORKSPACE_ROOT="$workspace" DATARIM_CLI_AUDIT_DIR="$BATS_TEST_TMPDIR/audit" \
         "$CLI_DIR/datarim" backlog add --id TUNE-9999 --priority P4 --complexity L1 --title spoof
-    [ "$status" -eq 23 ]
-    [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
-    [ "$before" = "$(shasum -a 256 "$backlog" | awk '{print $1}')" ]
-    ! grep -q 'TUNE-9999' "$backlog"
+    [ "$status" -eq 23 ] \
+        && [[ "$output" == *"no active entry matching task TUNE-0268"* ]] \
+        && [ "$before" = "$(shasum -a 256 "$backlog" | awk '{print $1}')" ] \
+        && ! grep -q 'TUNE-9999' "$backlog"
 }
 
 @test "retired acceptance keeps protective audit halt available" {

--- a/cli/tests/accepted-risk-expiry.bats
+++ b/cli/tests/accepted-risk-expiry.bats
@@ -128,10 +128,10 @@ EOF
     rm -f "$fixture"
 }
 
-@test "V-AC-15: accepted-risk cache invalidates when the register changes" {
+@test "V-AC-15: accepted-risk gate revalidates when the register changes" {
     [ -f "$LIB" ] || skip "lib missing"
     fixture_root="$BATS_TEST_TMPDIR/fixture-root"
-    mkdir -p "$fixture_root/dev-tools" "$BATS_TEST_TMPDIR/cache"
+    mkdir -p "$fixture_root/dev-tools"
     cp "$VALIDATOR" "$fixture_root/dev-tools/check-accepted-risk-aal.sh"
     accepted=$(date -u +%F)
     later=$(python3 -c "import datetime; print((datetime.date.today() + datetime.timedelta(days=30)).isoformat())")
@@ -152,19 +152,27 @@ entries:
     risk_summary: "test"
     rollback: "test"
 EOF
-    # First call populates cache; second short-circuits.
-    run bash -c "export TMPDIR='$BATS_TEST_TMPDIR/cache' DATARIM_ROOT='$fixture_root'; . '$LIB'; aal_check TUNE-0268"
-    [ "$status" -eq 0 ]
-    [ -d "$BATS_TEST_TMPDIR/cache/datarim-cli-aal-cache" ]
-    # Second invocation is silent + 0.
-    run bash -c "export TMPDIR='$BATS_TEST_TMPDIR/cache' DATARIM_ROOT='$fixture_root'; . '$LIB'; aal_check TUNE-0268"
+    run bash -c "export DATARIM_ROOT='$fixture_root'; . '$LIB'; aal_check TUNE-0268"
     [ "$status" -eq 0 ]
     cat >"$fixture_root/accepted-risk-aal.yml" <<'EOF'
 schema_version: 1
 entries: []
 EOF
-    run bash -c "export TMPDIR='$BATS_TEST_TMPDIR/cache' DATARIM_ROOT='$fixture_root'; . '$LIB'; aal_check TUNE-0268"
+    run bash -c "export DATARIM_ROOT='$fixture_root'; . '$LIB'; aal_check TUNE-0268"
     [ "$status" -eq 23 ]
+}
+
+@test "V-AC-15: caller-controlled TMPDIR cache bytes cannot bypass validation" {
+    [ -f "$LIB" ] || skip "lib missing"
+    cache_root="$BATS_TEST_TMPDIR/poisoned-tmp"
+    mkdir -p "$cache_root/datarim-cli-aal-cache"
+    risk_hash="$(shasum -a 256 "$REAL_FILE" | awk '{print $1}')"
+    cache_key="$(printf '%s' "TUNE-0268-$VALIDATOR-$risk_hash" | shasum -a 256 | awk '{print $1}')"
+    : > "$cache_root/datarim-cli-aal-cache/$cache_key"
+
+    run bash -c "export TMPDIR='$cache_root' DATARIM_ROOT='$REPO_ROOT'; . '$LIB'; aal_check TUNE-0268"
+    [ "$status" -eq 23 ]
+    [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
 }
 
 @test "expired acceptance makes installer fail closed with exit 23" {
@@ -192,6 +200,7 @@ EOF
             && [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
     }
     assert_blocked tasks move TUNE-9999 "do" \
+        && assert_blocked backlog add --id TUNE-9999 --priority P4 --complexity L1 --title probe \
         && assert_blocked tmux kill %0 \
         && assert_blocked audit resume \
         && assert_blocked audit purge \
@@ -199,6 +208,22 @@ EOF
         && assert_blocked plugin disable example \
         && assert_blocked plugin sync \
         && assert_blocked plugin doctor --fix
+}
+
+@test "retired acceptance blocks backlog add before it appends" {
+    workspace="$BATS_TEST_TMPDIR/mutation-workspace"
+    backlog="$workspace/datarim/backlog.md"
+    mkdir -p "$(dirname "$backlog")"
+    printf '# Backlog\n' > "$backlog"
+    before="$(shasum -a 256 "$backlog" | awk '{print $1}')"
+
+    run env HOME="$BATS_TEST_TMPDIR/home" DATARIM_ROOT="$REPO_ROOT" \
+        DATARIM_WORKSPACE_ROOT="$workspace" "$CLI_DIR/datarim" backlog add \
+        --id TUNE-9999 --priority P4 --complexity L1 --title probe
+    [ "$status" -eq 23 ]
+    [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
+    [ "$before" = "$(shasum -a 256 "$backlog" | awk '{print $1}')" ]
+    ! grep -q 'TUNE-9999' "$backlog"
 }
 
 @test "retired acceptance keeps protective audit halt available" {

--- a/cli/tests/accepted-risk-expiry.bats
+++ b/cli/tests/accepted-risk-expiry.bats
@@ -131,8 +131,10 @@ EOF
 @test "V-AC-15: accepted-risk gate revalidates when the register changes" {
     [ -f "$LIB" ] || skip "lib missing"
     fixture_root="$BATS_TEST_TMPDIR/fixture-root"
-    mkdir -p "$fixture_root/dev-tools"
+    mkdir -p "$fixture_root/dev-tools" "$fixture_root/cli/lib"
     cp "$VALIDATOR" "$fixture_root/dev-tools/check-accepted-risk-aal.sh"
+    cp "$LIB" "$fixture_root/cli/lib/accepted-risk-check.sh"
+    fixture_lib="$fixture_root/cli/lib/accepted-risk-check.sh"
     accepted=$(date -u +%F)
     later=$(python3 -c "import datetime; print((datetime.date.today() + datetime.timedelta(days=30)).isoformat())")
     cat >"$fixture_root/accepted-risk-aal.yml" <<EOF
@@ -152,13 +154,13 @@ entries:
     risk_summary: "test"
     rollback: "test"
 EOF
-    run bash -c "export DATARIM_ROOT='$fixture_root'; . '$LIB'; aal_check TUNE-0268"
+    run bash -c ". '$fixture_lib'; aal_check TUNE-0268"
     [ "$status" -eq 0 ]
     cat >"$fixture_root/accepted-risk-aal.yml" <<'EOF'
 schema_version: 1
 entries: []
 EOF
-    run bash -c "export DATARIM_ROOT='$fixture_root'; . '$LIB'; aal_check TUNE-0268"
+    run bash -c ". '$fixture_lib'; aal_check TUNE-0268"
     [ "$status" -eq 23 ]
 }
 
@@ -170,7 +172,7 @@ EOF
     cache_key="$(printf '%s' "TUNE-0268-$VALIDATOR-$risk_hash" | shasum -a 256 | awk '{print $1}')"
     : > "$cache_root/datarim-cli-aal-cache/$cache_key"
 
-    run bash -c "export TMPDIR='$cache_root' DATARIM_ROOT='$REPO_ROOT'; . '$LIB'; aal_check TUNE-0268"
+    run bash -c "export TMPDIR='$cache_root'; . '$LIB'; aal_check TUNE-0268"
     [ "$status" -eq 23 ]
     [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
 }
@@ -220,6 +222,25 @@ EOF
     run env HOME="$BATS_TEST_TMPDIR/home" DATARIM_ROOT="$REPO_ROOT" \
         DATARIM_WORKSPACE_ROOT="$workspace" "$CLI_DIR/datarim" backlog add \
         --id TUNE-9999 --priority P4 --complexity L1 --title probe
+    [ "$status" -eq 23 ]
+    [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
+    [ "$before" = "$(shasum -a 256 "$backlog" | awk '{print $1}')" ]
+    ! grep -q 'TUNE-9999' "$backlog"
+}
+
+@test "caller-controlled DATARIM_ROOT cannot replace validator provenance" {
+    spoof_root="$BATS_TEST_TMPDIR/spoof-root"
+    workspace="$BATS_TEST_TMPDIR/spoof-workspace"
+    backlog="$workspace/datarim/backlog.md"
+    mkdir -p "$spoof_root/dev-tools" "$(dirname "$backlog")"
+    cp /bin/true "$spoof_root/dev-tools/check-accepted-risk-aal.sh"
+    printf 'schema_version: 1\nentries: []\n' > "$spoof_root/accepted-risk-aal.yml"
+    printf '# Backlog\n' > "$backlog"
+    before="$(shasum -a 256 "$backlog" | awk '{print $1}')"
+
+    run env HOME="$BATS_TEST_TMPDIR/home" DATARIM_ROOT="$spoof_root" \
+        DATARIM_WORKSPACE_ROOT="$workspace" DATARIM_CLI_AUDIT_DIR="$BATS_TEST_TMPDIR/audit" \
+        "$CLI_DIR/datarim" backlog add --id TUNE-9999 --priority P4 --complexity L1 --title spoof
     [ "$status" -eq 23 ]
     [[ "$output" == *"no active entry matching task TUNE-0268"* ]]
     [ "$before" = "$(shasum -a 256 "$backlog" | awk '{print $1}')" ]

--- a/cli/tests/helpers/active-aal-fixture.bash
+++ b/cli/tests/helpers/active-aal-fixture.bash
@@ -1,5 +1,7 @@
 setup_active_aal_fixture() {
     local framework_root="$1" fixture_root="$2" accepted_at expires
+    mkdir -p "$fixture_root"
+    cp -R "$framework_root/cli" "$fixture_root/cli"
     mkdir -p "$fixture_root/dev-tools"
     cp "$framework_root/dev-tools/check-accepted-risk-aal.sh" \
         "$fixture_root/dev-tools/check-accepted-risk-aal.sh"
@@ -22,5 +24,12 @@ entries:
     risk_summary: "Temporary acceptance confined to an isolated Bats process."
     rollback: "Bats removes the temporary fixture directory."
 EOF
-    export DATARIM_ROOT="$fixture_root"
+    # Exercise an isolated installation root. The shipped gate deliberately
+    # ignores DATARIM_ROOT so callers cannot select their own validator.
+    CLI_DIR="$fixture_root/cli"
+    DATARIM_BIN="$CLI_DIR/datarim"
+    MOCK="$CLI_DIR/tests/fixtures/mock-webhook.py"
+    UUID_GEN="$CLI_DIR/lib/uuid7-gen.sh"
+    export CLI_DIR DATARIM_BIN MOCK UUID_GEN
+    unset DATARIM_ROOT
 }

--- a/cli/tests/helpers/active-aal-fixture.bash
+++ b/cli/tests/helpers/active-aal-fixture.bash
@@ -1,5 +1,21 @@
 setup_active_aal_fixture() {
-    local framework_root="$1" fixture_root="$2" accepted_at expires
+    local framework_root="$1" fixture_root="$2" accepted_at expires scope
+    shift 2
+    if [ "$#" -eq 0 ]; then
+        set -- \
+            "cli_subcommand:run" \
+            "cli_subcommand:tasks move" \
+            "cli_subcommand:backlog add" \
+            "cli_subcommand:tmux attach" \
+            "cli_subcommand:tmux new" \
+            "cli_subcommand:tmux kill" \
+            "cli_subcommand:audit resume" \
+            "cli_subcommand:audit purge" \
+            "cli_subcommand:plugin enable" \
+            "cli_subcommand:plugin disable" \
+            "cli_subcommand:plugin sync" \
+            "cli_subcommand:plugin doctor --fix"
+    fi
     mkdir -p "$fixture_root"
     cp -R "$framework_root/cli" "$fixture_root/cli"
     mkdir -p "$fixture_root/dev-tools"
@@ -19,7 +35,12 @@ entries:
     mandate_overridden: documentation/mandates/aal-mandate.md
     mandate_ceiling: 2
     declared_level: 3
-    scope: ["test-only mutation paths"]
+    scope:
+EOF
+    for scope in "$@"; do
+        printf '      - "%s"\n' "$scope" >> "$fixture_root/accepted-risk-aal.yml"
+    done
+    cat >>"$fixture_root/accepted-risk-aal.yml" <<'EOF'
     mitigations: ["isolated fixtures"]
     risk_summary: "Temporary acceptance confined to an isolated Bats process."
     rollback: "Bats removes the temporary fixture directory."

--- a/cli/tests/helpers/active-aal-fixture.bash
+++ b/cli/tests/helpers/active-aal-fixture.bash
@@ -1,0 +1,26 @@
+setup_active_aal_fixture() {
+    local framework_root="$1" fixture_root="$2" accepted_at expires
+    mkdir -p "$fixture_root/dev-tools"
+    cp "$framework_root/dev-tools/check-accepted-risk-aal.sh" \
+        "$fixture_root/dev-tools/check-accepted-risk-aal.sh"
+    accepted_at="$(date -u +%F)"
+    expires="$(python3 -c 'import datetime; print((datetime.date.today() + datetime.timedelta(days=30)).isoformat())')"
+    cat >"$fixture_root/accepted-risk-aal.yml" <<EOF
+schema_version: 1
+entries:
+  - id: tune-0268-aal3-cli
+    title: "Active Bats-only AAL acceptance"
+    accepted_at: $accepted_at
+    expires: $expires
+    review_required_by: $expires
+    operator: test
+    mandate_overridden: documentation/mandates/aal-mandate.md
+    mandate_ceiling: 2
+    declared_level: 3
+    scope: ["test-only mutation paths"]
+    mitigations: ["isolated fixtures"]
+    risk_summary: "Temporary acceptance confined to an isolated Bats process."
+    rollback: "Bats removes the temporary fixture directory."
+EOF
+    export DATARIM_ROOT="$fixture_root"
+}

--- a/cli/tests/install-warning-content.bats
+++ b/cli/tests/install-warning-content.bats
@@ -45,9 +45,9 @@ setup() {
     [[ "$output" == *"retention 90d"* ]]
 }
 
-@test "V-AC-28: expiry date 2026-08-21 mentioned in both languages" {
+@test "V-AC-28: warning says no AAL 3 mandate override is active" {
     run "$WARNING"
-    count=$(printf '%s' "$output" | grep -c '2026-08-21')
+    count=$(printf '%s' "$output" | grep -c 'no active acceptance\|нет действующего принятия риска')
     [ "$count" -ge 2 ]
 }
 

--- a/cli/tests/slash-dispatch-contract.bats
+++ b/cli/tests/slash-dispatch-contract.bats
@@ -2,6 +2,8 @@
 # V-AC-8 — `datarim run /dr-status` ≡ direct webhook POST.
 # Source: TUNE-0271 plan § Implementation Steps Batch 3.
 
+load 'helpers/active-aal-fixture'
+
 setup() {
     CLI_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
     DATARIM_BIN="$CLI_DIR/datarim"
@@ -12,7 +14,9 @@ setup() {
     TMP_DIR="$(mktemp -d)"
     export DATARIM_CLI_AUDIT_DIR="$TMP_DIR/audit"
     export DATARIM_CLI_HALT_PATH="$TMP_DIR/HALT"
-    export DATARIM_CLI_AGENT_ID="$("$UUID_GEN")"
+    DATARIM_CLI_AGENT_ID="$("$UUID_GEN")"
+    export DATARIM_CLI_AGENT_ID
+    setup_active_aal_fixture "$CLI_DIR/.." "$TMP_DIR/active-aal"
 
     MOCK_PORT="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1",0)); print(s.getsockname()[1]); s.close()')"
     export DATARIM_CLI_WEBHOOK_URL="http://127.0.0.1:$MOCK_PORT"

--- a/cli/tests/tmux-attach.bats
+++ b/cli/tests/tmux-attach.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 # Phase 4 V-AC-22, V-AC-21, V-AC-27 — datarim tmux attach.
 
+load 'helpers/active-aal-fixture'
+
 setup() {
     CLI_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
     DATARIM_BIN="$CLI_DIR/datarim"
@@ -10,7 +12,9 @@ setup() {
     TMP_DIR="$(mktemp -d)"
     export DATARIM_CLI_AUDIT_DIR="$TMP_DIR/audit"
     export DATARIM_CLI_HALT_PATH="$TMP_DIR/HALT"
-    export DATARIM_CLI_AGENT_ID="$("$UUID_GEN")"
+    DATARIM_CLI_AGENT_ID="$("$UUID_GEN")"
+    export DATARIM_CLI_AGENT_ID
+    setup_active_aal_fixture "$CLI_DIR/.." "$TMP_DIR/active-aal"
 }
 
 teardown() {

--- a/cli/tests/tmux-kill.bats
+++ b/cli/tests/tmux-kill.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 # Phase 4 V-AC-10, V-AC-20, V-AC-25 — datarim tmux kill (irreversible, hard-gated).
 
+load 'helpers/active-aal-fixture'
+
 setup() {
     CLI_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
     DATARIM_BIN="$CLI_DIR/datarim"
@@ -10,7 +12,9 @@ setup() {
     TMP_DIR="$(mktemp -d)"
     export DATARIM_CLI_AUDIT_DIR="$TMP_DIR/audit"
     export DATARIM_CLI_HALT_PATH="$TMP_DIR/HALT"
-    export DATARIM_CLI_AGENT_ID="$("$UUID_GEN")"
+    DATARIM_CLI_AGENT_ID="$("$UUID_GEN")"
+    export DATARIM_CLI_AGENT_ID
+    setup_active_aal_fixture "$CLI_DIR/.." "$TMP_DIR/active-aal"
 }
 
 teardown() {

--- a/cli/tests/tmux-new.bats
+++ b/cli/tests/tmux-new.bats
@@ -1,6 +1,8 @@
 #!/usr/bin/env bats
 # Phase 4 V-AC-19, V-AC-24 — datarim tmux new (whitelist enforcement, async timeout).
 
+load 'helpers/active-aal-fixture'
+
 setup() {
     CLI_DIR="$(cd "$BATS_TEST_DIRNAME/.." && pwd)"
     DATARIM_BIN="$CLI_DIR/datarim"
@@ -10,10 +12,12 @@ setup() {
     TMP_DIR="$(mktemp -d)"
     export DATARIM_CLI_AUDIT_DIR="$TMP_DIR/audit"
     export DATARIM_CLI_HALT_PATH="$TMP_DIR/HALT"
-    export DATARIM_CLI_AGENT_ID="$("$UUID_GEN")"
+    DATARIM_CLI_AGENT_ID="$("$UUID_GEN")"
+    export DATARIM_CLI_AGENT_ID
     # Notifier stub: targets=stub, results=ack — so notifier_gate passes.
     export DATARIM_CLI_NOTIFIER_TARGETS=stub
     export DATARIM_CLI_NOTIFY_STUB_RESULT=0
+    setup_active_aal_fixture "$CLI_DIR/.." "$TMP_DIR/active-aal"
 }
 
 teardown() {

--- a/dev-tools/check-accepted-risk-aal.sh
+++ b/dev-tools/check-accepted-risk-aal.sh
@@ -86,7 +86,8 @@ def find_entry(task_id):
         return None
     slug_part = task_id.lower()
     for e in entries:
-        if (e.get("id") or "").startswith(slug_part):
+        entry_id = str(e.get("id") or "").lower()
+        if entry_id == slug_part or entry_id.startswith(slug_part + "-"):
             return e
     return None
 

--- a/dev-tools/check-accepted-risk-aal.sh
+++ b/dev-tools/check-accepted-risk-aal.sh
@@ -4,6 +4,7 @@
 #
 # Modes:
 #   --task TUNE-NNNN          ensure entry id "tune-NNNN-..." is present + valid
+#   --require-scope SCOPE     require exact membership in the target entry scope
 #   --file <path>             override default location
 #   --warn-window-days N      pre-expiry stderr warning window (default 7)
 #   --check-expiry-only       only check expires >= today (skip other fields)
@@ -13,7 +14,7 @@
 #   0   OK (entry present, not expired)
 #   1   validation failure
 #   2   usage error
-#   23  entry expired (intentional sentinel — CLI uses this to gate AAL 3)
+#   23  entry missing, out of scope, or expired (CLI AAL 3 gate sentinel)
 
 set -eu
 
@@ -22,7 +23,7 @@ usage() {
 check-accepted-risk-aal.sh — validate AAL mandate-override register.
 
 Usage:
-  check-accepted-risk-aal.sh --task TUNE-NNNN [--file PATH] [--warn-window-days N]
+  check-accepted-risk-aal.sh --task TUNE-NNNN [--require-scope SCOPE] [--file PATH] [--warn-window-days N]
   check-accepted-risk-aal.sh --file PATH (validate schema)
 EOF
 }
@@ -31,10 +32,12 @@ task=""
 file=""
 warn_days="${DATARIM_AAL_WARN_DAYS:-7}"
 check_expiry_only=0
+required_scope=""
 
 while [ $# -gt 0 ]; do
     case "$1" in
         --task) task="${2:-}"; shift 2 ;;
+        --require-scope) required_scope="${2:-}"; shift 2 ;;
         --file) file="${2:-}"; shift 2 ;;
         --warn-window-days) warn_days="${2:-}"; shift 2 ;;
         --check-expiry-only) check_expiry_only=1; shift ;;
@@ -52,7 +55,7 @@ if [ ! -f "$file" ]; then
     exit 1
 fi
 
-python3 - "$file" "$task" "$warn_days" "$check_expiry_only" <<'PY'
+python3 - "$file" "$task" "$warn_days" "$check_expiry_only" "$required_scope" <<'PY'
 import sys, datetime
 try:
     import yaml
@@ -60,7 +63,9 @@ except ImportError:
     print("[check-aal] python3 yaml package required", file=sys.stderr)
     sys.exit(1)
 
-path, task, warn_days, expiry_only = sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4])
+path, task, warn_days, expiry_only, required_scope = (
+    sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4]), sys.argv[5]
+)
 with open(path, "r", encoding="utf-8") as f:
     data = yaml.safe_load(f) or {}
 
@@ -123,6 +128,13 @@ for e in entries:
 
 if errors and not expiry_only:
     sys.exit(1)
+
+if target and required_scope and required_scope not in target.get("scope", []):
+    print(
+        f"[check-aal] entry {target['id']} does not authorize scope {required_scope}",
+        file=sys.stderr,
+    )
+    sys.exit(23)
 
 # Expiry check for target entry (if given).
 if target:

--- a/dev-tools/check-accepted-risk-aal.sh
+++ b/dev-tools/check-accepted-risk-aal.sh
@@ -69,9 +69,9 @@ if data.get("schema_version") != 1:
     print(f"[check-aal] schema_version != 1 (got {data.get('schema_version')!r})", file=sys.stderr)
     errors += 1
 
-entries = data.get("entries") or []
-if not isinstance(entries, list) or not entries:
-    print("[check-aal] entries[] missing or empty", file=sys.stderr)
+entries = data.get("entries")
+if not isinstance(entries, list):
+    print("[check-aal] entries must be a list", file=sys.stderr)
     sys.exit(1)
 
 today = datetime.date.today()
@@ -87,8 +87,8 @@ def find_entry(task_id):
 
 target = find_entry(task) if task else None
 if task and not target:
-    print(f"[check-aal] no entry matching task {task}", file=sys.stderr)
-    sys.exit(1)
+    print(f"[check-aal] no active entry matching task {task}", file=sys.stderr)
+    sys.exit(23)
 
 # Schema validation pass over ALL entries (cheap; under 10).
 REQUIRED = {"id","title","accepted_at","expires","review_required_by","operator",

--- a/dev-tools/dr-orchestrate-soak.sh
+++ b/dev-tools/dr-orchestrate-soak.sh
@@ -49,8 +49,9 @@ W_NOOP="${DR_SOAK_W_NOOP:-10}"
 CMD="${DR_SOAK_CMD:-/opt/datarim/plugins/dr-orchestrate/scripts/cmd_run.sh}"
 
 if [[ -n "${DR_SOAK_RANDOM_SEED:-}" ]]; then
-  if [[ ! "$DR_SOAK_RANDOM_SEED" =~ ^[0-9]+$ ]]; then
-    echo "[soak] ERR DR_SOAK_RANDOM_SEED must be a non-negative integer" >&2
+  if [[ ! "$DR_SOAK_RANDOM_SEED" =~ ^(0|[1-9][0-9]{0,4})$ ]] \
+      || (( DR_SOAK_RANDOM_SEED > 32767 )); then
+    echo "[soak] ERR DR_SOAK_RANDOM_SEED must be a canonical integer in range 0..32767" >&2
     exit 2
   fi
   RANDOM="$DR_SOAK_RANDOM_SEED"

--- a/dev-tools/dr-orchestrate-soak.sh
+++ b/dev-tools/dr-orchestrate-soak.sh
@@ -27,6 +27,7 @@
 #   DR_SOAK_W_RESOLVED      — relative weight resolved corpus (default 70)
 #   DR_SOAK_W_ESCALATED     — relative weight escalated corpus (default 20)
 #   DR_SOAK_W_NOOP          — relative weight no-op mode (default 10)
+#   DR_SOAK_RANDOM_SEED     — optional integer seed for reproducible traffic
 #   DR_SOAK_CMD             — path to cmd_run.sh
 #   DR_SOAK_AUDIT_DIR       — exported as DR_ORCH_AUDIT_DIR for child
 #
@@ -46,6 +47,14 @@ W_RESOLVED="${DR_SOAK_W_RESOLVED:-70}"
 W_ESCALATED="${DR_SOAK_W_ESCALATED:-20}"
 W_NOOP="${DR_SOAK_W_NOOP:-10}"
 CMD="${DR_SOAK_CMD:-/opt/datarim/plugins/dr-orchestrate/scripts/cmd_run.sh}"
+
+if [[ -n "${DR_SOAK_RANDOM_SEED:-}" ]]; then
+  if [[ ! "$DR_SOAK_RANDOM_SEED" =~ ^[0-9]+$ ]]; then
+    echo "[soak] ERR DR_SOAK_RANDOM_SEED must be a non-negative integer" >&2
+    exit 2
+  fi
+  RANDOM="$DR_SOAK_RANDOM_SEED"
+fi
 
 if [[ -n "${DR_SOAK_AUDIT_DIR:-}" ]]; then
   export DR_ORCH_AUDIT_DIR="$DR_SOAK_AUDIT_DIR"

--- a/dev-tools/tests/dr-orchestrate-soak.bats
+++ b/dev-tools/tests/dr-orchestrate-soak.bats
@@ -48,6 +48,13 @@ teardown() {
     [[ "$output" =~ "missing or not executable" ]]
 }
 
+@test "T2b non-integer random seed → exit 2" {
+    run env DR_SOAK_RANDOM_SEED=not-a-number DR_SOAK_CMD="$MOCK" \
+        DR_SOAK_DURATION_SECONDS=2 "$SOAK"
+    [ "$status" -eq 2 ]
+    [[ "$output" =~ "DR_SOAK_RANDOM_SEED must be a non-negative integer" ]]
+}
+
 @test "T3 short run respects DURATION_SECONDS" {
     start=$(date +%s)
     run env DR_SOAK_DURATION_SECONDS=3 DR_SOAK_CYCLE_SLEEP=1 DR_SOAK_CMD="$MOCK" "$SOAK"
@@ -142,6 +149,7 @@ exit 0
 WEOF
     chmod +x "$MOCK3"
     run env DR_SOAK_W_RESOLVED=100 DR_SOAK_W_ESCALATED=0 DR_SOAK_W_NOOP=0 \
+        DR_SOAK_RANDOM_SEED=2 \
         DR_SOAK_DURATION_SECONDS=3 DR_SOAK_CYCLE_SLEEP=1 DR_SOAK_CMD="$MOCK3" "$SOAK"
     [ "$status" -eq 0 ]
     [ -f "$LOG2" ]

--- a/dev-tools/tests/dr-orchestrate-soak.bats
+++ b/dev-tools/tests/dr-orchestrate-soak.bats
@@ -52,7 +52,15 @@ teardown() {
     run env DR_SOAK_RANDOM_SEED=not-a-number DR_SOAK_CMD="$MOCK" \
         DR_SOAK_DURATION_SECONDS=2 "$SOAK"
     [ "$status" -eq 2 ]
-    [[ "$output" =~ "DR_SOAK_RANDOM_SEED must be a non-negative integer" ]]
+    [[ "$output" =~ "DR_SOAK_RANDOM_SEED must be a canonical integer in range 0..32767" ]]
+}
+
+@test "T2c octal-looking random seed → exit 2 instead of running unseeded" {
+    run env DR_SOAK_RANDOM_SEED=08 DR_SOAK_CMD="$MOCK" \
+        DR_SOAK_DURATION_SECONDS=2 "$SOAK"
+    [ "$status" -eq 2 ]
+    [[ "$output" =~ "DR_SOAK_RANDOM_SEED must be a canonical integer in range 0..32767" ]]
+    [[ "$output" != *"[soak] start"* ]]
 }
 
 @test "T3 short run respects DURATION_SECONDS" {

--- a/documentation/reference/cli.md
+++ b/documentation/reference/cli.md
@@ -116,7 +116,7 @@ Self-explanatory.
 - **Dual-channel notifier** — eligible actions emit an alert before execution; zero ACK within 3000ms causes exit 18. Notification never grants permission for a hard-gated action.
 - **JSONL audit log** — schema version 1, 10 keys, flock atomic append (portable python3 fcntl wrapper on macOS).
 - **Kill-switch sentinel** — presence of `~/.config/datarim-cli/HALT` triggers exit 17 on every subcommand.
-- **`accepted-risk-aal.yml` entry** — invocation-time gate for mutation-capable commands (1h cache keyed by register content); a register change invalidates the cache, while a missing, removed, or expired entry exits 23.
+- **`accepted-risk-aal.yml` entry** — uncached invocation-time gate for mutation-capable commands; every invocation revalidates the current register and validator, while a missing, removed, or expired entry exits 23.
 - **Bilingual install warning** — 6 RU + 6 EN canonical lines printed on every install run.
 - **UUID v7 agent identity** — env-only enforcement (no `--as` flag in Phase 3).
 

--- a/documentation/reference/cli.md
+++ b/documentation/reference/cli.md
@@ -2,14 +2,14 @@
 
 ## Overview
 
-The `datarim` CLI is the external-agent surface for Datarim — it lets a non-interactive process (Codex, Cursor, or a custom agent) inspect local state and drive eligible `/dr-*` operations through the existing `/dr-orchestrate` webhook. AAL 3 is opt-in only and requires an `accepted-risk-aal.yml` entry `tune-0268-aal3-cli`. Hard-gated actions remain operator-controlled; a notifier acknowledgement is observability, not authorization.
+The `datarim` CLI is the external-agent surface for Datarim — it lets a non-interactive process (Codex, Cursor, or a custom agent) inspect local state and drive eligible `/dr-*` operations through the existing `/dr-orchestrate` webhook. AAL 3 is opt-in only and requires a current `accepted-risk-aal.yml` entry. With no active entry, mutation-capable commands fail closed with exit 23 while read-only inspection and the protective `audit halt` command remain available. Hard-gated actions remain operator-controlled; a notifier acknowledgement is observability, not authorization.
 
 ## When to use CLI vs slash command
 
 | Aspect | CLI (`datarim run /dr-*`) | Slash command (inside Claude Code session) |
 |--------|---------------------------|--------------------------------------------|
 | Interactive Q&A | Pre-confirmed flows only | Full interactive Q&A supported |
-| AAL | 3 (opt-in via `accepted-risk-aal.yml`) | 2 (default) |
+| AAL | 3 only with an active `accepted-risk-aal.yml` entry; otherwise read-only | 2 (default) |
 | Audit log | `datarim/audit/cli-audit-YYYY-MM-DD.jsonl` (90d retention) | Session JSONL |
 | Kill-switch | `~/.config/datarim-cli/HALT` sentinel | SIGINT |
 | Token cost | None (HTTP webhook only) | Current session |
@@ -20,7 +20,7 @@ The `datarim` CLI is the external-agent surface for Datarim — it lets a non-in
 cd code/datarim/cli && ./install.sh
 ```
 
-The installer: (a) prints the bilingual AAL 3 warning, (b) validates that `accepted-risk-aal.yml` contains entry `tune-0268-aal3-cli` and that the entry is not expired (exits 23 otherwise), (c) symlinks `code/datarim/cli/datarim` to `/usr/local/bin/datarim` (or `$HOME/.local/bin/datarim` if no sudo).
+The installer: (a) prints the bilingual AAL 3 warning, (b) validates that `accepted-risk-aal.yml` contains a current approval entry (exits 23 otherwise), (c) symlinks `code/datarim/cli/datarim` to `/usr/local/bin/datarim` (or `$HOME/.local/bin/datarim` if no sudo). The shipped register currently has no active override, so installation fails closed until a new approval is recorded.
 
 - Uninstall: `./install.sh --uninstall`
 - Dry-run: `./install.sh --dry-run`
@@ -116,7 +116,7 @@ Self-explanatory.
 - **Dual-channel notifier** — eligible actions emit an alert before execution; zero ACK within 3000ms causes exit 18. Notification never grants permission for a hard-gated action.
 - **JSONL audit log** — schema version 1, 10 keys, flock atomic append (portable python3 fcntl wrapper on macOS).
 - **Kill-switch sentinel** — presence of `~/.config/datarim-cli/HALT` triggers exit 17 on every subcommand.
-- **`accepted-risk-aal.yml` entry** — invocation-time gate (1h cache); missing or expired entry exits 23.
+- **`accepted-risk-aal.yml` entry** — invocation-time gate for mutation-capable commands (1h cache keyed by register content); a register change invalidates the cache, while a missing, removed, or expired entry exits 23.
 - **Bilingual install warning** — 6 RU + 6 EN canonical lines printed on every install run.
 - **UUID v7 agent identity** — env-only enforcement (no `--as` flag in Phase 3).
 
@@ -130,7 +130,7 @@ Self-explanatory.
 | 20 | Config mutation or managed-key access refused |
 | 21 | Invalid or missing slash command |
 | 22 | Missing or malformed `$DATARIM_CLI_AGENT_ID` (must be UUID v7) |
-| 23 | `accepted-risk-aal.yml` entry `tune-0268-aal3-cli` missing or expired |
+| 23 | Required `accepted-risk-aal.yml` entry missing or expired |
 | 24 | HTTP dispatch failure / network error |
 | 25 | Command returned non-zero from webhook |
 | 26 | Non-idempotent command requested on sync path |

--- a/documentation/reference/cli.md
+++ b/documentation/reference/cli.md
@@ -130,7 +130,7 @@ Self-explanatory.
 | 20 | Config mutation or managed-key access refused |
 | 21 | Invalid or missing slash command |
 | 22 | Missing or malformed `$DATARIM_CLI_AGENT_ID` (must be UUID v7) |
-| 23 | Required `accepted-risk-aal.yml` entry missing or expired |
+| 23 | Required `accepted-risk-aal.yml` entry missing, out of operation scope, or expired |
 | 24 | HTTP dispatch failure / network error |
 | 25 | Command returned non-zero from webhook |
 | 26 | Non-idempotent command requested on sync path |
@@ -145,7 +145,7 @@ Self-explanatory.
 - `cli/install.sh`, `cli/install-warning.sh`
 - `accepted-risk-aal.yml` — repo root
 - `dev-tools/check-cli-audit-schema.sh`
-- `dev-tools/check-accepted-risk-aal.sh`
+- `dev-tools/check-accepted-risk-aal.sh` — validates exact `cli_subcommand:<operation>` scope membership for mutations
 - `datarim/audit/cli-audit-YYYY-MM-DD.jsonl` — workspace only
 
 ## Related

--- a/documentation/tutorials/getting-started.md
+++ b/documentation/tutorials/getting-started.md
@@ -54,7 +54,7 @@ The main `./install.sh` symlinks runtime scopes (agents/skills/commands/…) int
 cd cli && ./install.sh
 ```
 
-It prints the bilingual AAL 3 warning, validates `accepted-risk-aal.yml` entry `tune-0268-aal3-cli`, and symlinks `cli/datarim` → `/usr/local/bin/datarim` (falls back to `$HOME/.local/bin/datarim` when `/usr/local/bin` is not writable). Set `DATARIM_CLI_AGENT_ID` to a UUID v7 before the first `datarim run` invocation — generate via `cli/lib/uuid7-gen.sh`. Full reference: [documentation/reference/cli.md](../reference/cli.md).
+It prints the bilingual AAL 3 warning and validates a current `accepted-risk-aal.yml` approval before creating the symlink. With no active approval, installation fails closed with exit 23. When approved, it symlinks `cli/datarim` → `/usr/local/bin/datarim` (falling back to `$HOME/.local/bin/datarim` when `/usr/local/bin` is not writable). Set `DATARIM_CLI_AGENT_ID` to a UUID v7 before the first `datarim run` invocation — generate via `cli/lib/uuid7-gen.sh`. Full reference: [documentation/reference/cli.md](../reference/cli.md).
 
 The CLI is opt-in. Slash commands inside a Claude Code session work without it.
 


### PR DESCRIPTION
Retires the expired AAL 3 override without renewal, preserves exit-23 enforcement before mutation dispatch, fixes validator status propagation and cache invalidation, and keeps read-only/protective CLI paths available. Verification: CLI 205/205; exact shard 1/8 48 suites passed; ShellCheck and changed-doc policy gates clean. Base 8a98dbed84e9f71156b521be9c49bee298dac8c1; head cedf88e43eeda9fb813a00a8d507d2f9f8e9c12a.