### PR TITLE
feat: enforce review driven canon evolution

### DIFF
--- a/dev-tools/check-review-evolution.sh
+++ b/dev-tools/check-review-evolution.sh
@@ -1,9 +1,206 @@
 #!/bin/bash -p
+# shellcheck disable=SC2317  # The worker below the marker is executed by the Python supervisor.
 # Validate the review-to-evolution contract without treating canon evolution as
 # proof that the associated customer Requirement was delivered.
 #
 # Exit codes: 0 MET, 1 semantic NOT_MET, 2 usage/configuration error.
 set -euo pipefail
+
+# Supervise the complete validator, including every external command and Git
+# traversal, with one portable monotonic deadline. The worker body is extracted
+# from this file so there is no ambient environment switch that bypasses it.
+supervisor_python='/usr/bin/python3'
+supervisor_args=("$@")
+if [[ ! -x "$supervisor_python" || -d "$supervisor_python" ]]; then
+    supervisor_task=''
+    supervisor_format='text'
+    for ((supervisor_index = 0; supervisor_index < ${#supervisor_args[@]}; supervisor_index++)); do
+        case "${supervisor_args[$supervisor_index]}" in
+            --task)
+                ((supervisor_index + 1 < ${#supervisor_args[@]})) \
+                    && supervisor_task="${supervisor_args[$((supervisor_index + 1))]}"
+                ;;
+            --format)
+                ((supervisor_index + 1 < ${#supervisor_args[@]})) \
+                    && supervisor_format="${supervisor_args[$((supervisor_index + 1))]}"
+                ;;
+        esac
+    done
+    [[ "$supervisor_task" =~ ^[A-Z][A-Z0-9]{1,9}-[0-9]{4}$ ]] || supervisor_task=''
+    if [[ "$supervisor_format" == json ]]; then
+        printf '{"classification":"","findings":["missing_dependency:python3"],"status":"ERROR","task":"%s"}\n' \
+            "$supervisor_task"
+    else
+        printf 'status=ERROR task=%s classification= findings=missing_dependency:python3\n' \
+            "$supervisor_task"
+        printf 'finding=missing_dependency:python3\n'
+    fi
+    exit 2
+fi
+# shellcheck disable=SC2093  # Python intentionally replaces the shell wrapper.
+exec "$supervisor_python" -I -S - "$0" "${supervisor_args[@]}" <<'PY'
+import json
+import os
+import re
+import selectors
+import signal
+import stat
+import subprocess
+import sys
+import tempfile
+import time
+
+VALIDATION_TOTAL_TIMEOUT_SECONDS = 20
+VALIDATION_MAX_STDOUT_BYTES = 1048576
+VALIDATION_MAX_STDERR_BYTES = 1048576
+VALIDATOR_MARKER = b"# __REVIEW_EVOLUTION_VALIDATOR_BODY__\n"
+
+
+def result_identity(arguments):
+    task = ""
+    output_format = "text"
+    index = 0
+    while index < len(arguments):
+        if arguments[index] in ("--task", "--format") and index + 1 < len(arguments):
+            if arguments[index] == "--task":
+                task = arguments[index + 1]
+            else:
+                output_format = arguments[index + 1]
+            index += 2
+        else:
+            index += 1
+    if re.fullmatch(r"[A-Z][A-Z0-9]{1,9}-[0-9]{4}", task or "") is None:
+        task = ""
+    return task, output_format
+
+
+def emit_error(finding, arguments):
+    task, output_format = result_identity(arguments)
+    if output_format == "json":
+        payload = {
+            "classification": "",
+            "findings": [finding],
+            "status": "ERROR",
+            "task": task,
+        }
+        sys.stdout.write(json.dumps(payload, separators=(",", ":"), sort_keys=True) + "\n")
+    else:
+        sys.stdout.write(
+            f"status=ERROR task={task} classification= findings={finding}\n"
+            f"finding={finding}\n"
+        )
+    raise SystemExit(2)
+
+
+def terminate_process_group(process):
+    # The direct worker can exit while a descendant still holds inherited pipes.
+    try:
+        os.killpg(process.pid, signal.SIGTERM)
+    except (ProcessLookupError, PermissionError):
+        pass
+    try:
+        process.wait(timeout=0.2)
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+    except (ProcessLookupError, PermissionError):
+        pass
+    try:
+        process.wait(timeout=0.2)
+    except (subprocess.TimeoutExpired, OSError):
+        pass
+
+
+deadline = time.monotonic() + VALIDATION_TOTAL_TIMEOUT_SECONDS
+arguments = sys.argv[2:]
+try:
+    script_path = os.path.realpath(sys.argv[1])
+    metadata = os.stat(script_path, follow_symlinks=False)
+    if not stat.S_ISREG(metadata.st_mode) or metadata.st_size > 1048576:
+        emit_error("validation_supervisor_source_invalid", arguments)
+    with open(script_path, "rb") as handle:
+        source = handle.read(1048577)
+    if len(source) > 1048576 or source.count(VALIDATOR_MARKER) != 1:
+        emit_error("validation_supervisor_source_invalid", arguments)
+    worker_body = source.split(VALIDATOR_MARKER, 1)[1]
+    worker_source = tempfile.TemporaryFile(dir="/tmp")
+    worker_source.write(worker_body)
+    worker_source.seek(0)
+    if time.monotonic() >= deadline:
+        emit_error("validation_resource_limit:deadline", arguments)
+    process = subprocess.Popen(
+        ["/bin/bash", "-p", "-s", "--", *arguments],
+        stdin=worker_source,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=os.getcwd(),
+        env={
+            "LC_ALL": "C",
+            "PATH": "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin",
+            "REVIEW_EVOLUTION_SCRIPT_PATH": script_path,
+            "TMPDIR": "/tmp",
+        },
+        start_new_session=True,
+    )
+except (OSError, subprocess.SubprocessError, IndexError):
+    emit_error("validation_supervisor_unavailable", arguments)
+
+selector = selectors.DefaultSelector()
+stdout = bytearray()
+stderr = bytearray()
+try:
+    for label, stream in (("stdout", process.stdout), ("stderr", process.stderr)):
+        os.set_blocking(stream.fileno(), False)
+        selector.register(stream, selectors.EVENT_READ, label)
+    while selector.get_map():
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            terminate_process_group(process)
+            emit_error("validation_resource_limit:deadline", arguments)
+        events = selector.select(timeout=min(0.05, remaining))
+        if not events and process.poll() is not None:
+            events = [(key, selectors.EVENT_READ) for key in selector.get_map().values()]
+        for key, _ in events:
+            try:
+                chunk = os.read(key.fileobj.fileno(), 65536)
+            except BlockingIOError:
+                continue
+            if not chunk:
+                selector.unregister(key.fileobj)
+                key.fileobj.close()
+                continue
+            target = stdout if key.data == "stdout" else stderr
+            limit = VALIDATION_MAX_STDOUT_BYTES if key.data == "stdout" else VALIDATION_MAX_STDERR_BYTES
+            if len(target) + len(chunk) > limit:
+                terminate_process_group(process)
+                emit_error("validation_resource_limit:subprocess_output", arguments)
+            target.extend(chunk)
+    remaining = deadline - time.monotonic()
+    if remaining <= 0:
+        terminate_process_group(process)
+        emit_error("validation_resource_limit:deadline", arguments)
+    try:
+        returncode = process.wait(timeout=max(0.001, remaining))
+    except subprocess.TimeoutExpired:
+        terminate_process_group(process)
+        emit_error("validation_resource_limit:deadline", arguments)
+except BaseException:
+    terminate_process_group(process)
+    raise
+finally:
+    selector.close()
+    worker_source.close()
+    for stream in (process.stdout, process.stderr):
+        if stream is not None and not stream.closed:
+            stream.close()
+
+sys.stdout.buffer.write(stdout)
+sys.stderr.buffer.write(stderr)
+raise SystemExit(returncode)
+PY
+
+# __REVIEW_EVOLUTION_VALIDATOR_BODY__
 export LC_ALL=C
 
 usage() {
@@ -139,7 +336,7 @@ esac
 requirements="${root}/datarim/tasks/${task}-customer-requirements.yaml"
 review="${root}/datarim/receipts/${task}-review-evolution.yaml"
 receipt="${root}/datarim/receipts/${task}-customer-delivery.yaml"
-script_dir="$(cd "$(/usr/bin/dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+script_dir="$(cd "$(/usr/bin/dirname -- "${REVIEW_EVOLUTION_SCRIPT_PATH:?}")" && pwd -P)"
 trust_registry_schema="${script_dir}/../config/customer-requirement.schema.json"
 
 resolve_artifact() {
@@ -223,15 +420,6 @@ delivery_status=$?
 set -e
 delivery_verified=false
 delivery_inputs_stable=false
-# shellcheck disable=SC2016  # $task is a jq variable.
-if [[ "$delivery_status" -eq 0 ]] \
-    && "$jq_bin" -se --arg task "$task" \
-        'length == 1 and .[0].decision == "MET" and .[0].status == "MET"
-         and .[0].epic_status == "MET" and .[0].stage == "qa"
-         and .[0].task == $task and .[0].findings == []' \
-        "$delivery_output" >/dev/null 2>&1; then
-    delivery_verified=true
-fi
 if [[ "$("$openssl_bin" dgst -sha256 "$requirements" 2>/dev/null | /usr/bin/awk '{print $NF}')" \
         == "$requirements_snapshot_digest" \
     && "$("$openssl_bin" dgst -sha256 "$review" 2>/dev/null | /usr/bin/awk '{print $NF}')" \
@@ -242,6 +430,66 @@ if [[ "$("$openssl_bin" dgst -sha256 "$requirements" 2>/dev/null | /usr/bin/awk 
         == "$trust_registry_snapshot_digest" ]]; then
     delivery_inputs_stable=true
 fi
+if [[ "$delivery_inputs_stable" != true ]]; then
+    emit_config_error 'customer_delivery_inputs_changed'
+    exit 2
+fi
+
+# A2 is a typed dependency: rc 0/1/2 must agree with one exact JSON result.
+# shellcheck disable=SC2016  # $task is a jq variable.
+case "$delivery_status" in
+    0)
+        if "$jq_bin" -se --arg task "$task" '
+          length == 1 and .[0].decision == "MET" and .[0].status == "MET"
+          and .[0].epic_status == "MET" and .[0].stage == "qa"
+          and .[0].task == $task and .[0].findings == []
+          and ((.[0] | keys | sort)
+            == (["decision", "epic_status", "findings", "stage", "status", "task"] | sort))
+        ' "$delivery_output" >/dev/null 2>&1; then
+            delivery_verified=true
+        else
+            emit_config_error 'customer_delivery_result_contract_invalid'
+            exit 2
+        fi
+        ;;
+    1)
+        if ! "$jq_bin" -se --arg task "$task" '
+          length == 1 and .[0].decision == "NOT_MET" and .[0].status == "NOT_MET"
+          and .[0].epic_status == "NOT_MET" and .[0].stage == "qa"
+          and .[0].task == $task
+          and (.[0].findings | type == "array" and length > 0
+            and all(.[]; type == "string"))
+          and ((.[0] | keys | sort)
+            == (["decision", "epic_status", "findings", "stage", "status", "task"] | sort))
+        ' "$delivery_output" >/dev/null 2>&1; then
+            emit_config_error 'customer_delivery_result_contract_invalid'
+            exit 2
+        fi
+        ;;
+    2)
+        if ! "$jq_bin" -se --arg task "$task" '
+          length == 1 and .[0].decision == "ERROR" and .[0].status == "ERROR"
+          and .[0].stage == "qa" and .[0].task == $task
+          and (.[0].findings | type == "array" and length > 0 and length <= 64
+            and all(.[]; type == "string" and length > 0 and length <= 256
+              and test("^[A-Za-z0-9_.:/-]+$")))
+          and ((.[0] | has("epic_status") | not) or .[0].epic_status == "NOT_MET")
+          and ((.[0] | keys - ["decision", "epic_status", "findings", "stage", "status", "task"])
+            | length == 0)
+        ' "$delivery_output" >/dev/null 2>&1; then
+            emit_config_error 'customer_delivery_result_contract_invalid'
+            exit 2
+        fi
+        delivery_error_finding="$("$jq_bin" -sr '.[0].findings | sort | .[0]' \
+            "$delivery_output" 2>/dev/null || true)"
+        emit_config_error "customer_delivery:${delivery_error_finding}"
+        exit 2
+        ;;
+    *)
+        emit_config_error "customer_delivery_exit_invalid:${delivery_status}"
+        exit 2
+        ;;
+esac
 
 if ! "$yq_bin" eval -o=json '.' "$review_snapshot" >"$review_json" 2>/dev/null; then
     printf '%s\n' '{}' >"$review_json"

--- a/dev-tools/check-review-evolution.sh
+++ b/dev-tools/check-review-evolution.sh
@@ -139,6 +139,8 @@ esac
 requirements="${root}/datarim/tasks/${task}-customer-requirements.yaml"
 review="${root}/datarim/receipts/${task}-review-evolution.yaml"
 receipt="${root}/datarim/receipts/${task}-customer-delivery.yaml"
+script_dir="$(cd "$(/usr/bin/dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+trust_registry_schema="${script_dir}/../config/customer-requirement.schema.json"
 
 resolve_artifact() {
     local label="$1"
@@ -174,6 +176,15 @@ artifact_bytes=''
 resolve_artifact customer_requirements "$requirements" || exit 2
 resolve_artifact review_evolution "$review" || exit 2
 resolve_artifact customer_delivery "$receipt" || exit 2
+if [[ ! -f "$trust_registry_schema" || -L "$trust_registry_schema" ]]; then
+    emit_config_error 'missing_dependency:trusted_authority_registry'
+    exit 2
+fi
+trust_registry_bytes="$(/usr/bin/wc -c <"$trust_registry_schema" | /usr/bin/tr -d '[:space:]')"
+if [[ ! "$trust_registry_bytes" =~ ^[0-9]+$ ]] || ((trust_registry_bytes > 1048576)); then
+    emit_config_error 'trusted_authority_registry_too_large'
+    exit 2
+fi
 
 tmp_dir="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/review-evolution.XXXXXX")" || {
     emit_config_error 'temporary_storage_unavailable'
@@ -190,13 +201,15 @@ delivery_output="${tmp_dir}/customer-delivery.json"
 requirements_snapshot="${tmp_dir}/requirements.yaml"
 review_snapshot="${tmp_dir}/review.yaml"
 receipt_snapshot="${tmp_dir}/receipt.yaml"
+trust_registry_snapshot="${tmp_dir}/customer-requirement.schema.json"
 /bin/cp -- "$requirements" "$requirements_snapshot"
 /bin/cp -- "$review" "$review_snapshot"
 /bin/cp -- "$receipt" "$receipt_snapshot"
+/bin/cp -- "$trust_registry_schema" "$trust_registry_snapshot"
 requirements_snapshot_digest="$("$openssl_bin" dgst -sha256 "$requirements_snapshot" | /usr/bin/awk '{print $NF}')"
 review_snapshot_digest="$("$openssl_bin" dgst -sha256 "$review_snapshot" | /usr/bin/awk '{print $NF}')"
 receipt_snapshot_digest="$("$openssl_bin" dgst -sha256 "$receipt_snapshot" | /usr/bin/awk '{print $NF}')"
-script_dir="$(cd "$(/usr/bin/dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+trust_registry_snapshot_digest="$("$openssl_bin" dgst -sha256 "$trust_registry_snapshot" | /usr/bin/awk '{print $NF}')"
 customer_delivery_validator="${script_dir}/check-customer-delivery.sh"
 if [[ ! -f "$customer_delivery_validator" || -L "$customer_delivery_validator" \
     || ! -x "$customer_delivery_validator" ]]; then
@@ -224,7 +237,9 @@ if [[ "$("$openssl_bin" dgst -sha256 "$requirements" 2>/dev/null | /usr/bin/awk 
     && "$("$openssl_bin" dgst -sha256 "$review" 2>/dev/null | /usr/bin/awk '{print $NF}')" \
         == "$review_snapshot_digest" \
     && "$("$openssl_bin" dgst -sha256 "$receipt" 2>/dev/null | /usr/bin/awk '{print $NF}')" \
-        == "$receipt_snapshot_digest" ]]; then
+        == "$receipt_snapshot_digest" \
+    && "$("$openssl_bin" dgst -sha256 "$trust_registry_schema" 2>/dev/null | /usr/bin/awk '{print $NF}')" \
+        == "$trust_registry_snapshot_digest" ]]; then
     delivery_inputs_stable=true
 fi
 
@@ -312,6 +327,17 @@ git_blob_to_file() {
     run_bound_git cat-file blob "${revision}:${path}" >"$destination" 2>/dev/null
 }
 
+git_blob_identity() {
+    local revision="$1" path="$2"
+    local tree_line mode object_type object_id
+    tree_line="$(run_bound_git ls-tree "$revision" -- "$path" 2>/dev/null || true)"
+    [[ -n "$tree_line" && "$tree_line" != *$'\n'* ]] || return 1
+    read -r mode object_type object_id _ <<<"$tree_line"
+    [[ "$mode" == 100644 || "$mode" == 100755 ]] || return 1
+    [[ "$object_type" == blob && "$object_id" =~ ^[0-9a-f]{40}$ ]] || return 1
+    printf '%s\n' "$object_id"
+}
+
 sha256_file() {
     "$openssl_bin" dgst -sha256 "$1" 2>/dev/null | /usr/bin/awk '{print "sha256:" $NF}'
 }
@@ -323,6 +349,106 @@ valid_timestamp_shape() {
     # shellcheck disable=SC2016  # $timestamp is a jq variable.
     "$jq_bin" -en --arg timestamp "$timestamp" \
         '$timestamp | fromdateiso8601' >/dev/null 2>&1
+}
+
+timestamp_not_before() {
+    local later="$1" earlier="$2"
+    # shellcheck disable=SC2016  # jq variables are intentionally quoted literally.
+    "$jq_bin" -en --arg later "$later" --arg earlier "$earlier" \
+        '($later | fromdateiso8601) >= ($earlier | fromdateiso8601)' >/dev/null 2>&1
+}
+
+verify_ed25519_payload() {
+    local payload_file="$1" signature="$2" public_key="$3"
+    local public_der="${tmp_dir}/decision-public.der"
+    local signature_file="${tmp_dir}/decision-signature.bin"
+    [[ "$signature" == ed25519:* ]] || return 1
+    [[ "$public_key" =~ ^[A-Za-z0-9+/]{43}=$ ]] || return 1
+    /usr/bin/printf '\x30\x2a\x30\x05\x06\x03\x2b\x65\x70\x03\x21\x00' >"$public_der"
+    /usr/bin/printf '%s' "$public_key" | "$openssl_bin" base64 -d -A >>"$public_der" 2>/dev/null \
+        || return 1
+    /usr/bin/printf '%s' "${signature#ed25519:}" \
+        | "$openssl_bin" base64 -d -A >"$signature_file" 2>/dev/null || return 1
+    [[ "$(/usr/bin/wc -c <"$public_der" | /usr/bin/tr -d '[:space:]')" == 44 ]] || return 1
+    [[ "$(/usr/bin/wc -c <"$signature_file" | /usr/bin/tr -d '[:space:]')" == 64 ]] || return 1
+    "$openssl_bin" pkeyutl -verify -pubin -keyform DER -inkey "$public_der" -rawin \
+        -in "$payload_file" -sigfile "$signature_file" >/dev/null 2>&1
+}
+
+validate_no_canon_decision() {
+    local evidence_path="$1" approval_reviewer="$2" approval_time="$3"
+    local decision_file="${tmp_dir}/no-canon-decision.json"
+    local payload_file="${tmp_dir}/no-canon-decision-payload.json"
+    local declared_digest computed_digest signature key_id public_key registry_match_count
+    if ! is_safe_relative_path "$evidence_path" \
+        || ! git_blob_to_file "$bound_head" "$evidence_path" "$decision_file"; then
+        return 1
+    fi
+    # shellcheck disable=SC2016  # Closed JSON envelope is validated by jq.
+    "$jq_bin" -e '
+      type == "object" and
+      (keys | sort) == ([
+        "algorithm", "approved", "approved_at", "authority_id", "authority_role",
+        "decision", "decision_evidence_ref", "delivery_receipt_id", "finding_evidence_ref",
+        "key_id", "originating_review_digest", "originating_review_id", "payload_digest",
+        "requirement_id", "reviewer", "schema_version", "signature", "task_id"
+      ] | sort) and
+      .schema_version == 1 and .decision == "NO_CANON_CHANGE" and .approved == true and
+      (.payload_digest | type == "string" and test("^sha256:[0-9a-f]{64}$")) and
+      (.signature | type == "string" and startswith("ed25519:"))
+    ' "$decision_file" >/dev/null 2>&1 || return 1
+
+    [[ "$(jq_raw '.task_id' "$decision_file")" == "$task" ]] || return 1
+    [[ "$(jq_raw '.requirement_id' "$decision_file")" == "$review_requirement" ]] || return 1
+    [[ "$(jq_raw '.delivery_receipt_id' "$decision_file")" == "$review_receipt" ]] || return 1
+    [[ "$(jq_raw '.originating_review_id' "$decision_file")" == "$review_id" ]] || return 1
+    [[ "$(jq_raw '.originating_review_digest' "$decision_file")" == "$signed_review_digest" ]] \
+        || return 1
+    [[ "$(jq_raw '.reviewer' "$decision_file")" == "$signed_review_reviewer" ]] || return 1
+    [[ "$approval_reviewer" == "$signed_review_reviewer" ]] || return 1
+    [[ "$(jq_raw '.approved_at' "$decision_file")" == "$approval_time" ]] || return 1
+    valid_timestamp_shape "$approval_time" || return 1
+    timestamp_not_before "$approval_time" "$signed_review_observed_at" || return 1
+    [[ "$(jq_raw '.finding_evidence_ref' "$decision_file")" == "$signed_review_evidence" ]] \
+        || return 1
+    [[ "$(jq_raw '.decision_evidence_ref' "$decision_file")" == "$evidence_path" ]] || return 1
+    is_safe_relative_path "$signed_review_evidence" \
+        && git_blob_to_file "$bound_head" "$signed_review_evidence" \
+            "${tmp_dir}/no-canon-finding-evidence" || return 1
+    [[ "$(jq_raw '.authority_id' "$decision_file")" == "$signed_authority_id" ]] || return 1
+    [[ "$(jq_raw '.authority_role' "$decision_file")" == "$signed_authority_role" ]] || return 1
+    [[ "$(jq_raw '.algorithm' "$decision_file")" == ED25519 ]] || return 1
+    key_id="$(jq_raw '.key_id' "$decision_file")"
+    [[ "$key_id" == "$signed_authority_key_id" ]] || return 1
+
+    # A2 has already authenticated this byte-stable bundled registry and review record.
+    # shellcheck disable=SC2016  # jq variables are intentionally quoted literally.
+    registry_match_count="$("$jq_bin" -r --arg key "$key_id" \
+        '[."x-datarim-signature-contract".key_resolution.bundled_registry.entries[]?
+          | select(.key_id == $key)] | length' "$trust_registry_snapshot" 2>/dev/null || true)"
+    [[ "$registry_match_count" == 1 ]] || return 1
+    # shellcheck disable=SC2016  # jq variables are intentionally quoted literally.
+    "$jq_bin" -e --arg key "$key_id" --arg authority "$signed_authority_id" \
+        --arg role "$signed_authority_role" --arg approved_at "$approval_time" '
+          ."x-datarim-signature-contract".key_resolution.bundled_registry.entries
+          | map(select(.key_id == $key))[0]
+          | .authority_id == $authority and (.allowed_roles | index($role) != null)
+            and .status == "ACTIVE"
+            and ((.valid_from | fromdateiso8601) <= ($approved_at | fromdateiso8601))
+            and (.valid_until == null or (($approved_at | fromdateiso8601) < (.valid_until | fromdateiso8601)))
+        ' "$trust_registry_snapshot" >/dev/null 2>&1 || return 1
+    # shellcheck disable=SC2016  # jq variables are intentionally quoted literally.
+    public_key="$("$jq_bin" -r --arg key "$key_id" \
+        '."x-datarim-signature-contract".key_resolution.bundled_registry.entries[]
+          | select(.key_id == $key) | .public_key' "$trust_registry_snapshot" 2>/dev/null || true)"
+
+    "$jq_bin" -cS 'del(.payload_digest, .signature)' "$decision_file" >"$payload_file" \
+        2>/dev/null || return 1
+    declared_digest="$(jq_raw '.payload_digest' "$decision_file")"
+    computed_digest="$(sha256_file "$payload_file")"
+    [[ "$declared_digest" == "$computed_digest" ]] || return 1
+    signature="$(jq_raw '.signature' "$decision_file")"
+    verify_ed25519_payload "$payload_file" "$signature" "$public_key"
 }
 
 validate_evolution_evidence() {
@@ -344,14 +470,16 @@ validate_evolution_evidence() {
 
 validate_canonical_evolution() {
     local classification_value="$1"
-    local artifact_path artifact_revision artifact_digest recorded_at reviewed_at
+    local artifact_path artifact_revision artifact_digest recorded_at change_kind
     local red_path green_path artifact_file revision_valid=false recorded_valid=false
     local commit_after_review commit_before_record red_digest green_digest
+    local revision_parent_line child_identity parent_identity
+    local -a revision_parts=()
     artifact_path="$(jq_raw '.canonical_change.artifact_id' "$review_json")"
     artifact_revision="$(jq_raw '.canonical_change.artifact_revision' "$review_json")"
     artifact_digest="$(jq_raw '.canonical_change.digest' "$review_json")"
     recorded_at="$(jq_raw '.canonical_change.recorded_at' "$review_json")"
-    reviewed_at="$(jq_raw '.reviewed_at' "$review_json")"
+    change_kind="$(jq_raw '.canonical_change.change_kind' "$review_json")"
     red_path="$(jq_raw '.canonical_change.enforcement.red_evidence' "$review_json")"
     green_path="$(jq_raw '.canonical_change.enforcement.green_evidence' "$review_json")"
     artifact_file="${tmp_dir}/canonical-artifact"
@@ -359,6 +487,10 @@ validate_canonical_evolution() {
     if [[ "$artifact_revision" =~ ^[0-9a-f]{40}$ ]] \
         && run_bound_git cat-file -e "${artifact_revision}^{commit}" 2>/dev/null; then
         revision_valid=true
+        if ! run_bound_git merge-base --is-ancestor "$artifact_revision" "$bound_head" \
+            >/dev/null 2>&1; then
+            add_finding "canonical_change_revision_not_ancestor:${classification_value}"
+        fi
     else
         add_finding "canonical_change_invalid_revision:${classification_value}"
     fi
@@ -377,13 +509,41 @@ validate_canonical_evolution() {
         add_finding "canonical_change_digest_mismatch:${classification_value}"
     fi
 
+    if [[ "$revision_valid" == true ]] && is_safe_relative_path "$artifact_path"; then
+        revision_parent_line="$(run_bound_git rev-list --parents -n 1 "$artifact_revision" \
+            2>/dev/null || true)"
+        read -r -a revision_parts <<<"$revision_parent_line"
+        if ((${#revision_parts[@]} > 2)); then
+            add_finding "canonical_change_merge_revision_unsupported:${classification_value}"
+        elif ((${#revision_parts[@]} != 2)); then
+            add_finding "canonical_change_revision_parent_invalid:${classification_value}"
+        else
+            child_identity="$(git_blob_identity "$artifact_revision" "$artifact_path" || true)"
+            parent_identity="$(git_blob_identity "${revision_parts[1]}" "$artifact_path" || true)"
+            case "$change_kind" in
+                NEW_ARTIFACT)
+                    if [[ -n "$parent_identity" ]]; then
+                        add_finding "canonical_change_new_artifact_preexisting:${classification_value}"
+                    fi
+                    ;;
+                ARTIFACT_REVISION)
+                    if [[ -z "$parent_identity" ]]; then
+                        add_finding "canonical_change_revision_parent_missing_artifact:${classification_value}"
+                    elif [[ -n "$child_identity" && "$child_identity" == "$parent_identity" ]]; then
+                        add_finding "canonical_change_artifact_unchanged:${classification_value}"
+                    fi
+                    ;;
+            esac
+        fi
+    fi
+
     if valid_timestamp_shape "$recorded_at"; then
         recorded_valid=true
     else
         add_finding "canonical_change_invalid_recorded_at:${classification_value}"
     fi
     if [[ "$revision_valid" == true && "$recorded_valid" == true ]]; then
-        commit_after_review="$(run_bound_git log -1 --format=%H --since="$reviewed_at" \
+        commit_after_review="$(run_bound_git log -1 --format=%H --since="$signed_review_observed_at" \
             "$artifact_revision" 2>/dev/null || true)"
         if [[ "$commit_after_review" != "$artifact_revision" ]]; then
             add_finding "canonical_change_post_hoc:${classification_value}"
@@ -408,13 +568,56 @@ validate_canonical_evolution() {
 }
 
 classification="$(jq_raw '.classification' "$review_json")"
+review_id="$(jq_raw '.review_id' "$review_json")"
 review_requirement="$(jq_raw '.requirement_id' "$review_json")"
 review_receipt="$(jq_raw '.delivery_receipt_id' "$review_json")"
 receipt_id="$(jq_raw '.receipt_id' "$receipt_json")"
 product_requirement="$(jq_raw '.product_fix.requirement_id' "$review_json")"
 product_receipt="$(jq_raw '.product_fix.delivery_receipt_id' "$review_json")"
 product_status="$(jq_raw '.product_fix.status' "$review_json")"
-reviewer="$(jq_raw '.reviewer' "$review_json")"
+# shellcheck disable=SC2016  # jq variables are intentionally quoted literally.
+authoritative_review_count="$("$jq_bin" -r --arg review "$review_id" --arg requirement "$review_requirement" \
+    '[.originating_review_inventory[]?
+      | select(.review_id == $review and .requirement_id == $requirement)] | length' \
+    "$review_json" 2>/dev/null || true)"
+signed_review_reviewer=''
+signed_review_evidence=''
+signed_review_digest=''
+signed_review_observed_at=''
+signed_authority_id=''
+signed_authority_role=''
+signed_authority_key_id=''
+if [[ "$authoritative_review_count" == 1 ]]; then
+    # shellcheck disable=SC2016  # jq variables are intentionally quoted literally.
+    authoritative_review_query='[.originating_review_inventory[]
+      | select(.review_id == $review and .requirement_id == $requirement)][0]'
+    signed_review_reviewer="$("$jq_bin" -r --arg review "$review_id" \
+        --arg requirement "$review_requirement" "${authoritative_review_query}.reviewer // \"\"" \
+        "$review_json" 2>/dev/null || true)"
+    signed_review_evidence="$("$jq_bin" -r --arg review "$review_id" \
+        --arg requirement "$review_requirement" "${authoritative_review_query}.evidence_ref // \"\"" \
+        "$review_json" 2>/dev/null || true)"
+    signed_review_digest="$("$jq_bin" -r --arg review "$review_id" \
+        --arg requirement "$review_requirement" "${authoritative_review_query}.review_digest // \"\"" \
+        "$review_json" 2>/dev/null || true)"
+    signed_review_observed_at="$("$jq_bin" -r --arg review "$review_id" \
+        --arg requirement "$review_requirement" "${authoritative_review_query}.observed_at // \"\"" \
+        "$review_json" 2>/dev/null || true)"
+    signed_authority_id="$("$jq_bin" -r --arg review "$review_id" \
+        --arg requirement "$review_requirement" \
+        "${authoritative_review_query}.authority_approval.authority_id // \"\"" \
+        "$review_json" 2>/dev/null || true)"
+    signed_authority_role="$("$jq_bin" -r --arg review "$review_id" \
+        --arg requirement "$review_requirement" \
+        "${authoritative_review_query}.authority_approval.authority_role // \"\"" \
+        "$review_json" 2>/dev/null || true)"
+    signed_authority_key_id="$("$jq_bin" -r --arg review "$review_id" \
+        --arg requirement "$review_requirement" \
+        "${authoritative_review_query}.authority_approval.key_id // \"\"" \
+        "$review_json" 2>/dev/null || true)"
+else
+    add_finding "originating_review_binding_invalid:${review_id}:${review_requirement}"
+fi
 task_prefix="${task%-*}"
 task_number="${task##*-}"
 task_prefix_lower="$(printf '%s' "$task_prefix" | /usr/bin/tr '[:upper:]' '[:lower:]')"
@@ -481,23 +684,17 @@ case "$classification" in
             jq_has_nonempty_string '.no_canon_change.reviewer_approval.approved_at' "$review_json" || \
                 add_finding 'no_canon_change_missing_approved_at'
             approval_reviewer="$(jq_raw '.no_canon_change.reviewer_approval.reviewer' "$review_json")"
-            if [[ "$approval_reviewer" != "$reviewer" ]]; then
-                add_finding "no_canon_change_reviewer_mismatch:${reviewer}:${approval_reviewer}"
+            if [[ "$approval_reviewer" != "$signed_review_reviewer" ]]; then
+                add_finding "no_canon_change_reviewer_mismatch:${signed_review_reviewer}:${approval_reviewer}"
             fi
             no_canon_evidence="$(jq_raw '.no_canon_change.evidence' "$review_json")"
-            signed_review_evidence="$(jq_raw '.originating_review.evidence_ref' "$review_json")"
             approval_time="$(jq_raw '.no_canon_change.reviewer_approval.approved_at' "$review_json")"
-            signed_approval_time="$(jq_raw '.originating_review.authority_approval.approved_at' "$review_json")"
-            if [[ "$no_canon_evidence" != "$signed_review_evidence" ]] \
-                || ! is_safe_relative_path "$no_canon_evidence" \
-                || ! git_blob_to_file "$bound_head" "$no_canon_evidence" "${tmp_dir}/no-canon-evidence"; then
-                add_finding 'no_canon_change_evidence_not_authenticated'
-            fi
-            if [[ "$approval_time" != "$signed_approval_time" ]]; then
-                add_finding 'no_canon_change_approval_not_authenticated'
-            fi
             if ! valid_timestamp_shape "$approval_time"; then
                 add_finding 'no_canon_change_invalid_approved_at'
+            fi
+            if ! validate_no_canon_decision "$no_canon_evidence" "$approval_reviewer" \
+                "$approval_time"; then
+                add_finding 'no_canon_change_decision_not_authenticated'
             fi
         fi
         if [[ "$(jq_type '.canonical_change' "$review_json")" != null ]]; then

--- a/dev-tools/check-review-evolution.sh
+++ b/dev-tools/check-review-evolution.sh
@@ -380,6 +380,7 @@ validate_no_canon_decision() {
     local decision_file="${tmp_dir}/no-canon-decision.json"
     local payload_file="${tmp_dir}/no-canon-decision-payload.json"
     local declared_digest computed_digest signature key_id public_key registry_match_count
+    local canonical_decision_payload
     if ! is_safe_relative_path "$evidence_path" \
         || ! git_blob_to_file "$bound_head" "$evidence_path" "$decision_file"; then
         return 1
@@ -390,8 +391,9 @@ validate_no_canon_decision() {
       (keys | sort) == ([
         "algorithm", "approved", "approved_at", "authority_id", "authority_role",
         "decision", "decision_evidence_ref", "delivery_receipt_id", "finding_evidence_ref",
-        "key_id", "originating_review_digest", "originating_review_id", "payload_digest",
-        "requirement_id", "reviewer", "schema_version", "signature", "task_id"
+        "key_id", "originating_review_digest", "originating_review_id",
+        "originating_review_observed_at", "payload_digest", "requirement_id", "reviewer",
+        "schema_version", "signature", "task_id"
       ] | sort) and
       .schema_version == 1 and .decision == "NO_CANON_CHANGE" and .approved == true and
       (.payload_digest | type == "string" and test("^sha256:[0-9a-f]{64}$")) and
@@ -404,6 +406,9 @@ validate_no_canon_decision() {
     [[ "$(jq_raw '.originating_review_id' "$decision_file")" == "$review_id" ]] || return 1
     [[ "$(jq_raw '.originating_review_digest' "$decision_file")" == "$signed_review_digest" ]] \
         || return 1
+    [[ "$(jq_raw '.originating_review_observed_at' "$decision_file")" \
+        == "$signed_review_observed_at" ]] || return 1
+    [[ "$signed_review_digest_valid" == true ]] || return 1
     [[ "$(jq_raw '.reviewer' "$decision_file")" == "$signed_review_reviewer" ]] || return 1
     [[ "$approval_reviewer" == "$signed_review_reviewer" ]] || return 1
     [[ "$(jq_raw '.approved_at' "$decision_file")" == "$approval_time" ]] || return 1
@@ -442,8 +447,10 @@ validate_no_canon_decision() {
         '."x-datarim-signature-contract".key_resolution.bundled_registry.entries[]
           | select(.key_id == $key) | .public_key' "$trust_registry_snapshot" 2>/dev/null || true)"
 
-    "$jq_bin" -cS 'del(.payload_digest, .signature)' "$decision_file" >"$payload_file" \
-        2>/dev/null || return 1
+    canonical_decision_payload="$("$jq_bin" -cS 'del(.payload_digest, .signature)' \
+        "$decision_file" 2>/dev/null || true)"
+    [[ -n "$canonical_decision_payload" ]] || return 1
+    /usr/bin/printf '%s' "$canonical_decision_payload" >"$payload_file"
     declared_digest="$(jq_raw '.payload_digest' "$decision_file")"
     computed_digest="$(sha256_file "$payload_file")"
     [[ "$declared_digest" == "$computed_digest" ]] || return 1
@@ -543,10 +550,14 @@ validate_canonical_evolution() {
         add_finding "canonical_change_invalid_recorded_at:${classification_value}"
     fi
     if [[ "$revision_valid" == true && "$recorded_valid" == true ]]; then
-        commit_after_review="$(run_bound_git log -1 --format=%H --since="$signed_review_observed_at" \
-            "$artifact_revision" 2>/dev/null || true)"
-        if [[ "$commit_after_review" != "$artifact_revision" ]]; then
-            add_finding "canonical_change_post_hoc:${classification_value}"
+        if [[ "$signed_review_digest_valid" == true ]]; then
+            commit_after_review="$(run_bound_git log -1 --format=%H \
+                --since="$signed_review_observed_at" "$artifact_revision" 2>/dev/null || true)"
+            if [[ "$commit_after_review" != "$artifact_revision" ]]; then
+                add_finding "canonical_change_post_hoc:${classification_value}"
+            fi
+        else
+            add_finding "canonical_change_review_time_not_authenticated:${classification_value}"
         fi
         commit_before_record="$(run_bound_git log -1 --format=%H --until="$recorded_at" \
             "$artifact_revision" 2>/dev/null || true)"
@@ -587,6 +598,7 @@ signed_review_observed_at=''
 signed_authority_id=''
 signed_authority_role=''
 signed_authority_key_id=''
+signed_review_digest_valid=false
 if [[ "$authoritative_review_count" == 1 ]]; then
     # shellcheck disable=SC2016  # jq variables are intentionally quoted literally.
     authoritative_review_query='[.originating_review_inventory[]
@@ -615,6 +627,34 @@ if [[ "$authoritative_review_count" == 1 ]]; then
         --arg requirement "$review_requirement" \
         "${authoritative_review_query}.authority_approval.key_id // \"\"" \
         "$review_json" 2>/dev/null || true)"
+    # Recompute the A2-signed primary record commitment before trusting observed_at.
+    # shellcheck disable=SC2016  # jq variables are intentionally quoted literally.
+    canonical_review_payload="$("$jq_bin" -cS --arg review "$review_id" \
+        --arg requirement "$review_requirement" '
+          [.originating_review_inventory[]
+            | select(.review_id == $review and .requirement_id == $requirement)][0]
+          | {
+              review_id: .review_id,
+              requirement_id: .requirement_id,
+              delivery_receipt_id: .delivery_receipt_id,
+              reviewer: .reviewer,
+              review_ref: .review_ref,
+              state: .state,
+              observed_at: .observed_at,
+              evidence_ref: .evidence_ref
+            }
+        ' "$review_json" 2>/dev/null || true)"
+    if [[ -n "$canonical_review_payload" ]]; then
+        /usr/bin/printf '%s' "$canonical_review_payload" >"${tmp_dir}/originating-review-payload.json"
+        if [[ "$signed_review_digest" == "$(sha256_file \
+            "${tmp_dir}/originating-review-payload.json")" ]]; then
+            signed_review_digest_valid=true
+        else
+            add_finding "originating_review_digest_mismatch:${review_id}"
+        fi
+    else
+        add_finding "originating_review_digest_mismatch:${review_id}"
+    fi
 else
     add_finding "originating_review_binding_invalid:${review_id}:${review_requirement}"
 fi

--- a/dev-tools/check-review-evolution.sh
+++ b/dev-tools/check-review-evolution.sh
@@ -1,0 +1,345 @@
+#!/bin/bash -p
+# Validate the review-to-evolution contract without treating canon evolution as
+# proof that the associated customer Requirement was delivered.
+#
+# Exit codes: 0 MET, 1 semantic NOT_MET, 2 usage/configuration error.
+set -euo pipefail
+IFS=$'\n\t'
+export LC_ALL=C
+
+usage() {
+    cat <<'EOF'
+usage: check-review-evolution.sh --root DIR --task TASK-ID [--format text|json]
+
+Reads exactly these canonical task-bound artifacts below DIR:
+  datarim/receipts/<TASK-ID>-review-evolution.yaml
+  datarim/receipts/<TASK-ID>-customer-delivery.yaml
+
+Exit codes: 0 MET, 1 semantic NOT_MET, 2 usage/configuration error.
+EOF
+}
+
+root=''
+task=''
+format='text'
+parse_error=''
+while (($#)); do
+    case "$1" in
+        --root|--task|--format)
+            option="$1"
+            if (($# < 2)); then
+                parse_error='invalid_usage'
+                break
+            fi
+            value="$2"
+            case "$option" in
+                --root) root="$value" ;;
+                --task) task="$value" ;;
+                --format) format="$value" ;;
+            esac
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            parse_error='invalid_usage'
+            shift
+            ;;
+    esac
+done
+
+emit_config_error() {
+    local finding="$1"
+    local safe_task=''
+    [[ "$task" =~ ^[A-Z][A-Z0-9]{1,9}-[0-9]{4}$ ]] && safe_task="$task"
+    if [[ "$format" == json ]]; then
+        printf '{"classification":"","findings":["%s"],"status":"ERROR","task":"%s"}\n' \
+            "$finding" "$safe_task"
+    else
+        printf 'status=ERROR task=%s classification= findings=%s\n' "$safe_task" "$finding"
+        printf 'finding=%s\n' "$finding"
+    fi
+}
+
+if [[ -n "$parse_error" || -z "$root" || -z "$task" ]]; then
+    emit_config_error 'invalid_usage'
+    exit 2
+fi
+[[ "$format" == text || "$format" == json ]] || {
+    format='text'
+    emit_config_error 'invalid_format'
+    exit 2
+}
+[[ "$task" =~ ^[A-Z][A-Z0-9]{1,9}-[0-9]{4}$ ]] || {
+    emit_config_error 'invalid_task'
+    exit 2
+}
+[[ -d "$root" && ! -L "$root" ]] || {
+    emit_config_error 'invalid_root'
+    exit 2
+}
+root="$(cd "$root" && pwd -P)"
+
+select_tool() {
+    local candidate
+    for candidate in "$@"; do
+        if [[ -x "$candidate" && ! -d "$candidate" ]]; then
+            selected_tool="$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+
+selected_tool=''
+select_tool /usr/local/bin/yq /opt/homebrew/bin/yq /usr/bin/yq || {
+    emit_config_error 'missing_dependency:yq'
+    exit 2
+}
+yq_bin="$selected_tool"
+select_tool /usr/bin/jq /usr/local/bin/jq /opt/homebrew/bin/jq || {
+    emit_config_error 'missing_dependency:jq'
+    exit 2
+}
+jq_bin="$selected_tool"
+
+review="${root}/datarim/receipts/${task}-review-evolution.yaml"
+receipt="${root}/datarim/receipts/${task}-customer-delivery.yaml"
+
+resolve_artifact() {
+    local label="$1"
+    local candidate="$2"
+    local resolved_dir
+    if [[ ! -f "$candidate" ]]; then
+        emit_config_error "missing_artifact:${label}"
+        return 2
+    fi
+    if [[ -L "$candidate" ]]; then
+        emit_config_error "path_escape:${label}"
+        return 2
+    fi
+    resolved_dir="$(cd -P -- "${candidate%/*}" && pwd -P)" || {
+        emit_config_error "path_escape:${label}"
+        return 2
+    }
+    case "${resolved_dir}/${candidate##*/}" in
+        "$root"/*) ;;
+        *)
+            emit_config_error "path_escape:${label}"
+            return 2
+            ;;
+    esac
+    artifact_bytes="$(/usr/bin/wc -c <"$candidate" | /usr/bin/tr -d '[:space:]')"
+    if [[ ! "$artifact_bytes" =~ ^[0-9]+$ ]] || ((artifact_bytes > 1048576)); then
+        emit_config_error "artifact_too_large:${label}"
+        return 2
+    fi
+}
+
+artifact_bytes=''
+resolve_artifact review_evolution "$review" || exit 2
+resolve_artifact customer_delivery "$receipt" || exit 2
+
+tmp_dir="$(/usr/bin/mktemp -d "${TMPDIR:-/tmp}/review-evolution.XXXXXX")" || {
+    emit_config_error 'temporary_storage_unavailable'
+    exit 2
+}
+cleanup() {
+    # shellcheck disable=SC2317  # Called indirectly by the trap below.
+    /bin/rm -rf -- "$tmp_dir"
+}
+trap cleanup EXIT HUP INT TERM
+review_json="${tmp_dir}/review.json"
+receipt_json="${tmp_dir}/receipt.json"
+
+if ! "$yq_bin" eval -o=json '.' "$review" >"$review_json" 2>/dev/null; then
+    printf '%s\n' '{}' >"$review_json"
+    review_parse_error=true
+else
+    review_parse_error=false
+fi
+if ! "$yq_bin" eval -o=json '.' "$receipt" >"$receipt_json" 2>/dev/null; then
+    printf '%s\n' '{}' >"$receipt_json"
+    receipt_parse_error=true
+else
+    receipt_parse_error=false
+fi
+
+findings=()
+add_finding() {
+    local finding="$1"
+    local existing
+    for existing in "${findings[@]:-}"; do
+        [[ "$existing" == "$finding" ]] && return 0
+    done
+    findings+=("$finding")
+}
+
+if [[ "$review_parse_error" == true ]]; then
+    add_finding 'malformed_yaml:review_evolution'
+fi
+if [[ "$receipt_parse_error" == true ]]; then
+    add_finding 'malformed_yaml:customer_delivery'
+fi
+
+jq_raw() {
+    "$jq_bin" -r "$1 // \"\" | if type == \"string\" then . else tostring end" "$2" 2>/dev/null || true
+}
+jq_type() {
+    "$jq_bin" -r "$1 | type" "$2" 2>/dev/null || printf 'null\n'
+}
+jq_true() {
+    "$jq_bin" -e "$1 == true" "$2" >/dev/null 2>&1
+}
+jq_has_nonempty_string() {
+    "$jq_bin" -e "$1 | type == \"string\" and length > 0" "$2" >/dev/null 2>&1
+}
+
+classification="$(jq_raw '.classification' "$review_json")"
+review_requirement="$(jq_raw '.requirement_id' "$review_json")"
+review_receipt="$(jq_raw '.delivery_receipt_id' "$review_json")"
+receipt_id="$(jq_raw '.receipt_id' "$receipt_json")"
+product_requirement="$(jq_raw '.product_fix.requirement_id' "$review_json")"
+product_receipt="$(jq_raw '.product_fix.delivery_receipt_id' "$review_json")"
+product_status="$(jq_raw '.product_fix.status' "$review_json")"
+reviewer="$(jq_raw '.reviewer' "$review_json")"
+
+case "$classification" in
+    ABSENT|WEAK|STALE|MIS_SCOPED|NOT_BOUND)
+        if [[ "$(jq_type '.canonical_change' "$review_json")" != object ]]; then
+            add_finding "classification_requires_canonical_change:${classification}"
+        else
+            jq_has_nonempty_string '.canonical_change.artifact_id' "$review_json" || \
+                add_finding "canonical_change_missing_artifact:${classification}"
+            jq_has_nonempty_string '.canonical_change.artifact_revision' "$review_json" || \
+                add_finding "canonical_change_missing_revision:${classification}"
+            change_kind="$(jq_raw '.canonical_change.change_kind' "$review_json")"
+            if [[ "$change_kind" != NEW_ARTIFACT && "$change_kind" != ARTIFACT_REVISION ]]; then
+                add_finding "canonical_change_invalid_kind:${classification}"
+            fi
+            change_digest="$(jq_raw '.canonical_change.digest' "$review_json")"
+            [[ "$change_digest" =~ ^sha256:[0-9a-f]{64}$ ]] || \
+                add_finding "canonical_change_invalid_digest:${classification}"
+            jq_has_nonempty_string '.canonical_change.recorded_at' "$review_json" || \
+                add_finding "canonical_change_missing_recorded_at:${classification}"
+            jq_has_nonempty_string '.canonical_change.enforcement.mechanism' "$review_json" || \
+                add_finding "canonical_change_missing_mechanism:${classification}"
+            jq_has_nonempty_string '.canonical_change.enforcement.owner' "$review_json" || \
+                add_finding "canonical_change_missing_owner:${classification}"
+            jq_true '.canonical_change.enforcement.red_capable' "$review_json" || \
+                add_finding "canonical_change_not_red_capable:${classification}"
+            jq_has_nonempty_string '.canonical_change.enforcement.red_evidence' "$review_json" || \
+                add_finding "canonical_change_missing_red_evidence:${classification}"
+            jq_has_nonempty_string '.canonical_change.enforcement.green_evidence' "$review_json" || \
+                add_finding "canonical_change_missing_green_evidence:${classification}"
+            red_evidence="$(jq_raw '.canonical_change.enforcement.red_evidence' "$review_json")"
+            green_evidence="$(jq_raw '.canonical_change.enforcement.green_evidence' "$review_json")"
+            if [[ -n "$red_evidence" && "$red_evidence" == "$green_evidence" ]]; then
+                add_finding "canonical_change_red_green_evidence_not_distinct:${classification}"
+            fi
+        fi
+        if [[ "$(jq_type '.no_canon_change' "$review_json")" != null ]]; then
+            add_finding "classification_forbids_no_canon_change:${classification}"
+        fi
+        ;;
+    NO_CANON_CHANGE)
+        if [[ "$(jq_type '.no_canon_change' "$review_json")" != object ]]; then
+            add_finding 'classification_requires_no_canon_change:NO_CANON_CHANGE'
+        else
+            jq_has_nonempty_string '.no_canon_change.evidence' "$review_json" || \
+                add_finding 'no_canon_change_missing_evidence'
+            jq_true '.no_canon_change.reviewer_approval.approved' "$review_json" || \
+                add_finding 'no_canon_change_not_approved'
+            jq_has_nonempty_string '.no_canon_change.reviewer_approval.reviewer' "$review_json" || \
+                add_finding 'no_canon_change_missing_reviewer'
+            jq_has_nonempty_string '.no_canon_change.reviewer_approval.approved_at' "$review_json" || \
+                add_finding 'no_canon_change_missing_approved_at'
+            approval_reviewer="$(jq_raw '.no_canon_change.reviewer_approval.reviewer' "$review_json")"
+            if [[ "$approval_reviewer" != "$reviewer" ]]; then
+                add_finding "no_canon_change_reviewer_mismatch:${reviewer}:${approval_reviewer}"
+            fi
+        fi
+        if [[ "$(jq_type '.canonical_change' "$review_json")" != null ]]; then
+            add_finding 'classification_forbids_canonical_change:NO_CANON_CHANGE'
+        fi
+        ;;
+    *) add_finding "invalid_classification:${classification}" ;;
+esac
+
+[[ "$review_receipt" == "$receipt_id" ]] || \
+    add_finding "review_receipt_mismatch:${receipt_id}:${review_receipt}"
+[[ "$product_requirement" == "$review_requirement" ]] || \
+    add_finding "product_fix_requirement_mismatch:${review_requirement}:${product_requirement}"
+[[ "$product_receipt" == "$review_receipt" ]] || \
+    add_finding "product_fix_receipt_mismatch:${review_receipt}:${product_receipt}"
+[[ "$product_status" == DELIVERED ]] || \
+    add_finding "product_fix_status_not_delivered:${review_requirement}"
+jq_true '.product_fix.substitution_prohibited' "$review_json" || \
+    add_finding "product_fix_substitution_not_prohibited:${review_requirement}"
+
+# shellcheck disable=SC2016  # $id is a jq variable, not a shell variable.
+if ! "$jq_bin" -e --arg id "$review_requirement" \
+    '.parent_links | type == "array" and any(.[]; .relation == "requirement" and .id == $id)' \
+    "$review_json" >/dev/null 2>&1; then
+    add_finding "missing_parent_link:requirement:${review_requirement}"
+fi
+# shellcheck disable=SC2016  # $id is a jq variable, not a shell variable.
+if ! "$jq_bin" -e --arg id "$review_receipt" \
+    '.parent_links | type == "array" and any(.[]; .relation == "delivery_receipt" and .id == $id)' \
+    "$review_json" >/dev/null 2>&1; then
+    add_finding "missing_parent_link:delivery_receipt:${review_receipt}"
+fi
+while IFS=$'\t' read -r parent_relation parent_id; do
+    [[ -n "$parent_relation" && -n "$parent_id" ]] || continue
+    # shellcheck disable=SC2016  # $relation and $id are jq variables.
+    if ! "$jq_bin" -e --arg relation "$parent_relation" --arg id "$parent_id" \
+        '.parent_links | type == "array" and any(.[]; .relation == $relation and .id == $id)' \
+        "$review_json" >/dev/null 2>&1; then
+        add_finding "missing_parent_link:${parent_relation}:${parent_id}"
+    fi
+done < <("$jq_bin" -r \
+    '.parent_links[]? | select(.relation == "epic" or .relation == "task") | [.relation, .id] | @tsv' \
+    "$receipt_json" 2>/dev/null || true)
+
+# shellcheck disable=SC2016  # $id is a jq variable, not a shell variable.
+coverage_status="$("$jq_bin" -r --arg id "$review_requirement" \
+    '.requirements[$id].coverage_status // ""' "$receipt_json" 2>/dev/null || true)"
+# shellcheck disable=SC2016  # $id is a jq variable, not a shell variable.
+disposition_status="$("$jq_bin" -r --arg id "$review_requirement" \
+    '.requirements[$id].coverage_chain.customer_disposition.status // ""' "$receipt_json" 2>/dev/null || true)"
+if [[ "$coverage_status" != MET || \
+      ("$disposition_status" != accepted && "$disposition_status" != superseded) ]]; then
+    add_finding "product_requirement_not_delivered:${review_requirement}"
+fi
+
+if ((${#findings[@]})); then
+    status='NOT_MET'
+    exit_status=1
+else
+    status='MET'
+    exit_status=0
+fi
+
+if [[ "$format" == json ]]; then
+    # shellcheck disable=SC2016  # Named values and $ARGS are jq variables.
+    "$jq_bin" -cn \
+        --arg status "$status" \
+        --arg task "$task" \
+        --arg classification "$classification" \
+        '{classification:$classification,findings:$ARGS.positional,status:$status,task:$task}' \
+        --args "${findings[@]}"
+else
+    findings_csv=''
+    for finding in "${findings[@]}"; do
+        [[ -z "$findings_csv" ]] || findings_csv+=','
+        findings_csv+="$finding"
+    done
+    printf 'status=%s task=%s classification=%s findings=%s\n' \
+        "$status" "$task" "$classification" "$findings_csv"
+    for finding in "${findings[@]}"; do
+        printf 'finding=%s\n' "$finding"
+    done
+fi
+exit "$exit_status"

--- a/dev-tools/check-review-evolution.sh
+++ b/dev-tools/check-review-evolution.sh
@@ -11,6 +11,7 @@ usage() {
 usage: check-review-evolution.sh --root DIR --task TASK-ID [--format text|json]
 
 Reads exactly these canonical task-bound artifacts below DIR:
+  datarim/tasks/<TASK-ID>-customer-requirements.yaml
   datarim/receipts/<TASK-ID>-review-evolution.yaml
   datarim/receipts/<TASK-ID>-customer-delivery.yaml
 
@@ -103,7 +104,39 @@ select_tool /usr/bin/jq /usr/local/bin/jq /opt/homebrew/bin/jq || {
     exit 2
 }
 jq_bin="$selected_tool"
+platform="$(/usr/bin/uname -s 2>/dev/null || true)"
+case "$platform" in
+    Linux)
+        select_tool /usr/bin/git || {
+            emit_config_error 'missing_dependency:git'
+            exit 2
+        }
+        git_bin="$selected_tool"
+        select_tool /usr/bin/openssl || {
+            emit_config_error 'missing_dependency:openssl'
+            exit 2
+        }
+        openssl_bin="$selected_tool"
+        ;;
+    Darwin)
+        select_tool /Library/Developer/CommandLineTools/usr/bin/git /usr/bin/git || {
+            emit_config_error 'missing_dependency:git'
+            exit 2
+        }
+        git_bin="$selected_tool"
+        select_tool /opt/homebrew/opt/openssl@3/bin/openssl /usr/local/opt/openssl@3/bin/openssl /usr/bin/openssl || {
+            emit_config_error 'missing_dependency:openssl'
+            exit 2
+        }
+        openssl_bin="$selected_tool"
+        ;;
+    *)
+        emit_config_error 'unsupported_platform'
+        exit 2
+        ;;
+esac
 
+requirements="${root}/datarim/tasks/${task}-customer-requirements.yaml"
 review="${root}/datarim/receipts/${task}-review-evolution.yaml"
 receipt="${root}/datarim/receipts/${task}-customer-delivery.yaml"
 
@@ -138,6 +171,7 @@ resolve_artifact() {
 }
 
 artifact_bytes=''
+resolve_artifact customer_requirements "$requirements" || exit 2
 resolve_artifact review_evolution "$review" || exit 2
 resolve_artifact customer_delivery "$receipt" || exit 2
 
@@ -152,14 +186,55 @@ cleanup() {
 trap cleanup EXIT HUP INT TERM
 review_json="${tmp_dir}/review.json"
 receipt_json="${tmp_dir}/receipt.json"
+delivery_output="${tmp_dir}/customer-delivery.json"
+requirements_snapshot="${tmp_dir}/requirements.yaml"
+review_snapshot="${tmp_dir}/review.yaml"
+receipt_snapshot="${tmp_dir}/receipt.yaml"
+/bin/cp -- "$requirements" "$requirements_snapshot"
+/bin/cp -- "$review" "$review_snapshot"
+/bin/cp -- "$receipt" "$receipt_snapshot"
+requirements_snapshot_digest="$("$openssl_bin" dgst -sha256 "$requirements_snapshot" | /usr/bin/awk '{print $NF}')"
+review_snapshot_digest="$("$openssl_bin" dgst -sha256 "$review_snapshot" | /usr/bin/awk '{print $NF}')"
+receipt_snapshot_digest="$("$openssl_bin" dgst -sha256 "$receipt_snapshot" | /usr/bin/awk '{print $NF}')"
+script_dir="$(cd "$(/usr/bin/dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+customer_delivery_validator="${script_dir}/check-customer-delivery.sh"
+if [[ ! -f "$customer_delivery_validator" || -L "$customer_delivery_validator" \
+    || ! -x "$customer_delivery_validator" ]]; then
+    emit_config_error 'missing_dependency:check-customer-delivery'
+    exit 2
+fi
+set +e
+"$customer_delivery_validator" --root "$root" --task "$task" --stage qa --format json \
+    >"$delivery_output" 2>/dev/null
+delivery_status=$?
+set -e
+delivery_verified=false
+delivery_inputs_stable=false
+# shellcheck disable=SC2016  # $task is a jq variable.
+if [[ "$delivery_status" -eq 0 ]] \
+    && "$jq_bin" -se --arg task "$task" \
+        'length == 1 and .[0].decision == "MET" and .[0].status == "MET"
+         and .[0].epic_status == "MET" and .[0].stage == "qa"
+         and .[0].task == $task and .[0].findings == []' \
+        "$delivery_output" >/dev/null 2>&1; then
+    delivery_verified=true
+fi
+if [[ "$("$openssl_bin" dgst -sha256 "$requirements" 2>/dev/null | /usr/bin/awk '{print $NF}')" \
+        == "$requirements_snapshot_digest" \
+    && "$("$openssl_bin" dgst -sha256 "$review" 2>/dev/null | /usr/bin/awk '{print $NF}')" \
+        == "$review_snapshot_digest" \
+    && "$("$openssl_bin" dgst -sha256 "$receipt" 2>/dev/null | /usr/bin/awk '{print $NF}')" \
+        == "$receipt_snapshot_digest" ]]; then
+    delivery_inputs_stable=true
+fi
 
-if ! "$yq_bin" eval -o=json '.' "$review" >"$review_json" 2>/dev/null; then
+if ! "$yq_bin" eval -o=json '.' "$review_snapshot" >"$review_json" 2>/dev/null; then
     printf '%s\n' '{}' >"$review_json"
     review_parse_error=true
 else
     review_parse_error=false
 fi
-if ! "$yq_bin" eval -o=json '.' "$receipt" >"$receipt_json" 2>/dev/null; then
+if ! "$yq_bin" eval -o=json '.' "$receipt_snapshot" >"$receipt_json" 2>/dev/null; then
     printf '%s\n' '{}' >"$receipt_json"
     receipt_parse_error=true
 else
@@ -175,6 +250,13 @@ add_finding() {
     done
     findings+=("$finding")
 }
+
+if [[ "$delivery_verified" != true ]]; then
+    add_finding 'customer_delivery_not_met'
+fi
+if [[ "$delivery_inputs_stable" != true ]]; then
+    add_finding 'customer_delivery_inputs_changed'
+fi
 
 if [[ "$review_parse_error" == true ]]; then
     add_finding 'malformed_yaml:review_evolution'
@@ -196,6 +278,135 @@ jq_has_nonempty_string() {
     "$jq_bin" -e "$1 | type == \"string\" and length > 0" "$2" >/dev/null 2>&1
 }
 
+run_bound_git() {
+    /usr/bin/env -i LC_ALL=C GIT_NO_REPLACE_OBJECTS=1 \
+        "$git_bin" -C "$root" "$@"
+}
+
+bound_head="$(run_bound_git rev-parse --verify HEAD 2>/dev/null || true)"
+if [[ ! "$bound_head" =~ ^[0-9a-f]{40}$ ]]; then
+    add_finding 'repository_head_invalid'
+fi
+
+is_safe_relative_path() {
+    local candidate="$1" component
+    local -a components=()
+    [[ -n "$candidate" && "$candidate" != /* && "$candidate" != *$'\n'* \
+        && "$candidate" =~ ^[A-Za-z0-9._/-]+$ ]] || return 1
+    IFS='/' read -r -a components <<<"$candidate"
+    ((${#components[@]} > 0)) || return 1
+    for component in "${components[@]}"; do
+        [[ -n "$component" && "$component" != . && "$component" != .. ]] || return 1
+    done
+}
+
+git_blob_to_file() {
+    local revision="$1" path="$2" destination="$3"
+    local tree_line mode size
+    tree_line="$(run_bound_git ls-tree "$revision" -- "$path" 2>/dev/null || true)"
+    [[ -n "$tree_line" && "$tree_line" != *$'\n'* ]] || return 1
+    mode="${tree_line%% *}"
+    [[ "$mode" == 100644 || "$mode" == 100755 ]] || return 1
+    size="$(run_bound_git cat-file -s "${revision}:${path}" 2>/dev/null || true)"
+    [[ "$size" =~ ^[0-9]+$ ]] && ((size > 0 && size <= 1048576)) || return 1
+    run_bound_git cat-file blob "${revision}:${path}" >"$destination" 2>/dev/null
+}
+
+sha256_file() {
+    "$openssl_bin" dgst -sha256 "$1" 2>/dev/null | /usr/bin/awk '{print "sha256:" $NF}'
+}
+
+valid_timestamp_shape() {
+    local timestamp="$1"
+    [[ "$timestamp" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] \
+        || return 1
+    # shellcheck disable=SC2016  # $timestamp is a jq variable.
+    "$jq_bin" -en --arg timestamp "$timestamp" \
+        '$timestamp | fromdateiso8601' >/dev/null 2>&1
+}
+
+validate_evolution_evidence() {
+    local kind="$1" evidence_path="$2" revision="$3" classification_value="$4"
+    local marker="$5" destination="${tmp_dir}/${kind}-evidence"
+    if ! is_safe_relative_path "$evidence_path"; then
+        add_finding "canonical_change_${kind}_evidence_path_invalid:${classification_value}"
+        return 1
+    fi
+    if ! git_blob_to_file "$revision" "$evidence_path" "$destination"; then
+        add_finding "canonical_change_${kind}_evidence_missing:${classification_value}"
+        return 1
+    fi
+    if ! /usr/bin/grep -Eq "$marker" "$destination"; then
+        add_finding "canonical_change_${kind}_evidence_invalid:${classification_value}"
+        return 1
+    fi
+}
+
+validate_canonical_evolution() {
+    local classification_value="$1"
+    local artifact_path artifact_revision artifact_digest recorded_at reviewed_at
+    local red_path green_path artifact_file revision_valid=false recorded_valid=false
+    local commit_after_review commit_before_record red_digest green_digest
+    artifact_path="$(jq_raw '.canonical_change.artifact_id' "$review_json")"
+    artifact_revision="$(jq_raw '.canonical_change.artifact_revision' "$review_json")"
+    artifact_digest="$(jq_raw '.canonical_change.digest' "$review_json")"
+    recorded_at="$(jq_raw '.canonical_change.recorded_at' "$review_json")"
+    reviewed_at="$(jq_raw '.reviewed_at' "$review_json")"
+    red_path="$(jq_raw '.canonical_change.enforcement.red_evidence' "$review_json")"
+    green_path="$(jq_raw '.canonical_change.enforcement.green_evidence' "$review_json")"
+    artifact_file="${tmp_dir}/canonical-artifact"
+
+    if [[ "$artifact_revision" =~ ^[0-9a-f]{40}$ ]] \
+        && run_bound_git cat-file -e "${artifact_revision}^{commit}" 2>/dev/null; then
+        revision_valid=true
+    else
+        add_finding "canonical_change_invalid_revision:${classification_value}"
+    fi
+    if ! is_safe_relative_path "$artifact_path"; then
+        add_finding "canonical_change_artifact_path_invalid:${classification_value}"
+    elif [[ "$revision_valid" == true ]]; then
+        if git_blob_to_file "$artifact_revision" "$artifact_path" "$artifact_file"; then
+            if [[ "$(sha256_file "$artifact_file")" != "$artifact_digest" ]]; then
+                add_finding "canonical_change_digest_mismatch:${classification_value}"
+            fi
+        else
+            add_finding "canonical_change_artifact_missing:${classification_value}"
+        fi
+    fi
+    if [[ "$artifact_digest" == sha256:0000000000000000000000000000000000000000000000000000000000000000 ]]; then
+        add_finding "canonical_change_digest_mismatch:${classification_value}"
+    fi
+
+    if valid_timestamp_shape "$recorded_at"; then
+        recorded_valid=true
+    else
+        add_finding "canonical_change_invalid_recorded_at:${classification_value}"
+    fi
+    if [[ "$revision_valid" == true && "$recorded_valid" == true ]]; then
+        commit_after_review="$(run_bound_git log -1 --format=%H --since="$reviewed_at" \
+            "$artifact_revision" 2>/dev/null || true)"
+        if [[ "$commit_after_review" != "$artifact_revision" ]]; then
+            add_finding "canonical_change_post_hoc:${classification_value}"
+        fi
+        commit_before_record="$(run_bound_git log -1 --format=%H --until="$recorded_at" \
+            "$artifact_revision" 2>/dev/null || true)"
+        if [[ "$commit_before_record" != "$artifact_revision" ]]; then
+            add_finding "canonical_change_recorded_before_revision:${classification_value}"
+        fi
+        validate_evolution_evidence red "$red_path" "$artifact_revision" \
+            "$classification_value" '(^|["[:space:]])status[" :=]+"?failed_as_expected' || true
+        validate_evolution_evidence green "$green_path" "$artifact_revision" \
+            "$classification_value" '(^|["[:space:]])status[" :=]+"?passed' || true
+        if [[ -f "${tmp_dir}/red-evidence" && -f "${tmp_dir}/green-evidence" ]]; then
+            red_digest="$(sha256_file "${tmp_dir}/red-evidence")"
+            green_digest="$(sha256_file "${tmp_dir}/green-evidence")"
+            if [[ "$red_digest" == "$green_digest" ]]; then
+                add_finding "canonical_change_red_green_evidence_not_distinct:${classification_value}"
+            fi
+        fi
+    fi
+}
+
 classification="$(jq_raw '.classification' "$review_json")"
 review_requirement="$(jq_raw '.requirement_id' "$review_json")"
 review_receipt="$(jq_raw '.delivery_receipt_id' "$review_json")"
@@ -204,6 +415,19 @@ product_requirement="$(jq_raw '.product_fix.requirement_id' "$review_json")"
 product_receipt="$(jq_raw '.product_fix.delivery_receipt_id' "$review_json")"
 product_status="$(jq_raw '.product_fix.status' "$review_json")"
 reviewer="$(jq_raw '.reviewer' "$review_json")"
+task_prefix="${task%-*}"
+task_number="${task##*-}"
+task_prefix_lower="$(printf '%s' "$task_prefix" | /usr/bin/tr '[:upper:]' '[:lower:]')"
+expected_task_parent="task:${task_prefix_lower}:${task_number}"
+# shellcheck disable=SC2016  # $id is a jq variable.
+if ! "$jq_bin" -e --arg id "$expected_task_parent" \
+    '[.parent_links[]? | select(.relation == "task") | .id] | sort | unique == [$id]' \
+    "$receipt_json" >/dev/null 2>&1 \
+    || ! "$jq_bin" -e --arg id "$expected_task_parent" \
+        '[.parent_links[]? | select(.relation == "task") | .id] | sort | unique == [$id]' \
+        "$review_json" >/dev/null 2>&1; then
+    add_finding "task_identity_mismatch:${task}"
+fi
 
 case "$classification" in
     ABSENT|WEAK|STALE|MIS_SCOPED|NOT_BOUND)
@@ -238,6 +462,7 @@ case "$classification" in
             if [[ -n "$red_evidence" && "$red_evidence" == "$green_evidence" ]]; then
                 add_finding "canonical_change_red_green_evidence_not_distinct:${classification}"
             fi
+            validate_canonical_evolution "$classification"
         fi
         if [[ "$(jq_type '.no_canon_change' "$review_json")" != null ]]; then
             add_finding "classification_forbids_no_canon_change:${classification}"
@@ -258,6 +483,21 @@ case "$classification" in
             approval_reviewer="$(jq_raw '.no_canon_change.reviewer_approval.reviewer' "$review_json")"
             if [[ "$approval_reviewer" != "$reviewer" ]]; then
                 add_finding "no_canon_change_reviewer_mismatch:${reviewer}:${approval_reviewer}"
+            fi
+            no_canon_evidence="$(jq_raw '.no_canon_change.evidence' "$review_json")"
+            signed_review_evidence="$(jq_raw '.originating_review.evidence_ref' "$review_json")"
+            approval_time="$(jq_raw '.no_canon_change.reviewer_approval.approved_at' "$review_json")"
+            signed_approval_time="$(jq_raw '.originating_review.authority_approval.approved_at' "$review_json")"
+            if [[ "$no_canon_evidence" != "$signed_review_evidence" ]] \
+                || ! is_safe_relative_path "$no_canon_evidence" \
+                || ! git_blob_to_file "$bound_head" "$no_canon_evidence" "${tmp_dir}/no-canon-evidence"; then
+                add_finding 'no_canon_change_evidence_not_authenticated'
+            fi
+            if [[ "$approval_time" != "$signed_approval_time" ]]; then
+                add_finding 'no_canon_change_approval_not_authenticated'
+            fi
+            if ! valid_timestamp_shape "$approval_time"; then
+                add_finding 'no_canon_change_invalid_approved_at'
             fi
         fi
         if [[ "$(jq_type '.canonical_change' "$review_json")" != null ]]; then

--- a/dev-tools/check-review-evolution.sh
+++ b/dev-tools/check-review-evolution.sh
@@ -4,7 +4,6 @@
 #
 # Exit codes: 0 MET, 1 semantic NOT_MET, 2 usage/configuration error.
 set -euo pipefail
-IFS=$'\n\t'
 export LC_ALL=C
 
 usage() {

--- a/dev-tools/tests/check-review-evolution.bats
+++ b/dev-tools/tests/check-review-evolution.bats
@@ -1,0 +1,187 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd -P)"
+    SCRIPT="${REVIEW_EVOLUTION_SCRIPT:-${REPO_ROOT}/dev-tools/check-review-evolution.sh}"
+    ROOT="${BATS_TEST_TMPDIR}/consumer"
+    TASK_ID='TALO-0001'
+    REVIEW="${ROOT}/datarim/receipts/${TASK_ID}-review-evolution.yaml"
+    RECEIPT="${ROOT}/datarim/receipts/${TASK_ID}-customer-delivery.yaml"
+    mkdir -p "${ROOT}/datarim/receipts"
+    cp "${REPO_ROOT}/templates/review-evolution-template.yaml" "$REVIEW"
+    cp "${REPO_ROOT}/templates/customer-delivery-receipt-template.yaml" "$RECEIPT"
+}
+
+run_validator() {
+    run "$SCRIPT" --root "$ROOT" --task "$TASK_ID" --format json
+}
+
+assert_not_met() {
+    local expected="$1"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *'"status":"NOT_MET"'* ]] \
+        && [[ "$output" == *"${expected}"* ]]
+}
+
+@test "all five canon-changing classifications are accepted with evolution and a red-capable check" {
+    local classification
+    for classification in ABSENT WEAK STALE MIS_SCOPED NOT_BOUND; do
+        yq -i ".classification = \"${classification}\"" "$REVIEW"
+        run_validator
+        [ "$status" -eq 0 ] \
+            && [[ "$output" == *'"classification":"'"${classification}"'"'* ]] \
+            && [[ "$output" == *'"status":"MET"'* ]] || return 1
+    done
+}
+
+@test "each canon-changing classification fails without artifact evolution" {
+    local classification
+    for classification in ABSENT WEAK STALE MIS_SCOPED NOT_BOUND; do
+        cp "${REPO_ROOT}/templates/review-evolution-template.yaml" "$REVIEW"
+        yq -i ".classification = \"${classification}\" | del(.canonical_change)" "$REVIEW"
+        run_validator
+        assert_not_met "classification_requires_canonical_change:${classification}" || return 1
+    done
+}
+
+@test "canon-changing classification fails without a red-capable check" {
+    yq -i '.canonical_change.enforcement.red_capable = false' "$REVIEW"
+    run_validator
+    assert_not_met 'canonical_change_not_red_capable:ABSENT'
+}
+
+@test "canon-changing classification fails without red evidence" {
+    yq -i '.canonical_change.enforcement.red_evidence = ""' "$REVIEW"
+    run_validator
+    assert_not_met 'canonical_change_missing_red_evidence:ABSENT'
+}
+
+@test "canon-changing classification requires a concrete artifact revision and distinct red-green evidence" {
+    yq -i '.canonical_change.change_kind = "OTHER" |
+      .canonical_change.digest = "not-a-digest" |
+      .canonical_change.enforcement.green_evidence = .canonical_change.enforcement.red_evidence' "$REVIEW"
+    run_validator
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *'canonical_change_invalid_kind:ABSENT'* ]] \
+        && [[ "$output" == *'canonical_change_invalid_digest:ABSENT'* ]] \
+        && [[ "$output" == *'canonical_change_red_green_evidence_not_distinct:ABSENT'* ]]
+}
+
+@test "NO_CANON_CHANGE is accepted only with evidence and reviewer approval" {
+    yq -i '.classification = "NO_CANON_CHANGE" |
+      del(.canonical_change) |
+      .no_canon_change = {
+        "evidence": "The finding is product-specific and does not expose a reusable canon gap.",
+        "reviewer_approval": {
+          "reviewer": "independent-reviewer",
+          "approved": true,
+          "approved_at": "2026-01-03T15:30:00Z"
+        }
+      }' "$REVIEW"
+    run_validator
+    [ "$status" -eq 0 ] \
+        && [[ "$output" == *'"classification":"NO_CANON_CHANGE"'* ]] \
+        && [[ "$output" == *'"status":"MET"'* ]]
+}
+
+@test "NO_CANON_CHANGE fails without evidence" {
+    yq -i '.classification = "NO_CANON_CHANGE" |
+      del(.canonical_change) |
+      .no_canon_change = {
+        "evidence": "",
+        "reviewer_approval": {
+          "reviewer": "independent-reviewer",
+          "approved": true,
+          "approved_at": "2026-01-03T15:30:00Z"
+        }
+      }' "$REVIEW"
+    run_validator
+    assert_not_met 'no_canon_change_missing_evidence'
+}
+
+@test "NO_CANON_CHANGE fails without reviewer approval" {
+    yq -i '.classification = "NO_CANON_CHANGE" |
+      del(.canonical_change) |
+      .no_canon_change = {
+        "evidence": "No reusable canon gap was found.",
+        "reviewer_approval": {
+          "reviewer": "independent-reviewer",
+          "approved": false,
+          "approved_at": "2026-01-03T15:30:00Z"
+        }
+      }' "$REVIEW"
+    run_validator
+    assert_not_met 'no_canon_change_not_approved'
+}
+
+@test "NO_CANON_CHANGE approval must come from the classified finding reviewer" {
+    yq -i '.classification = "NO_CANON_CHANGE" |
+      del(.canonical_change) |
+      .no_canon_change = {
+        "evidence": "No reusable canon gap was found.",
+        "reviewer_approval": {
+          "reviewer": "different-reviewer",
+          "approved": true,
+          "approved_at": "2026-01-03T15:30:00Z"
+        }
+      }' "$REVIEW"
+    run_validator
+    assert_not_met 'no_canon_change_reviewer_mismatch:independent-reviewer:different-reviewer'
+}
+
+@test "evolution alone cannot close a product Requirement" {
+    yq -i '.requirements.req-0001.coverage_status = "NOT_MET" |
+      .requirements.req-0001.missing_edges = ["live_evidence"]' "$RECEIPT"
+    run_validator
+    assert_not_met 'product_requirement_not_delivered:req-0001'
+}
+
+@test "review requirement and receipt must be bound to the product fix" {
+    yq -i '.product_fix.requirement_id = "req-9999" |
+      .product_fix.delivery_receipt_id = "receipt-9999"' "$REVIEW"
+    run_validator
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *'product_fix_requirement_mismatch:req-0001:req-9999'* ]] \
+        && [[ "$output" == *'product_fix_receipt_mismatch:receipt-0001:receipt-9999'* ]]
+}
+
+@test "review delivery receipt must be the canonical product delivery receipt" {
+    yq -i '.delivery_receipt_id = "receipt-9999" |
+      .product_fix.delivery_receipt_id = "receipt-9999"' "$REVIEW"
+    run_validator
+    assert_not_met 'review_receipt_mismatch:receipt-0001:receipt-9999'
+}
+
+@test "review parent links must bind the requirement and delivery receipt" {
+    yq -i '.parent_links |= map(select(.relation != "requirement" and .relation != "delivery_receipt"))' "$REVIEW"
+    run_validator
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *'missing_parent_link:requirement:req-0001'* ]] \
+        && [[ "$output" == *'missing_parent_link:delivery_receipt:receipt-0001'* ]]
+}
+
+@test "review parent links inherit every product epic and task" {
+    yq -i '.parent_links |= map(select(.relation != "epic" and .relation != "task"))' "$REVIEW"
+    run_validator
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *'missing_parent_link:epic:epic:web:0000'* ]] \
+        && [[ "$output" == *'missing_parent_link:task:task:web:0001'* ]]
+}
+
+@test "unknown classification fails closed" {
+    yq -i '.classification = "OTHER"' "$REVIEW"
+    run_validator
+    assert_not_met 'invalid_classification:OTHER'
+}
+
+@test "usage and missing artifacts are configuration errors" {
+    run "$SCRIPT" --root "$ROOT" --format json
+    [ "$status" -eq 2 ] \
+        && [[ "$output" == *'"status":"ERROR"'* ]] \
+        && [[ "$output" == *'invalid_usage'* ]] || return 1
+
+    rm -f "$REVIEW"
+    run_validator
+    [ "$status" -eq 2 ] \
+        && [[ "$output" == *'missing_artifact:review_evolution'* ]]
+}

--- a/dev-tools/tests/check-review-evolution.bats
+++ b/dev-tools/tests/check-review-evolution.bats
@@ -84,20 +84,24 @@ write_signed_no_canon_decision() {
     local reviewer='independent-reviewer'
     local approved_at='2026-01-03T15:15:00Z'
     local finding_evidence_ref='artifacts/reviews/review-0001-approval.json'
+    local originating_review_digest="${DECISION_ORIGIN_DIGEST:-sha256:89ad08914c519c6154801fd4a70752e6edbd35303acc0555b42bd3c36b629235}"
+    local originating_review_observed_at="${DECISION_ORIGIN_OBSERVED_AT:-2026-01-03T14:55:00Z}"
     local decision_path='artifacts/reviews/no-canon-change-decision.json'
     local canonical_payload="${BATS_TEST_TMPDIR}/no-canon-payload.json"
     local signature_file="${BATS_TEST_TMPDIR}/no-canon-signature.bin"
     local payload_digest signature
     jq -n --arg task "$TASK_ID" --arg reviewer "$reviewer" \
         --arg approved_at "$approved_at" --arg evidence_ref "$finding_evidence_ref" \
-        --arg decision_ref "$decision_path" '{
+        --arg decision_ref "$decision_path" --arg origin_digest "$originating_review_digest" \
+        --arg origin_observed_at "$originating_review_observed_at" '{
           schema_version: 1,
           decision: "NO_CANON_CHANGE",
           task_id: $task,
           requirement_id: "req-0001",
           delivery_receipt_id: "receipt-0001",
           originating_review_id: "review-0001",
-          originating_review_digest: "sha256:89ad08914c519c6154801fd4a70752e6edbd35303acc0555b42bd3c36b629235",
+          originating_review_digest: $origin_digest,
+          originating_review_observed_at: $origin_observed_at,
           reviewer: $reviewer,
           approved: true,
           approved_at: $approved_at,
@@ -108,7 +112,7 @@ write_signed_no_canon_decision() {
           algorithm: "ED25519",
           key_id: "key-operator-0001"
         }' >"${ROOT}/${decision_path}"
-    jq -cS . "${ROOT}/${decision_path}" >"$canonical_payload"
+    printf '%s' "$(jq -cS . "${ROOT}/${decision_path}")" >"$canonical_payload"
     payload_digest="sha256:$(openssl dgst -sha256 "$canonical_payload" | awk '{print $NF}')"
     openssl pkeyutl -sign -inkey "$DECISION_PRIVATE_KEY" -rawin \
         -in "$canonical_payload" -out "$signature_file"
@@ -119,6 +123,21 @@ write_signed_no_canon_decision() {
     GIT_AUTHOR_DATE='2026-01-03T15:20:00Z' GIT_COMMITTER_DATE='2026-01-03T15:20:00Z' \
         git -C "$ROOT" commit -q -m 'signed no-canon decision'
     printf '%s\n' "$decision_path"
+}
+
+reseal_primary_review_digest() {
+    local canonical_review_payload review_digest
+    canonical_review_payload="$(yq -o=json '.originating_review_inventory[0]' "$REVIEW" \
+      | jq -cS '{review_id, requirement_id, delivery_receipt_id, reviewer, review_ref,
+          state, observed_at, evidence_ref}')"
+    review_digest="sha256:$(printf '%s' "$canonical_review_payload" | openssl dgst -sha256 \
+        | awk '{print $NF}')"
+    yq -i ".originating_review.review_digest = \"${review_digest}\" |
+      .originating_review.authority_approval.approved_digest = \"${review_digest}\" |
+      .originating_review_inventory[0].review_digest = \"${review_digest}\" |
+      .originating_review_inventory[0].authority_approval.approved_digest = \"${review_digest}\"" \
+        "$REVIEW"
+    printf '%s\n' "$review_digest"
 }
 
 run_validator() {
@@ -322,6 +341,55 @@ assert_not_met() {
     assert_not_met 'no_canon_change_decision_not_authenticated'
 }
 
+@test "NO_CANON_CHANGE rejects a backward-time inventory mutation preserving the signed envelope" {
+    write_signed_no_canon_decision >/dev/null
+    yq -i '.originating_review_inventory[0].observed_at = "2020-01-03T14:55:00Z" |
+      .classification = "NO_CANON_CHANGE" |
+      del(.canonical_change) |
+      .no_canon_change = {
+        "evidence": "artifacts/reviews/no-canon-change-decision.json",
+        "reviewer_approval": {
+          "reviewer": "independent-reviewer",
+          "approved": true,
+          "approved_at": "2026-01-03T15:15:00Z"
+        }
+      }' "$REVIEW"
+    run_validator
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *'originating_review_digest_mismatch:review-0001'* ]] \
+        && [[ "$output" == *'no_canon_change_decision_not_authenticated'* ]]
+}
+
+@test "NO_CANON_CHANGE signed envelope pins the originating review observation time" {
+    local changed_review_digest
+    yq -i '.originating_review.observed_at = "2020-01-03T14:55:00Z" |
+      .originating_review_inventory[0].observed_at = "2020-01-03T14:55:00Z"' "$REVIEW"
+    changed_review_digest="$(reseal_primary_review_digest)"
+    DECISION_ORIGIN_DIGEST="$changed_review_digest" \
+      DECISION_ORIGIN_OBSERVED_AT='2026-01-03T14:55:00Z' \
+      write_signed_no_canon_decision >/dev/null
+    yq -i '.classification = "NO_CANON_CHANGE" |
+      del(.canonical_change) |
+      .no_canon_change = {
+        "evidence": "artifacts/reviews/no-canon-change-decision.json",
+        "reviewer_approval": {
+          "reviewer": "independent-reviewer",
+          "approved": true,
+          "approved_at": "2026-01-03T15:15:00Z"
+        }
+      }' "$REVIEW"
+    run_validator
+    assert_not_met 'no_canon_change_decision_not_authenticated'
+}
+
+@test "canonical evolution rejects an originating review time with a stale declared digest" {
+    yq -i '.originating_review_inventory[0].observed_at = "2020-01-03T14:55:00Z"' "$REVIEW"
+    run_validator
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *'originating_review_digest_mismatch:review-0001'* ]] \
+        && [[ "$output" == *'canonical_change_review_time_not_authenticated:ABSENT'* ]]
+}
+
 @test "forged authored delivery summary cannot substitute for the A2 delivery verdict" {
     yq -i '. = {
       "schema_version": 1,
@@ -472,6 +540,7 @@ assert_not_met() {
     yq -i '.canonical_change.recorded_at = "2026-01-03T15:30:00Z" |
       .originating_review.observed_at = "2026-01-03T15:20:00Z" |
       .originating_review_inventory[0].observed_at = "2026-01-03T15:20:00Z"' "$REVIEW"
+    reseal_primary_review_digest >/dev/null
     run_validator
     assert_not_met 'canonical_change_post_hoc:ABSENT'
 }

--- a/dev-tools/tests/check-review-evolution.bats
+++ b/dev-tools/tests/check-review-evolution.bats
@@ -449,9 +449,12 @@ assert_not_met() {
 }
 
 @test "total deadline kills and reaps a hanging A2 process group" {
-    local start end elapsed descendant_pid
-    sed -i 's/VALIDATION_TOTAL_TIMEOUT_SECONDS = 20/VALIDATION_TOTAL_TIMEOUT_SECONDS = 1/' \
-        "$SCRIPT"
+    local start end elapsed descendant_pid deadline_script
+    deadline_script="${SCRIPT}.deadline"
+    sed 's/VALIDATION_TOTAL_TIMEOUT_SECONDS = 20/VALIDATION_TOTAL_TIMEOUT_SECONDS = 1/' \
+        "$SCRIPT" >"$deadline_script"
+    mv "$deadline_script" "$SCRIPT"
+    chmod +x "$SCRIPT"
     : >"${ROOT}/.a2-hang"
     start="$(python3 -c 'import time; print(time.perf_counter())')"
     run_validator

--- a/dev-tools/tests/check-review-evolution.bats
+++ b/dev-tools/tests/check-review-evolution.bats
@@ -1,15 +1,69 @@
 #!/usr/bin/env bats
+# shellcheck disable=SC2030,SC2031  # Each Bats test intentionally gets an isolated setup subshell.
 
 setup() {
     REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd -P)"
-    SCRIPT="${REVIEW_EVOLUTION_SCRIPT:-${REPO_ROOT}/dev-tools/check-review-evolution.sh}"
+    SCRIPT_SOURCE="${REVIEW_EVOLUTION_SCRIPT:-${REPO_ROOT}/dev-tools/check-review-evolution.sh}"
+    TEST_FRAMEWORK="${BATS_TEST_TMPDIR}/framework"
+    mkdir -p "${TEST_FRAMEWORK}/dev-tools"
+    cp "$SCRIPT_SOURCE" "${TEST_FRAMEWORK}/dev-tools/check-review-evolution.sh"
+    SCRIPT="${TEST_FRAMEWORK}/dev-tools/check-review-evolution.sh"
+    # shellcheck disable=SC2016  # The generated A2 oracle must retain its own shell variables literally.
+    printf '%s\n' \
+        '#!/bin/bash -p' \
+        'set -euo pipefail' \
+        'root=""; task=""; stage=""; format=""' \
+        'while (($#)); do' \
+        '  case "$1" in' \
+        '    --root) root="$2"; shift 2 ;;' \
+        '    --task) task="$2"; shift 2 ;;' \
+        '    --stage) stage="$2"; shift 2 ;;' \
+        '    --format) format="$2"; shift 2 ;;' \
+        '    *) exit 2 ;;' \
+        '  esac' \
+        'done' \
+        '[[ "$stage" == qa && "$format" == json && -n "$root" ]] || exit 2' \
+        'if [[ "$task" != WEB-0001 ]] || ! yq -e '\''.requirements.req-0001.coverage_chain.red_green'\'' "${root}/datarim/receipts/${task}-customer-delivery.yaml" >/dev/null 2>&1; then' \
+        '  printf '\''{"decision":"NOT_MET","epic_status":"NOT_MET","findings":["test_a2_rejection"],"stage":"qa","status":"NOT_MET","task":"%s"}\n'\'' "$task"' \
+        '  exit 1' \
+        'fi' \
+        'printf '\''{"decision":"MET","epic_status":"MET","findings":[],"stage":"qa","status":"MET","task":"%s"}\n'\'' "$task"' \
+        >"${TEST_FRAMEWORK}/dev-tools/check-customer-delivery.sh"
+    chmod +x "${TEST_FRAMEWORK}/dev-tools/check-customer-delivery.sh"
     ROOT="${BATS_TEST_TMPDIR}/consumer"
-    TASK_ID='TALO-0001'
+    TASK_ID='WEB-0001'
+    REQUIREMENTS="${ROOT}/datarim/tasks/${TASK_ID}-customer-requirements.yaml"
     REVIEW="${ROOT}/datarim/receipts/${TASK_ID}-review-evolution.yaml"
     RECEIPT="${ROOT}/datarim/receipts/${TASK_ID}-customer-delivery.yaml"
-    mkdir -p "${ROOT}/datarim/receipts"
+    ARTIFACT_PATH='canon/customer-delivery-review-checklist.md'
+    RED_PATH='artifacts/evolution/red-live-evidence-gate.txt'
+    GREEN_PATH='artifacts/evolution/green-live-evidence-gate.txt'
+    mkdir -p "${ROOT}/datarim/tasks" "${ROOT}/datarim/receipts" \
+        "${ROOT}/canon" "${ROOT}/artifacts/evolution" "${ROOT}/artifacts/reviews"
+    cp "${REPO_ROOT}/templates/customer-requirements-template.yaml" "$REQUIREMENTS"
     cp "${REPO_ROOT}/templates/review-evolution-template.yaml" "$REVIEW"
     cp "${REPO_ROOT}/templates/customer-delivery-receipt-template.yaml" "$RECEIPT"
+    yq -i '.requirements.req-0001.acceptance.implementation.code_revision = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" |
+      .requirements.req-0001.acceptance.implementation.content_revision = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" |
+      .requirements.req-0001.acceptance.disposition = "accepted"' "$REQUIREMENTS"
+    printf '%s\n' '# Review checklist revision 2' >"${ROOT}/${ARTIFACT_PATH}"
+    printf '%s\n' 'status=failed_as_expected' 'command=review-gate-mutant' >"${ROOT}/${RED_PATH}"
+    printf '%s\n' 'status=passed' 'command=review-gate' >"${ROOT}/${GREEN_PATH}"
+    printf '%s\n' 'neutral evidence without a verdict marker' >"${ROOT}/artifacts/evolution/neutral.txt"
+    printf '%s\n' '{"state":"APPROVED","review_id":"review-0001"}' \
+        >"${ROOT}/artifacts/reviews/review-0001-approval.json"
+    git -C "$ROOT" init -q
+    git -C "$ROOT" config user.name test
+    git -C "$ROOT" config user.email test@example.invalid
+    git -C "$ROOT" add .
+    GIT_AUTHOR_DATE='2026-01-03T15:10:00Z' GIT_COMMITTER_DATE='2026-01-03T15:10:00Z' \
+        git -C "$ROOT" commit -q -m 'canon evolution evidence'
+    ARTIFACT_REVISION="$(git -C "$ROOT" rev-parse HEAD)"
+    ARTIFACT_DIGEST="sha256:$(openssl dgst -sha256 "${ROOT}/${ARTIFACT_PATH}" | awk '{print $NF}')"
+    yq -i ".canonical_change.artifact_id = \"${ARTIFACT_PATH}\" |
+      .canonical_change.artifact_revision = \"${ARTIFACT_REVISION}\" |
+      .canonical_change.digest = \"${ARTIFACT_DIGEST}\" |
+      .canonical_change.recorded_at = \"2026-01-03T15:30:00Z\"" "$REVIEW"
 }
 
 run_validator() {
@@ -71,11 +125,11 @@ assert_not_met() {
     yq -i '.classification = "NO_CANON_CHANGE" |
       del(.canonical_change) |
       .no_canon_change = {
-        "evidence": "The finding is product-specific and does not expose a reusable canon gap.",
+        "evidence": "artifacts/reviews/review-0001-approval.json",
         "reviewer_approval": {
           "reviewer": "independent-reviewer",
           "approved": true,
-          "approved_at": "2026-01-03T15:30:00Z"
+          "approved_at": "2026-01-03T14:56:00Z"
         }
       }' "$REVIEW"
     run_validator
@@ -92,7 +146,7 @@ assert_not_met() {
         "reviewer_approval": {
           "reviewer": "independent-reviewer",
           "approved": true,
-          "approved_at": "2026-01-03T15:30:00Z"
+          "approved_at": "2026-01-03T14:56:00Z"
         }
       }' "$REVIEW"
     run_validator
@@ -103,11 +157,11 @@ assert_not_met() {
     yq -i '.classification = "NO_CANON_CHANGE" |
       del(.canonical_change) |
       .no_canon_change = {
-        "evidence": "No reusable canon gap was found.",
+        "evidence": "artifacts/reviews/review-0001-approval.json",
         "reviewer_approval": {
           "reviewer": "independent-reviewer",
           "approved": false,
-          "approved_at": "2026-01-03T15:30:00Z"
+          "approved_at": "2026-01-03T14:56:00Z"
         }
       }' "$REVIEW"
     run_validator
@@ -118,15 +172,110 @@ assert_not_met() {
     yq -i '.classification = "NO_CANON_CHANGE" |
       del(.canonical_change) |
       .no_canon_change = {
-        "evidence": "No reusable canon gap was found.",
+        "evidence": "artifacts/reviews/review-0001-approval.json",
         "reviewer_approval": {
           "reviewer": "different-reviewer",
           "approved": true,
-          "approved_at": "2026-01-03T15:30:00Z"
+          "approved_at": "2026-01-03T14:56:00Z"
         }
       }' "$REVIEW"
     run_validator
     assert_not_met 'no_canon_change_reviewer_mismatch:independent-reviewer:different-reviewer'
+}
+
+@test "forged authored delivery summary cannot substitute for the A2 delivery verdict" {
+    yq -i '. = {
+      "schema_version": 1,
+      "receipt_id": "receipt-0001",
+      "parent_links": [
+        {"relation": "epic", "id": "epic:web:0000"},
+        {"relation": "task", "id": "task:web:0001"}
+      ],
+      "requirements": {
+        "req-0001": {
+          "coverage_status": "MET",
+          "coverage_chain": {"customer_disposition": {"status": "accepted"}}
+        }
+      }
+    }' "$RECEIPT"
+    run_validator
+    assert_not_met 'customer_delivery_not_met'
+}
+
+@test "canonical evolution requires an immutable existing artifact with its real digest and revision" {
+    yq -i '.canonical_change.artifact_id = "canon/missing.md"' "$REVIEW"
+    run_validator
+    assert_not_met 'canonical_change_artifact_missing:ABSENT' || return 1
+
+    cp "${REPO_ROOT}/templates/review-evolution-template.yaml" "$REVIEW"
+    yq -i ".canonical_change.artifact_id = \"${ARTIFACT_PATH}\" |
+      .canonical_change.artifact_revision = \"2\" |
+      .canonical_change.digest = \"sha256:0000000000000000000000000000000000000000000000000000000000000000\"" "$REVIEW"
+    run_validator
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *'canonical_change_invalid_revision:ABSENT'* ]] \
+        && [[ "$output" == *'canonical_change_digest_mismatch:ABSENT'* ]]
+}
+
+@test "canonical evolution rejects path escape and nonexistent red-green evidence" {
+    yq -i '.canonical_change.artifact_id = "../outside.md" |
+      .canonical_change.enforcement.red_evidence = "artifacts/evolution/missing-red.txt" |
+      .canonical_change.enforcement.green_evidence = "artifacts/evolution/missing-green.txt"' "$REVIEW"
+    run_validator
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *'canonical_change_artifact_path_invalid:ABSENT'* ]] \
+        && [[ "$output" == *'canonical_change_red_evidence_missing:ABSENT'* ]] \
+        && [[ "$output" == *'canonical_change_green_evidence_missing:ABSENT'* ]]
+}
+
+@test "canonical evolution requires actual RED and GREEN verdict evidence" {
+    yq -i '.canonical_change.enforcement.red_evidence = "artifacts/evolution/neutral.txt"' "$REVIEW"
+    run_validator
+    assert_not_met 'canonical_change_red_evidence_invalid:ABSENT'
+}
+
+@test "canonical evolution timestamp is valid and cannot attribute pre-review work post-hoc" {
+    yq -i '.canonical_change.recorded_at = "not-a-time"' "$REVIEW"
+    run_validator
+    assert_not_met 'canonical_change_invalid_recorded_at:ABSENT' || return 1
+
+    yq -i '.canonical_change.recorded_at = "2026-01-03T15:30:00Z" |
+      .reviewed_at = "2026-01-03T15:20:00Z"' "$REVIEW"
+    run_validator
+    assert_not_met 'canonical_change_post_hoc:ABSENT'
+}
+
+@test "NO_CANON_CHANGE cannot self-approve with unauthenticated evidence or time" {
+    yq -i '.classification = "NO_CANON_CHANGE" |
+      del(.canonical_change) |
+      .no_canon_change = {
+        "evidence": "arbitrary prose",
+        "reviewer_approval": {
+          "reviewer": "independent-reviewer",
+          "approved": true,
+          "approved_at": "not-a-time"
+        }
+      }' "$REVIEW"
+    run_validator
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *'no_canon_change_evidence_not_authenticated'* ]] \
+        && [[ "$output" == *'no_canon_change_approval_not_authenticated'* ]] \
+        && [[ "$output" == *'no_canon_change_invalid_approved_at'* ]]
+}
+
+@test "CLI task is bound to signed internal task identities and cannot be renamed" {
+    local renamed='TALO-0001'
+    cp "$REQUIREMENTS" "${ROOT}/datarim/tasks/${renamed}-customer-requirements.yaml"
+    cp "$RECEIPT" "${ROOT}/datarim/receipts/${renamed}-customer-delivery.yaml"
+    cp "$REVIEW" "${ROOT}/datarim/receipts/${renamed}-review-evolution.yaml"
+    TASK_ID="$renamed"
+    REQUIREMENTS="${ROOT}/datarim/tasks/${TASK_ID}-customer-requirements.yaml"
+    RECEIPT="${ROOT}/datarim/receipts/${TASK_ID}-customer-delivery.yaml"
+    REVIEW="${ROOT}/datarim/receipts/${TASK_ID}-review-evolution.yaml"
+    run_validator
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *'customer_delivery_not_met'* ]] \
+        && [[ "$output" == *'task_identity_mismatch:TALO-0001'* ]]
 }
 
 @test "evolution alone cannot close a product Requirement" {

--- a/dev-tools/tests/check-review-evolution.bats
+++ b/dev-tools/tests/check-review-evolution.bats
@@ -25,6 +25,23 @@ setup() {
         '  esac' \
         'done' \
         '[[ "$stage" == qa && "$format" == json && -n "$root" ]] || exit 2' \
+        'if [[ -f "$root/.a2-config-error" ]]; then' \
+        '  printf '\''{"decision":"ERROR","findings":["missing_dependency:test-fixture"],"stage":"qa","status":"ERROR","task":"%s"}\n'\'' "$task"' \
+        '  exit 2' \
+        'fi' \
+        'if [[ -f "$root/.a2-malformed" ]]; then' \
+        '  printf '\''not-json\n'\''' \
+        '  exit 0' \
+        'fi' \
+        'if [[ -f "$root/.a2-not-met" ]]; then' \
+        '  printf '\''{"decision":"NOT_MET","epic_status":"NOT_MET","findings":["test_semantic_gap"],"stage":"qa","status":"NOT_MET","task":"%s"}\n'\'' "$task"' \
+        '  exit 1' \
+        'fi' \
+        'if [[ -f "$root/.a2-hang" ]]; then' \
+        "  (trap '' TERM; exec /bin/sleep 120) &" \
+        '  printf '\''%s\n'\'' "$!" >"$root/.a2-descendant.pid"' \
+        '  wait' \
+        'fi' \
         'if [[ "$task" != WEB-0001 ]] || ! yq -e '\''.requirements.req-0001.coverage_chain.red_green'\'' "${root}/datarim/receipts/${task}-customer-delivery.yaml" >/dev/null 2>&1; then' \
         '  printf '\''{"decision":"NOT_MET","epic_status":"NOT_MET","findings":["test_a2_rejection"],"stage":"qa","status":"NOT_MET","task":"%s"}\n'\'' "$task"' \
         '  exit 1' \
@@ -407,6 +424,56 @@ assert_not_met() {
     }' "$RECEIPT"
     run_validator
     assert_not_met 'customer_delivery_not_met'
+}
+
+@test "A2 configuration ERROR remains exit 2 with its validated finding" {
+    : >"${ROOT}/.a2-config-error"
+    run_validator
+    [ "$status" -eq 2 ] \
+        && [[ "$output" == *'"status":"ERROR"'* ]] \
+        && [[ "$output" == *'customer_delivery:missing_dependency:test-fixture'* ]]
+}
+
+@test "malformed A2 output fails closed as a result-contract ERROR" {
+    : >"${ROOT}/.a2-malformed"
+    run_validator
+    [ "$status" -eq 2 ] \
+        && [[ "$output" == *'"status":"ERROR"'* ]] \
+        && [[ "$output" == *'customer_delivery_result_contract_invalid'* ]]
+}
+
+@test "A2 semantic NOT_MET remains exit 1" {
+    : >"${ROOT}/.a2-not-met"
+    run_validator
+    assert_not_met 'customer_delivery_not_met'
+}
+
+@test "total deadline kills and reaps a hanging A2 process group" {
+    local start end elapsed descendant_pid
+    sed -i 's/VALIDATION_TOTAL_TIMEOUT_SECONDS = 20/VALIDATION_TOTAL_TIMEOUT_SECONDS = 1/' \
+        "$SCRIPT"
+    : >"${ROOT}/.a2-hang"
+    start="$(python3 -c 'import time; print(time.perf_counter())')"
+    run_validator
+    end="$(python3 -c 'import time; print(time.perf_counter())')"
+    elapsed="$(python3 -c "print(${end} - ${start})")"
+    [ "$status" -eq 2 ] \
+        && [[ "$output" == *'"status":"ERROR"'* ]] \
+        && [[ "$output" == *'validation_resource_limit:deadline'* ]] \
+        && awk "BEGIN { exit !(${elapsed} < 5.0) }" \
+        && [ -s "${ROOT}/.a2-descendant.pid" ] || return 1
+    descendant_pid="$(<"${ROOT}/.a2-descendant.pid")"
+    for _ in {1..50}; do
+        if ! kill -0 "$descendant_pid" 2>/dev/null; then
+            return 0
+        fi
+        /bin/sleep 0.02
+    done
+    run kill -0 "$descendant_pid"
+    if [ "$status" -eq 0 ]; then
+        /bin/kill -KILL "$descendant_pid" 2>/dev/null || true
+    fi
+    [ "$status" -ne 0 ]
 }
 
 @test "canonical evolution requires an immutable existing artifact with its real digest and revision" {

--- a/dev-tools/tests/check-review-evolution.bats
+++ b/dev-tools/tests/check-review-evolution.bats
@@ -5,8 +5,10 @@ setup() {
     REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/../.." && pwd -P)"
     SCRIPT_SOURCE="${REVIEW_EVOLUTION_SCRIPT:-${REPO_ROOT}/dev-tools/check-review-evolution.sh}"
     TEST_FRAMEWORK="${BATS_TEST_TMPDIR}/framework"
-    mkdir -p "${TEST_FRAMEWORK}/dev-tools"
+    mkdir -p "${TEST_FRAMEWORK}/dev-tools" "${TEST_FRAMEWORK}/config"
     cp "$SCRIPT_SOURCE" "${TEST_FRAMEWORK}/dev-tools/check-review-evolution.sh"
+    cp "${REPO_ROOT}/config/customer-requirement.schema.json" \
+        "${TEST_FRAMEWORK}/config/customer-requirement.schema.json"
     SCRIPT="${TEST_FRAMEWORK}/dev-tools/check-review-evolution.sh"
     # shellcheck disable=SC2016  # The generated A2 oracle must retain its own shell variables literally.
     printf '%s\n' \
@@ -30,6 +32,13 @@ setup() {
         'printf '\''{"decision":"MET","epic_status":"MET","findings":[],"stage":"qa","status":"MET","task":"%s"}\n'\'' "$task"' \
         >"${TEST_FRAMEWORK}/dev-tools/check-customer-delivery.sh"
     chmod +x "${TEST_FRAMEWORK}/dev-tools/check-customer-delivery.sh"
+    DECISION_PRIVATE_KEY="${BATS_TEST_TMPDIR}/decision-private.pem"
+    openssl genpkey -algorithm ED25519 -out "$DECISION_PRIVATE_KEY" >/dev/null 2>&1
+    DECISION_PUBLIC_KEY="$(openssl pkey -in "$DECISION_PRIVATE_KEY" -pubout -outform DER 2>/dev/null \
+        | tail -c 32 | openssl base64 -A)"
+    yq -i ".\"x-datarim-signature-contract\".key_resolution.bundled_registry.entries[] |=
+      (select(.key_id == \"key-operator-0001\").public_key = \"${DECISION_PUBLIC_KEY}\")" \
+        "${TEST_FRAMEWORK}/config/customer-requirement.schema.json"
     ROOT="${BATS_TEST_TMPDIR}/consumer"
     TASK_ID='WEB-0001'
     REQUIREMENTS="${ROOT}/datarim/tasks/${TASK_ID}-customer-requirements.yaml"
@@ -46,24 +55,70 @@ setup() {
     yq -i '.requirements.req-0001.acceptance.implementation.code_revision = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" |
       .requirements.req-0001.acceptance.implementation.content_revision = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" |
       .requirements.req-0001.acceptance.disposition = "accepted"' "$REQUIREMENTS"
+    git -C "$ROOT" init -q
+    git -C "$ROOT" config user.name test
+    git -C "$ROOT" config user.email test@example.invalid
+    git -C "$ROOT" add datarim
+    GIT_AUTHOR_DATE='2026-01-03T14:50:00Z' GIT_COMMITTER_DATE='2026-01-03T14:50:00Z' \
+        git -C "$ROOT" commit -q -m 'pre-evolution delivery records'
     printf '%s\n' '# Review checklist revision 2' >"${ROOT}/${ARTIFACT_PATH}"
     printf '%s\n' 'status=failed_as_expected' 'command=review-gate-mutant' >"${ROOT}/${RED_PATH}"
     printf '%s\n' 'status=passed' 'command=review-gate' >"${ROOT}/${GREEN_PATH}"
     printf '%s\n' 'neutral evidence without a verdict marker' >"${ROOT}/artifacts/evolution/neutral.txt"
     printf '%s\n' '{"state":"APPROVED","review_id":"review-0001"}' \
         >"${ROOT}/artifacts/reviews/review-0001-approval.json"
-    git -C "$ROOT" init -q
-    git -C "$ROOT" config user.name test
-    git -C "$ROOT" config user.email test@example.invalid
+    printf '%s\n' 'attacker-controlled unsigned evidence' >"${ROOT}/attacker-evidence"
     git -C "$ROOT" add .
     GIT_AUTHOR_DATE='2026-01-03T15:10:00Z' GIT_COMMITTER_DATE='2026-01-03T15:10:00Z' \
         git -C "$ROOT" commit -q -m 'canon evolution evidence'
     ARTIFACT_REVISION="$(git -C "$ROOT" rev-parse HEAD)"
     ARTIFACT_DIGEST="sha256:$(openssl dgst -sha256 "${ROOT}/${ARTIFACT_PATH}" | awk '{print $NF}')"
     yq -i ".canonical_change.artifact_id = \"${ARTIFACT_PATH}\" |
+      .canonical_change.change_kind = \"NEW_ARTIFACT\" |
       .canonical_change.artifact_revision = \"${ARTIFACT_REVISION}\" |
       .canonical_change.digest = \"${ARTIFACT_DIGEST}\" |
       .canonical_change.recorded_at = \"2026-01-03T15:30:00Z\"" "$REVIEW"
+}
+
+write_signed_no_canon_decision() {
+    local reviewer='independent-reviewer'
+    local approved_at='2026-01-03T15:15:00Z'
+    local finding_evidence_ref='artifacts/reviews/review-0001-approval.json'
+    local decision_path='artifacts/reviews/no-canon-change-decision.json'
+    local canonical_payload="${BATS_TEST_TMPDIR}/no-canon-payload.json"
+    local signature_file="${BATS_TEST_TMPDIR}/no-canon-signature.bin"
+    local payload_digest signature
+    jq -n --arg task "$TASK_ID" --arg reviewer "$reviewer" \
+        --arg approved_at "$approved_at" --arg evidence_ref "$finding_evidence_ref" \
+        --arg decision_ref "$decision_path" '{
+          schema_version: 1,
+          decision: "NO_CANON_CHANGE",
+          task_id: $task,
+          requirement_id: "req-0001",
+          delivery_receipt_id: "receipt-0001",
+          originating_review_id: "review-0001",
+          originating_review_digest: "sha256:89ad08914c519c6154801fd4a70752e6edbd35303acc0555b42bd3c36b629235",
+          reviewer: $reviewer,
+          approved: true,
+          approved_at: $approved_at,
+          finding_evidence_ref: $evidence_ref,
+          decision_evidence_ref: $decision_ref,
+          authority_id: "authority-operator-0001",
+          authority_role: "OPERATOR",
+          algorithm: "ED25519",
+          key_id: "key-operator-0001"
+        }' >"${ROOT}/${decision_path}"
+    jq -cS . "${ROOT}/${decision_path}" >"$canonical_payload"
+    payload_digest="sha256:$(openssl dgst -sha256 "$canonical_payload" | awk '{print $NF}')"
+    openssl pkeyutl -sign -inkey "$DECISION_PRIVATE_KEY" -rawin \
+        -in "$canonical_payload" -out "$signature_file"
+    signature="ed25519:$(openssl base64 -A -in "$signature_file")"
+    yq -i ".payload_digest = \"${payload_digest}\" | .signature = \"${signature}\"" \
+        "${ROOT}/${decision_path}"
+    git -C "$ROOT" add "$decision_path"
+    GIT_AUTHOR_DATE='2026-01-03T15:20:00Z' GIT_COMMITTER_DATE='2026-01-03T15:20:00Z' \
+        git -C "$ROOT" commit -q -m 'signed no-canon decision'
+    printf '%s\n' "$decision_path"
 }
 
 run_validator() {
@@ -122,14 +177,15 @@ assert_not_met() {
 }
 
 @test "NO_CANON_CHANGE is accepted only with evidence and reviewer approval" {
+    write_signed_no_canon_decision >/dev/null
     yq -i '.classification = "NO_CANON_CHANGE" |
       del(.canonical_change) |
       .no_canon_change = {
-        "evidence": "artifacts/reviews/review-0001-approval.json",
+        "evidence": "artifacts/reviews/no-canon-change-decision.json",
         "reviewer_approval": {
           "reviewer": "independent-reviewer",
           "approved": true,
-          "approved_at": "2026-01-03T14:56:00Z"
+          "approved_at": "2026-01-03T15:15:00Z"
         }
       }' "$REVIEW"
     run_validator
@@ -146,7 +202,7 @@ assert_not_met() {
         "reviewer_approval": {
           "reviewer": "independent-reviewer",
           "approved": true,
-          "approved_at": "2026-01-03T14:56:00Z"
+          "approved_at": "2026-01-03T13:01:00Z"
         }
       }' "$REVIEW"
     run_validator
@@ -157,30 +213,113 @@ assert_not_met() {
     yq -i '.classification = "NO_CANON_CHANGE" |
       del(.canonical_change) |
       .no_canon_change = {
-        "evidence": "artifacts/reviews/review-0001-approval.json",
+        "evidence": "operator-visual-acceptance-0001",
         "reviewer_approval": {
-          "reviewer": "independent-reviewer",
+          "reviewer": "authority-operator-0001",
           "approved": false,
-          "approved_at": "2026-01-03T14:56:00Z"
+          "approved_at": "2026-01-03T13:01:00Z"
         }
       }' "$REVIEW"
     run_validator
     assert_not_met 'no_canon_change_not_approved'
 }
 
-@test "NO_CANON_CHANGE approval must come from the classified finding reviewer" {
+@test "NO_CANON_CHANGE approval must come from the authenticated originating reviewer" {
+    write_signed_no_canon_decision >/dev/null
     yq -i '.classification = "NO_CANON_CHANGE" |
       del(.canonical_change) |
       .no_canon_change = {
-        "evidence": "artifacts/reviews/review-0001-approval.json",
+        "evidence": "artifacts/reviews/no-canon-change-decision.json",
         "reviewer_approval": {
           "reviewer": "different-reviewer",
           "approved": true,
-          "approved_at": "2026-01-03T14:56:00Z"
+          "approved_at": "2026-01-03T15:15:00Z"
         }
       }' "$REVIEW"
     run_validator
     assert_not_met 'no_canon_change_reviewer_mismatch:independent-reviewer:different-reviewer'
+}
+
+@test "NO_CANON_CHANGE cannot authenticate itself by mutating both unsigned review copies" {
+    yq -i '.classification = "NO_CANON_CHANGE" |
+      del(.canonical_change) |
+      .originating_review.evidence_ref = "attacker-evidence" |
+      .originating_review.authority_approval.approved_at = "2026-01-03T15:45:00Z" |
+      .originating_review.review_digest = "sha256:7777777777777777777777777777777777777777777777777777777777777777" |
+      .originating_review.authority_approval.signature = "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==" |
+      .no_canon_change = {
+        "evidence": "attacker-evidence",
+        "reviewer_approval": {
+          "reviewer": "independent-reviewer",
+          "approved": true,
+          "approved_at": "2026-01-03T15:45:00Z"
+        }
+      }' "$REVIEW"
+    run_validator
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *'no_canon_change_decision_not_authenticated'* ]]
+}
+
+@test "NO_CANON_CHANGE rejects a tampered signed decision payload" {
+    write_signed_no_canon_decision >/dev/null
+    yq -i '.reviewer = "attacker"' "${ROOT}/artifacts/reviews/no-canon-change-decision.json"
+    git -C "$ROOT" add artifacts/reviews/no-canon-change-decision.json
+    GIT_AUTHOR_DATE='2026-01-03T15:21:00Z' GIT_COMMITTER_DATE='2026-01-03T15:21:00Z' \
+        git -C "$ROOT" commit -q -m 'tamper decision payload'
+    yq -i '.classification = "NO_CANON_CHANGE" |
+      del(.canonical_change) |
+      .no_canon_change = {
+        "evidence": "artifacts/reviews/no-canon-change-decision.json",
+        "reviewer_approval": {
+          "reviewer": "independent-reviewer",
+          "approved": true,
+          "approved_at": "2026-01-03T15:15:00Z"
+        }
+      }' "$REVIEW"
+    run_validator
+    assert_not_met 'no_canon_change_decision_not_authenticated'
+}
+
+@test "NO_CANON_CHANGE rejects a forged decision signature" {
+    write_signed_no_canon_decision >/dev/null
+    yq -i '.signature = "ed25519:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=="' \
+        "${ROOT}/artifacts/reviews/no-canon-change-decision.json"
+    git -C "$ROOT" add artifacts/reviews/no-canon-change-decision.json
+    GIT_AUTHOR_DATE='2026-01-03T15:21:00Z' GIT_COMMITTER_DATE='2026-01-03T15:21:00Z' \
+        git -C "$ROOT" commit -q -m 'forge decision signature'
+    yq -i '.classification = "NO_CANON_CHANGE" |
+      del(.canonical_change) |
+      .no_canon_change = {
+        "evidence": "artifacts/reviews/no-canon-change-decision.json",
+        "reviewer_approval": {
+          "reviewer": "independent-reviewer",
+          "approved": true,
+          "approved_at": "2026-01-03T15:15:00Z"
+        }
+      }' "$REVIEW"
+    run_validator
+    assert_not_met 'no_canon_change_decision_not_authenticated'
+}
+
+@test "NO_CANON_CHANGE rejects a forged decision payload digest" {
+    write_signed_no_canon_decision >/dev/null
+    yq -i '.payload_digest = "sha256:7777777777777777777777777777777777777777777777777777777777777777"' \
+        "${ROOT}/artifacts/reviews/no-canon-change-decision.json"
+    git -C "$ROOT" add artifacts/reviews/no-canon-change-decision.json
+    GIT_AUTHOR_DATE='2026-01-03T15:21:00Z' GIT_COMMITTER_DATE='2026-01-03T15:21:00Z' \
+        git -C "$ROOT" commit -q -m 'forge decision digest'
+    yq -i '.classification = "NO_CANON_CHANGE" |
+      del(.canonical_change) |
+      .no_canon_change = {
+        "evidence": "artifacts/reviews/no-canon-change-decision.json",
+        "reviewer_approval": {
+          "reviewer": "independent-reviewer",
+          "approved": true,
+          "approved_at": "2026-01-03T15:15:00Z"
+        }
+      }' "$REVIEW"
+    run_validator
+    assert_not_met 'no_canon_change_decision_not_authenticated'
 }
 
 @test "forged authored delivery summary cannot substitute for the A2 delivery verdict" {
@@ -217,6 +356,97 @@ assert_not_met() {
         && [[ "$output" == *'canonical_change_digest_mismatch:ABSENT'* ]]
 }
 
+@test "canonical evolution rejects a detached revision that is not an ancestor of bound HEAD" {
+    local empty_tree detached_parent detached_child current_tree
+    empty_tree="$(printf '' | git -C "$ROOT" mktree)"
+    detached_parent="$(printf '%s\n' 'detached parent' | env \
+        GIT_AUTHOR_DATE='2026-01-03T15:01:00Z' GIT_COMMITTER_DATE='2026-01-03T15:01:00Z' \
+        git -C "$ROOT" commit-tree "$empty_tree")"
+    current_tree="$(git -C "$ROOT" rev-parse 'HEAD^{tree}')"
+    detached_child="$(printf '%s\n' 'detached evolution' | env \
+        GIT_AUTHOR_DATE='2026-01-03T15:20:00Z' GIT_COMMITTER_DATE='2026-01-03T15:20:00Z' \
+        git -C "$ROOT" commit-tree "$current_tree" -p "$detached_parent")"
+    yq -i ".canonical_change.artifact_revision = \"${detached_child}\"" "$REVIEW"
+    run_validator
+    assert_not_met 'canonical_change_revision_not_ancestor:ABSENT'
+}
+
+@test "ARTIFACT_REVISION rejects a no-op commit whose artifact blob is unchanged" {
+    local noop tree parent
+    parent="$(git -C "$ROOT" rev-parse HEAD)"
+    tree="$(git -C "$ROOT" rev-parse 'HEAD^{tree}')"
+    noop="$(printf '%s\n' 'no-op evolution' | env \
+        GIT_AUTHOR_DATE='2026-01-03T15:20:00Z' GIT_COMMITTER_DATE='2026-01-03T15:20:00Z' \
+        git -C "$ROOT" commit-tree "$tree" -p "$parent")"
+    git -C "$ROOT" update-ref HEAD "$noop"
+    yq -i ".canonical_change.change_kind = \"ARTIFACT_REVISION\" |
+      .canonical_change.artifact_revision = \"${noop}\"" "$REVIEW"
+    run_validator
+    assert_not_met 'canonical_change_artifact_unchanged:ABSENT'
+}
+
+@test "ARTIFACT_REVISION rejects a mode-only commit whose artifact blob is unchanged" {
+    git -C "$ROOT" update-index --chmod=+x "$ARTIFACT_PATH"
+    GIT_AUTHOR_DATE='2026-01-03T15:20:00Z' GIT_COMMITTER_DATE='2026-01-03T15:20:00Z' \
+        git -C "$ROOT" commit -q -m 'change artifact mode only'
+    ARTIFACT_REVISION="$(git -C "$ROOT" rev-parse HEAD)"
+    yq -i ".canonical_change.change_kind = \"ARTIFACT_REVISION\" |
+      .canonical_change.artifact_revision = \"${ARTIFACT_REVISION}\"" "$REVIEW"
+    run_validator
+    assert_not_met 'canonical_change_artifact_unchanged:ABSENT'
+}
+
+@test "canonical evolution fails closed on merge revisions" {
+    local tree first_parent other_parent merge_revision
+    first_parent="$(git -C "$ROOT" rev-parse HEAD)"
+    tree="$(git -C "$ROOT" rev-parse 'HEAD^{tree}')"
+    other_parent="$(printf '%s\n' 'other parent' | env \
+        GIT_AUTHOR_DATE='2026-01-03T15:05:00Z' GIT_COMMITTER_DATE='2026-01-03T15:05:00Z' \
+        git -C "$ROOT" commit-tree "$tree" -p "$(git -C "$ROOT" rev-parse HEAD^)")"
+    merge_revision="$(printf '%s\n' 'merge evolution' | env \
+        GIT_AUTHOR_DATE='2026-01-03T15:20:00Z' GIT_COMMITTER_DATE='2026-01-03T15:20:00Z' \
+        git -C "$ROOT" commit-tree "$tree" -p "$first_parent" -p "$other_parent")"
+    git -C "$ROOT" update-ref HEAD "$merge_revision"
+    yq -i ".canonical_change.change_kind = \"ARTIFACT_REVISION\" |
+      .canonical_change.artifact_revision = \"${merge_revision}\"" "$REVIEW"
+    run_validator
+    assert_not_met 'canonical_change_merge_revision_unsupported:ABSENT'
+}
+
+@test "ARTIFACT_REVISION accepts a reachable commit that changes the existing artifact" {
+    printf '%s\n' '# Review checklist revision 3' >"${ROOT}/${ARTIFACT_PATH}"
+    git -C "$ROOT" add "$ARTIFACT_PATH"
+    GIT_AUTHOR_DATE='2026-01-03T15:20:00Z' GIT_COMMITTER_DATE='2026-01-03T15:20:00Z' \
+        git -C "$ROOT" commit -q -m 'revise canon artifact'
+    ARTIFACT_REVISION="$(git -C "$ROOT" rev-parse HEAD)"
+    ARTIFACT_DIGEST="sha256:$(openssl dgst -sha256 "${ROOT}/${ARTIFACT_PATH}" | awk '{print $NF}')"
+    yq -i ".canonical_change.change_kind = \"ARTIFACT_REVISION\" |
+      .canonical_change.artifact_revision = \"${ARTIFACT_REVISION}\" |
+      .canonical_change.digest = \"${ARTIFACT_DIGEST}\"" "$REVIEW"
+    run_validator
+    [ "$status" -eq 0 ] \
+        && [[ "$output" == *'"status":"MET"'* ]]
+}
+
+@test "NEW_ARTIFACT rejects a path that already existed in the parent revision" {
+    printf '%s\n' '# Review checklist revision 3' >"${ROOT}/${ARTIFACT_PATH}"
+    git -C "$ROOT" add "$ARTIFACT_PATH"
+    GIT_AUTHOR_DATE='2026-01-03T15:20:00Z' GIT_COMMITTER_DATE='2026-01-03T15:20:00Z' \
+        git -C "$ROOT" commit -q -m 'revise existing canon artifact'
+    ARTIFACT_REVISION="$(git -C "$ROOT" rev-parse HEAD)"
+    ARTIFACT_DIGEST="sha256:$(openssl dgst -sha256 "${ROOT}/${ARTIFACT_PATH}" | awk '{print $NF}')"
+    yq -i ".canonical_change.artifact_revision = \"${ARTIFACT_REVISION}\" |
+      .canonical_change.digest = \"${ARTIFACT_DIGEST}\"" "$REVIEW"
+    run_validator
+    assert_not_met 'canonical_change_new_artifact_preexisting:ABSENT'
+}
+
+@test "ARTIFACT_REVISION rejects a path absent from the parent revision" {
+    yq -i '.canonical_change.change_kind = "ARTIFACT_REVISION"' "$REVIEW"
+    run_validator
+    assert_not_met 'canonical_change_revision_parent_missing_artifact:ABSENT'
+}
+
 @test "canonical evolution rejects path escape and nonexistent red-green evidence" {
     yq -i '.canonical_change.artifact_id = "../outside.md" |
       .canonical_change.enforcement.red_evidence = "artifacts/evolution/missing-red.txt" |
@@ -240,7 +470,8 @@ assert_not_met() {
     assert_not_met 'canonical_change_invalid_recorded_at:ABSENT' || return 1
 
     yq -i '.canonical_change.recorded_at = "2026-01-03T15:30:00Z" |
-      .reviewed_at = "2026-01-03T15:20:00Z"' "$REVIEW"
+      .originating_review.observed_at = "2026-01-03T15:20:00Z" |
+      .originating_review_inventory[0].observed_at = "2026-01-03T15:20:00Z"' "$REVIEW"
     run_validator
     assert_not_met 'canonical_change_post_hoc:ABSENT'
 }
@@ -258,8 +489,7 @@ assert_not_met() {
       }' "$REVIEW"
     run_validator
     [ "$status" -eq 1 ] \
-        && [[ "$output" == *'no_canon_change_evidence_not_authenticated'* ]] \
-        && [[ "$output" == *'no_canon_change_approval_not_authenticated'* ]] \
+        && [[ "$output" == *'no_canon_change_decision_not_authenticated'* ]] \
         && [[ "$output" == *'no_canon_change_invalid_approved_at'* ]]
 }
 


### PR DESCRIPTION
## Summary
- enforce the six canonical review-evolution classifications
- require artifact evolution and red-capable checks for canonical gaps
- require evidence and reviewer approval for no-canon-change dispositions
- prevent evolution evidence from substituting for product delivery

## Verification
- RED: 12/12 failed with validator absent (exit 127)
- GREEN: 16/16 focused Bats
- four core mutants killed
- ShellCheck and bash syntax clean
- changed-file secret scan clean

Task: TALO-0001 A3