### PR TITLE
feat: bind expectations to customer requirements

### DIFF
--- a/.github/workflows/bats.yml
+++ b/.github/workflows/bats.yml
@@ -239,6 +239,7 @@ jobs:
             tests/stage-snapshot-id-regex.bats \
             tests/stage-snapshot-flock-race.bats \
             tests/session-handoff-writer.bats \
+            tests/customer-requirement-expectations-binding.bats \
             dev-tools/tests/check-archive-landing.bats \
             cli/tests/backlog.bats \
             cli/tests/backlog-add-collision.bats

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ Skills are reusable knowledge modules loaded on demand. They provide rules, patt
 - `session-handoff-replay.md` -- Consumer contract for `/dr-continue`: read session artefact in clean window, re-verify every claim via live probes (STALE SNAPSHOT / CLAIM-UNVERIFIED / FILE-MISSING banners), downgrade provenance tags, route to `/dr-next` or `/dr-auto`. Squash-collision detection via `git merge-base --is-ancestor`. Shares bilingual replay renderer with `/dr-next` via `skills/dr-next-snapshot-replay/SKILL.md § Shared Replay Renderer`. (loaded by: /dr-continue)
 - `context-window-self-clearing.md` — Default-off orchestrator contract for deterministic Claude Code/Codex pressure thresholds, checkpoint-before-reset transactions, fixed compact/clear instructions, and snapshot-first continuation. (loaded by: /dr-orchestrate plugin runtime)
 
-Skill files: `$HOME/.claude/skills/{name}/SKILL.md` (72 skills, 13 with supporting fragment directories — a "supporting fragment directory" is a skill folder that ships at least one sibling `.md` beside its `SKILL.md`)
+Skill files: `$HOME/.claude/skills/{name}/SKILL.md` (73 skills, 13 with supporting fragment directories — a "supporting fragment directory" is a skill folder that ships at least one sibling `.md` beside its `SKILL.md`)
 
 > **Available since v1.16.0:** `cta-format.md` — canonical CTA "Next Step" block specification, loaded by `planner`, `architect`, `developer`, `reviewer`, `compliance` agents. Defines structure, separators, primary marker, multi-task menu (Variant B), and FAIL-Routing variant.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ reflection. The result is inconsistent quality, skipped steps, and zero institut
 learning. Every task starts from scratch, repeating the same mistakes from yesterday.
 
 Datarim fixes this by providing a complete iterative pipeline for any project type.
-It includes 19 specialized agents, 72 reusable skills, and 28 commands that guide
+It includes 19 specialized agents, 73 reusable skills, and 28 commands that guide
 work through a structured process: requirements gathering, planning, design,
 execution, quality assurance, compliance, reflection, and archival. The pipeline is
 complexity-aware — a quick fix does not go through the same process as a major
@@ -97,7 +97,7 @@ Stages in `[brackets]` are conditional — included when the agent determines th
   cross-Claude-family fallback). Each agent has a defined role, capabilities,
   and the stages where it operates.
 
-- **72 reusable skills** — modular knowledge units that agents load on demand,
+- **73 reusable skills** — modular knowledge units that agents load on demand,
   covering everything from testing methodology to security hardening to content
   creation workflows and structured research.
 
@@ -553,7 +553,7 @@ involve most of the nineteen agents across different stages.
 | **reflecting** | Post-task reflection: lessons learned, evolution proposals, Class A/B gate | /dr-archive (Step 0.5) |
 
 The table above is a representative sample, not the full catalogue — the
-complete list of all 72 skills is in
+complete list of all 73 skills is in
 [`documentation/reference/skills.md`](documentation/reference/skills.md).
 
 Skills are modular. Each one is a directory containing a `SKILL.md` (plus any
@@ -1092,7 +1092,7 @@ and why it exists.
 ```
 datarim/
   agents/            # Agent personas (19 agents)
-  skills/            # Knowledge modules (72 skills)
+  skills/            # Knowledge modules (73 skills)
   commands/          # Slash commands (28 commands)
   templates/         # Task and document templates (25 templates)
   documentation/              # Extended documentation and use cases

--- a/dev-tools/check-expectations-checklist.sh
+++ b/dev-tools/check-expectations-checklist.sh
@@ -291,6 +291,7 @@ parse_items() {
             fence_line = fence_candidate($0)
             if (!in_comment && code_span_len == 0 && start_fence(fence_line)) next
             $0 = strip_html_comments($0)
+            if (suppress_structure) next
             if ($0 ~ /^[ \t]*$/) next
             fence_line = fence_candidate($0)
             if (start_fence(fence_line)) next
@@ -450,6 +451,7 @@ parse_items() {
 
         function strip_html_comments(line,    out, pos, close_at, run_len, match_at) {
             out = ""
+            suppress_structure = 0
             if (in_comment) {
                 close_at = index(line, "-->")
                 if (close_at == 0) return ""
@@ -460,8 +462,9 @@ parse_items() {
             pos = 1
             if (code_span_len > 0) {
                 match_at = matching_backtick_run(line, pos, code_span_len)
-                if (match_at == 0) return "<>"
-                out = "<>"
+                suppress_structure = 1
+                if (match_at == 0) return line
+                out = substr(line, 1, match_at + code_span_len - 1)
                 pos = match_at + code_span_len
                 code_span_len = 0
             }
@@ -470,12 +473,12 @@ parse_items() {
                     run_len = backtick_run(line, pos)
                     match_at = matching_backtick_run(line, pos + run_len, run_len)
                     if (match_at > 0) {
-                        out = out "<>"
+                        out = out substr(line, pos, match_at + run_len - pos)
                         pos = match_at + run_len
                         continue
                     }
                     code_span_len = run_len
-                    return out "<>"
+                    return out substr(line, pos)
                 }
                 if (substr(line, pos, 4) == "<!--" && !is_escaped(line, pos)) {
                     close_at = index(substr(line, pos + 4), "-->")
@@ -615,6 +618,10 @@ parse_items() {
                 }
                 if (verification_mode == "reproducible" && evidence_artifact == "") {
                     printf "ERROR: %s: item %d verification-not-wired: %s (reproducible requires evidence_artifact)\n", \
+                        f, current_item, wish_id > "/dev/stderr"
+                    errors++
+                } else if (verification_mode == "reproducible" && index(evidence_artifact, "`") > 0) {
+                    printf "ERROR: %s: item %d verification-not-wired: %s (evidence_artifact must be a plain scalar)\n", \
                         f, current_item, wish_id > "/dev/stderr"
                     errors++
                 }

--- a/dev-tools/check-expectations-checklist.sh
+++ b/dev-tools/check-expectations-checklist.sh
@@ -169,12 +169,20 @@ frontmatter_field_inventory() {
             in_fm = 1
             next
         }
-        in_fm && match($0, /^[A-Za-z_][A-Za-z0-9_-]*[ \t]*:/) {
+        in_fm {
+            if ($0 ~ /^[ \t]*$/ || $0 ~ /^[ \t]*#/) next
+            if ($0 !~ /^[A-Za-z_][A-Za-z0-9_]*:[ \t]+[^ \t]/ \
+                || $0 ~ /^[A-Za-z_][A-Za-z0-9_]*:[ \t]+[|>][-+0-9]*([ \t]+#.*)?[ \t]*$/) {
+                invalid[NR] = 1
+                next
+            }
             key = substr($0, 1, index($0, ":") - 1)
-            sub(/[ \t]+$/, "", key)
             seen[key]++
         }
-        END { for (key in seen) print key "|" seen[key] }
+        END {
+            for (line in invalid) print "__INVALID__|" line
+            for (key in seen) print key "|" seen[key]
+        }
     ' "$file"
 }
 
@@ -253,6 +261,7 @@ parse_items() {
     awk -v f="$file" -v schema="$schema" -v task="$task_id" '
         BEGIN {
             in_section = 0; current_item = 0; total_items = 0; errors = 0
+            expectations_heading_count = 0
             wish_id = ""; status = ""; override_text = ""; evidence_type = ""
             override_by = ""; override_class = ""; override_artifact = ""
             verification_mode = ""; evidence_artifact = ""; success_criterion = ""
@@ -283,6 +292,13 @@ parse_items() {
         }
 
         /^## Ожидания[ \t]*$/ {
+            expectations_heading_count++
+            if (expectations_heading_count > 1) {
+                if (current_item) emit_item()
+                current_item = 0
+                printf "ERROR: %s: duplicate active ## Ожидания heading\n", f > "/dev/stderr"
+                errors++
+            }
             in_section = 1; next
         }
         /^## / && in_section {
@@ -643,6 +659,11 @@ validate_single_task() {
 
     while IFS='|' read -r frontmatter_field field_count; do
         [ -z "$frontmatter_field" ] && continue
+        if [ "$frontmatter_field" = "__INVALID__" ]; then
+            echo "ERROR: $file: invalid frontmatter line ${field_count}; expected an unquoted flat 'key: value' scalar" >&2
+            errors=$(( errors + 1 ))
+            continue
+        fi
         if [ "${field_count:-0}" -gt 1 ]; then
             echo "ERROR: $file: duplicate frontmatter field '$frontmatter_field'" >&2
             errors=$(( errors + 1 ))

--- a/dev-tools/check-expectations-checklist.sh
+++ b/dev-tools/check-expectations-checklist.sh
@@ -161,7 +161,7 @@ extract_frontmatter_field() {
     ' "$file"
 }
 
-duplicate_frontmatter_fields() {
+frontmatter_field_inventory() {
     local file="$1"
     awk '
         /^---[ \t]*$/ {
@@ -173,8 +173,8 @@ duplicate_frontmatter_fields() {
             key = substr($0, 1, index($0, ":") - 1)
             sub(/[ \t]+$/, "", key)
             seen[key]++
-            if (seen[key] == 2) print key
         }
+        END { for (key in seen) print key "|" seen[key] }
     ' "$file"
 }
 
@@ -605,13 +605,27 @@ validate_single_task() {
         return 1
     fi
 
-    local errors=0 val schema_v customer_binding_from artifact_status duplicate_field
+    local errors=0 val schema_v artifact_status frontmatter_field field_count
 
-    while IFS= read -r duplicate_field; do
-        [ -z "$duplicate_field" ] && continue
-        echo "ERROR: $file: duplicate frontmatter field '$duplicate_field'" >&2
-        errors=$(( errors + 1 ))
-    done < <(duplicate_frontmatter_fields "$file")
+    while IFS='|' read -r frontmatter_field field_count; do
+        [ -z "$frontmatter_field" ] && continue
+        if [ "${field_count:-0}" -gt 1 ]; then
+            echo "ERROR: $file: duplicate frontmatter field '$frontmatter_field'" >&2
+            errors=$(( errors + 1 ))
+        fi
+        case "$frontmatter_field" in
+            task_id|artifact|schema_version|captured_at|captured_by|status|agent|parent_init_task|parent_prd)
+                ;;
+            customer_binding_from)
+                echo "ERROR: $file: customer_binding_from is obsolete; every schema v4 wish is governed" >&2
+                errors=$(( errors + 1 ))
+                ;;
+            *)
+                echo "ERROR: $file: unknown frontmatter field '$frontmatter_field'" >&2
+                errors=$(( errors + 1 ))
+                ;;
+        esac
+    done < <(frontmatter_field_inventory "$file")
 
     for field in task_id artifact schema_version captured_at captured_by status; do
         val=$(extract_frontmatter_field "$file" "$field")
@@ -633,14 +647,9 @@ validate_single_task() {
         echo "ERROR: $file: schema_version must be '1', '2', '3', or '4', got '$val'" >&2
         errors=$(( errors + 1 ))
     fi
-    customer_binding_from=$(extract_frontmatter_field "$file" "customer_binding_from")
     artifact_status=$(extract_frontmatter_field "$file" "status")
     if [ -n "$artifact_status" ] && [ "$artifact_status" != "canonical" ] && [ "$artifact_status" != "amended" ]; then
         echo "ERROR: $file: frontmatter status must be 'canonical' or 'amended', got '$artifact_status'" >&2
-        errors=$(( errors + 1 ))
-    fi
-    if [ "$schema_v" = "4" ] && [ -n "$customer_binding_from" ]; then
-        echo "ERROR: $file: customer_binding_from is obsolete in schema_version=4; every wish is governed" >&2
         errors=$(( errors + 1 ))
     fi
     # v1 legacy deprecation warning (TUNE-0266: 12-month sunset, see

--- a/dev-tools/check-expectations-checklist.sh
+++ b/dev-tools/check-expectations-checklist.sh
@@ -30,7 +30,7 @@
 #
 set -uo pipefail
 
-VERSION="1.1.0"
+VERSION="1.2.0"
 SCRIPT_NAME="check-expectations-checklist.sh"
 
 # TUNE-0266 Phase 4: pivot date for "all wishes evidence_type=static" advisory.
@@ -56,7 +56,14 @@ Options:
   --help               Show this help and exit 0.
   --version            Print version and exit 0.
 
-Schema v3 fields (optional per-wish, opt-in — requires schema_version: 3 in frontmatter):
+Schema v4 fields (current default; required per wish):
+  customer_binding_from: <wish_id> (required frontmatter cutover marker)
+  customer_derived: true | false
+    Every wish from the cutover marker onward declares whether it came from a
+    customer requirement. true requires requirement_id, surface_class,
+    visitor_visible, and delivery_receipt; false forbids those four fields.
+
+Schema v3 fields (also supported by v4):
   verification_mode: one-off | reproducible
     Distinguishes a one-off manual check (default when absent) from a
     reproducible/wired check. Bad enum value → ERROR.
@@ -202,14 +209,36 @@ days_between() {
 parse_items() {
     local file="$1"
     local schema="${2:-1}"
-    awk -v f="$file" -v schema="$schema" '
+    local task_id="${3:-}"
+    local cutover="${4:-}"
+    local artifact_status="${5:-}"
+    awk -v f="$file" -v schema="$schema" -v task="$task_id" \
+        -v cutover="$cutover" -v artifact_status="$artifact_status" '
         BEGIN {
             in_section = 0; current_item = 0; total_items = 0; errors = 0
             wish_id = ""; status = ""; override_text = ""; evidence_type = ""
             override_by = ""; override_class = ""; override_artifact = ""
             verification_mode = ""; evidence_artifact = ""; success_criterion = ""
+            customer_derived = ""
+            requirement_id = ""; surface_class = ""; visitor_visible = ""; delivery_receipt = ""
+            customer_derived_count = 0
+            requirement_id_count = 0; surface_class_count = 0
+            visitor_visible_count = 0; delivery_receipt_count = 0
+            in_comment = 0; binding_started = 0; cutover_seen = 0
+            first_wish_id = ""
             history_count = 0; has_history_heading = 0; has_status_heading = 0
             in_history = 0; in_status = 0
+        }
+
+        {
+            if (in_comment) {
+                if ($0 ~ /-->/) in_comment = 0
+                next
+            }
+            if ($0 ~ /<!--/) {
+                if ($0 !~ /-->/) in_comment = 1
+                next
+            }
         }
 
         /^## Ожидания[ \t]*$/ {
@@ -232,6 +261,11 @@ parse_items() {
                 wish_id = ""; status = ""; override_text = ""; evidence_type = ""
                 override_by = ""; override_class = ""; override_artifact = ""
                 verification_mode = ""; evidence_artifact = ""; success_criterion = ""
+                customer_derived = ""
+                requirement_id = ""; surface_class = ""; visitor_visible = ""; delivery_receipt = ""
+                customer_derived_count = 0
+                requirement_id_count = 0; surface_class_count = 0
+                visitor_visible_count = 0; delivery_receipt_count = 0
                 history_count = 0; has_history_heading = 0; has_status_heading = 0
                 in_history = 0; in_status = 0
                 next
@@ -240,11 +274,42 @@ parse_items() {
                 if (match($0, /^  - wish_id:[ \t]*/)) {
                     wish_id = substr($0, RLENGTH + 1)
                     sub(/[ \t]+$/, "", wish_id)
+                    if (current_item == 1) first_wish_id = wish_id
                     in_history = 0; in_status = 0; next
                 }
                 if (match($0, /^  - evidence_type:[ \t]*/)) {
                     evidence_type = substr($0, RLENGTH + 1)
                     sub(/[ \t]+$/, "", evidence_type)
+                    in_history = 0; in_status = 0; next
+                }
+                if (match($0, /^  - customer_derived:[ \t]*/)) {
+                    customer_derived_count++
+                    customer_derived = substr($0, RLENGTH + 1)
+                    sub(/[ \t]+$/, "", customer_derived)
+                    in_history = 0; in_status = 0; next
+                }
+                if (match($0, /^  - requirement_id:[ \t]*/)) {
+                    requirement_id_count++
+                    requirement_id = substr($0, RLENGTH + 1)
+                    sub(/[ \t]+$/, "", requirement_id)
+                    in_history = 0; in_status = 0; next
+                }
+                if (match($0, /^  - surface_class:[ \t]*/)) {
+                    surface_class_count++
+                    surface_class = substr($0, RLENGTH + 1)
+                    sub(/[ \t]+$/, "", surface_class)
+                    in_history = 0; in_status = 0; next
+                }
+                if (match($0, /^  - visitor_visible:[ \t]*/)) {
+                    visitor_visible_count++
+                    visitor_visible = substr($0, RLENGTH + 1)
+                    sub(/[ \t]+$/, "", visitor_visible)
+                    in_history = 0; in_status = 0; next
+                }
+                if (match($0, /^  - delivery_receipt:[ \t]*/)) {
+                    delivery_receipt_count++
+                    delivery_receipt = substr($0, RLENGTH + 1)
+                    sub(/[ \t]+$/, "", delivery_receipt)
                     in_history = 0; in_status = 0; next
                 }
                 if (match($0, /^  - verification_mode:[ \t]*/)) {
@@ -313,6 +378,16 @@ parse_items() {
                 printf "ERROR: %s: no items found under ## Ожидания (file appears empty)\n", f > "/dev/stderr"
                 errors++
             }
+            if (schema == "4" && cutover != "" && !cutover_seen) {
+                printf "ERROR: %s: customer_binding_from does not name a wish_id: %s\n", f, cutover > "/dev/stderr"
+                errors++
+            }
+            if (schema == "4" && artifact_status == "canonical" && first_wish_id != "" \
+                    && cutover != first_wish_id) {
+                printf "ERROR: %s: canonical schema v4 must start customer binding at its first wish: %s\n", \
+                    f, first_wish_id > "/dev/stderr"
+                errors++
+            }
             exit (errors > 0 ? 1 : 0)
         }
 
@@ -340,11 +415,11 @@ parse_items() {
                 printf "ERROR: %s: item %d status not in enum: %s\n", f, current_item, status > "/dev/stderr"
                 errors++
             }
-            # v2 schema: evidence_type required + enum (empirical|static|measurement).
+            # v2+ schema: evidence_type required + enum (empirical|static|measurement).
             # See skills/expectations-checklist/SKILL.md § Item rules.
-            if (schema == "2" || schema == "3") {
+            if (schema == "2" || schema == "3" || schema == "4") {
                 if (evidence_type == "") {
-                    printf "ERROR: %s: item %d missing evidence_type (required in schema_version=2/3)\n", f, current_item > "/dev/stderr"
+                    printf "ERROR: %s: item %d missing evidence_type (required in schema_version=2/3/4)\n", f, current_item > "/dev/stderr"
                     errors++
                 } else if (evidence_type != "empirical" && evidence_type != "static" \
                        && evidence_type != "measurement") {
@@ -352,11 +427,11 @@ parse_items() {
                     errors++
                 }
             }
-            # v3 schema: verification_mode optional enum; reproducible requires evidence_artifact.
+            # v3+ schema: verification_mode optional enum; reproducible requires evidence_artifact.
             # Hard error for bad enum and for reproducible-without-artifact.
             # advisory heuristic (missing mode on empirical with world-state text) and
             # stub-artifact check are done in the bash post-parse loop — they need file I/O.
-            if (schema == "3" && verification_mode != "") {
+            if ((schema == "3" || schema == "4") && verification_mode != "") {
                 if (verification_mode != "one-off" && verification_mode != "reproducible") {
                     printf "ERROR: %s: item %d verification_mode not in enum: %s (allowed: one-off|reproducible)\n", \
                         f, current_item, verification_mode > "/dev/stderr"
@@ -366,6 +441,80 @@ parse_items() {
                     printf "ERROR: %s: item %d verification-not-wired: %s (reproducible requires evidence_artifact)\n", \
                         f, current_item, wish_id > "/dev/stderr"
                     errors++
+                }
+            }
+            # v4 schema: every wish at or after the declared cutover explicitly
+            # declares customer derivation. Earlier wishes are preserved legacy.
+            if (schema == "4" && wish_id == cutover) {
+                binding_started = 1
+                cutover_seen = 1
+            }
+            if (schema == "4" && binding_started) {
+                if (customer_derived_count == 0) {
+                    printf "ERROR: %s: item %d missing customer_derived\n", f, current_item > "/dev/stderr"
+                    errors++
+                } else if (customer_derived_count > 1) {
+                    printf "ERROR: %s: item %d duplicate customer_derived\n", f, current_item > "/dev/stderr"
+                    errors++
+                } else if (customer_derived != "true" && customer_derived != "false") {
+                    printf "ERROR: %s: item %d customer_derived must be boolean true|false, got: %s\n", \
+                        f, current_item, customer_derived > "/dev/stderr"
+                    errors++
+                }
+
+                if (customer_derived == "true" && customer_derived_count == 1) {
+                    if (requirement_id_count == 0) {
+                        printf "ERROR: %s: item %d missing requirement_id\n", f, current_item > "/dev/stderr"
+                        errors++
+                    } else if (requirement_id_count > 1) {
+                        printf "ERROR: %s: item %d duplicate requirement_id\n", f, current_item > "/dev/stderr"
+                        errors++
+                    } else if (requirement_id !~ /^req-[0-9][0-9][0-9][0-9]$/) {
+                        printf "ERROR: %s: item %d requirement_id must match req-NNNN, got: %s\n", f, current_item, requirement_id > "/dev/stderr"
+                        errors++
+                    }
+                    if (surface_class_count == 0) {
+                        printf "ERROR: %s: item %d missing surface_class\n", f, current_item > "/dev/stderr"
+                        errors++
+                    } else if (surface_class_count > 1) {
+                        printf "ERROR: %s: item %d duplicate surface_class\n", f, current_item > "/dev/stderr"
+                        errors++
+                    } else if (surface_class != "VISITOR_VISIBLE" && surface_class != "ENABLING") {
+                        printf "ERROR: %s: item %d surface_class not in enum: %s (allowed: VISITOR_VISIBLE|ENABLING)\n", f, current_item, surface_class > "/dev/stderr"
+                        errors++
+                    }
+                    if (visitor_visible_count == 0) {
+                        printf "ERROR: %s: item %d missing visitor_visible\n", f, current_item > "/dev/stderr"
+                        errors++
+                    } else if (visitor_visible_count > 1) {
+                        printf "ERROR: %s: item %d duplicate visitor_visible\n", f, current_item > "/dev/stderr"
+                        errors++
+                    } else if (visitor_visible != "true" && visitor_visible != "false") {
+                        printf "ERROR: %s: item %d visitor_visible must be boolean true|false, got: %s\n", f, current_item, visitor_visible > "/dev/stderr"
+                        errors++
+                    }
+                    if (surface_class_count == 1 && visitor_visible_count == 1 \
+                            && ((surface_class == "VISITOR_VISIBLE" && visitor_visible != "true") \
+                            || (surface_class == "ENABLING" && visitor_visible != "false"))) {
+                        printf "ERROR: %s: item %d surface_class and visitor_visible disagree\n", f, current_item > "/dev/stderr"
+                        errors++
+                    }
+                    if (delivery_receipt_count == 0) {
+                        printf "ERROR: %s: item %d missing delivery_receipt\n", f, current_item > "/dev/stderr"
+                        errors++
+                    } else if (delivery_receipt_count > 1) {
+                        printf "ERROR: %s: item %d duplicate delivery_receipt\n", f, current_item > "/dev/stderr"
+                        errors++
+                    } else if (delivery_receipt != "datarim/receipts/" task "-customer-delivery.yaml") {
+                        printf "ERROR: %s: item %d delivery_receipt must be datarim/receipts/%s-customer-delivery.yaml, got: %s\n", \
+                            f, current_item, task, delivery_receipt > "/dev/stderr"
+                        errors++
+                    }
+                } else if (customer_derived == "false" && customer_derived_count == 1) {
+                    if (requirement_id_count + surface_class_count + visitor_visible_count + delivery_receipt_count > 0) {
+                        printf "ERROR: %s: item %d customer_derived=false must omit customer binding fields\n", f, current_item > "/dev/stderr"
+                        errors++
+                    }
                 }
             }
             ovr_len = length(override_text)
@@ -401,7 +550,7 @@ validate_single_task() {
         return 1
     fi
 
-    local errors=0 val
+    local errors=0 val schema_v customer_binding_from artifact_status
 
     for field in task_id artifact schema_version captured_at captured_by status; do
         val=$(extract_frontmatter_field "$file" "$field")
@@ -419,8 +568,14 @@ validate_single_task() {
 
     val=$(extract_frontmatter_field "$file" "schema_version")
     schema_v="$val"
-    if [ -n "$val" ] && [ "$val" != "1" ] && [ "$val" != "2" ] && [ "$val" != "3" ]; then
-        echo "ERROR: $file: schema_version must be '1', '2', or '3', got '$val'" >&2
+    if [ -n "$val" ] && [ "$val" != "1" ] && [ "$val" != "2" ] && [ "$val" != "3" ] && [ "$val" != "4" ]; then
+        echo "ERROR: $file: schema_version must be '1', '2', '3', or '4', got '$val'" >&2
+        errors=$(( errors + 1 ))
+    fi
+    customer_binding_from=$(extract_frontmatter_field "$file" "customer_binding_from")
+    artifact_status=$(extract_frontmatter_field "$file" "status")
+    if [ "$schema_v" = "4" ] && [ -z "$customer_binding_from" ]; then
+        echo "ERROR: $file: frontmatter missing required field 'customer_binding_from' for schema_version=4" >&2
         errors=$(( errors + 1 ))
     fi
     # v1 legacy deprecation warning (TUNE-0266: 12-month sunset, see
@@ -443,14 +598,14 @@ validate_single_task() {
     # Item-level parse — emits to stdout (captured here for v3 post-parse) + stderr.
     # schema_v passed through to enable evidence_type/verification_mode checks.
     local items_out
-    items_out=$(parse_items "$file" "${schema_v:-1}" 2>/tmp/_cec_stderr_$$) || errors=$(( errors + 1 ))
+    items_out=$(parse_items "$file" "${schema_v:-1}" "$id" "$customer_binding_from" "$artifact_status" 2>/tmp/_cec_stderr_$$) || errors=$(( errors + 1 ))
     # Pipe parse stderr to our stderr so callers see it.
     cat /tmp/_cec_stderr_$$ >&2 2>/dev/null || true
     rm -f /tmp/_cec_stderr_$$
 
-    # Post-parse bash loop: v3 evidence_artifact resolution + stub advisory + heuristic advisory.
+    # Post-parse bash loop: v3+ evidence_artifact resolution + stub advisory + heuristic advisory.
     # Done here (not in awk) because we need test -f, grep, and file scanning — unsafe inside awk system().
-    if [ "${schema_v:-1}" = "3" ] && [ -n "$items_out" ]; then
+    if { [ "${schema_v:-1}" = "3" ] || [ "${schema_v:-1}" = "4" ]; } && [ -n "$items_out" ]; then
         # Determine repo root for evidence_artifact resolution (two-tier: test -f, then grep).
         local repo_root
         repo_root=$(git -C "$(dirname "$file")" rev-parse --show-toplevel 2>/dev/null || echo "$ROOT")
@@ -538,10 +693,12 @@ verify_routing() {
         return 1
     fi
 
-    local schema_v
+    local schema_v customer_binding_from artifact_status
     schema_v=$(extract_frontmatter_field "$file" "schema_version")
+    customer_binding_from=$(extract_frontmatter_field "$file" "customer_binding_from")
+    artifact_status=$(extract_frontmatter_field "$file" "status")
     local items
-    items=$(parse_items "$file" "${schema_v:-1}" 2>/dev/null) || true
+    items=$(parse_items "$file" "${schema_v:-1}" "$id" "$customer_binding_from" "$artifact_status" 2>/dev/null) || true
 
     local blocking=()
     local has_partial_or_missed=0

--- a/dev-tools/check-expectations-checklist.sh
+++ b/dev-tools/check-expectations-checklist.sh
@@ -262,7 +262,7 @@ parse_items() {
         BEGIN {
             in_section = 0; current_item = 0; total_items = 0; errors = 0
             expectations_heading_count = 0
-            wish_id = ""; status = ""; override_text = ""; evidence_type = ""
+            wish_id = ""; wish_id_count = 0; status = ""; override_text = ""; evidence_type = ""
             override_by = ""; override_class = ""; override_artifact = ""
             verification_mode = ""; evidence_artifact = ""; success_criterion = ""
             customer_derived = ""
@@ -270,7 +270,8 @@ parse_items() {
             customer_derived_count = 0
             requirement_id_count = 0; surface_class_count = 0
             visitor_visible_count = 0; delivery_receipt_count = 0
-            in_comment = 0; in_fence = 0; fence_char = ""; fence_len = 0
+            in_comment = 0; code_span_len = 0
+            in_fence = 0; fence_char = ""; fence_len = 0
             history_count = 0; has_history_heading = 0; has_status_heading = 0
             in_history = 0; in_status = 0
         }
@@ -285,6 +286,10 @@ parse_items() {
                 }
                 next
             }
+            # Block fences take precedence over inline parsing, unless the
+            # line continues an already-open HTML comment or code span.
+            fence_line = fence_candidate($0)
+            if (!in_comment && code_span_len == 0 && start_fence(fence_line)) next
             $0 = strip_html_comments($0)
             if ($0 ~ /^[ \t]*$/) next
             fence_line = fence_candidate($0)
@@ -316,7 +321,7 @@ parse_items() {
                 if (current_item) emit_item()
                 total_items++
                 current_item = total_items
-                wish_id = ""; status = ""; override_text = ""; evidence_type = ""
+                wish_id = ""; wish_id_count = 0; status = ""; override_text = ""; evidence_type = ""
                 override_by = ""; override_class = ""; override_artifact = ""
                 verification_mode = ""; evidence_artifact = ""; success_criterion = ""
                 customer_derived = ""
@@ -330,6 +335,7 @@ parse_items() {
             }
             if (current_item) {
                 if (match($0, /^  - wish_id:[ \t]*/)) {
+                    wish_id_count++
                     wish_id = substr($0, RLENGTH + 1)
                     sub(/[ \t]+$/, "", wish_id)
                     in_history = 0; in_status = 0; next
@@ -438,27 +444,77 @@ parse_items() {
             exit (errors > 0 ? 1 : 0)
         }
 
-        function strip_html_comments(line,    open_at, close_at, prefix, tail) {
-            while (1) {
-                if (in_comment) {
-                    close_at = index(line, "-->")
-                    if (close_at == 0) return ""
-                    line = substr(line, close_at + 3)
-                    in_comment = 0
-                }
-
-                open_at = index(line, "<!--")
-                if (open_at == 0) return line
-
-                prefix = substr(line, 1, open_at - 1)
-                tail = substr(line, open_at + 4)
-                close_at = index(tail, "-->")
-                if (close_at == 0) {
-                    in_comment = 1
-                    return prefix
-                }
-                line = prefix substr(tail, close_at + 3)
+        function strip_html_comments(line,    out, pos, close_at, run_len, match_at) {
+            out = ""
+            if (in_comment) {
+                close_at = index(line, "-->")
+                if (close_at == 0) return ""
+                line = substr(line, close_at + 3)
+                in_comment = 0
             }
+
+            pos = 1
+            if (code_span_len > 0) {
+                match_at = matching_backtick_run(line, pos, code_span_len)
+                if (match_at == 0) return "x"
+                out = "x"
+                pos = match_at + code_span_len
+                code_span_len = 0
+            }
+            while (pos <= length(line)) {
+                if (substr(line, pos, 1) == "`" && !is_escaped(line, pos)) {
+                    run_len = backtick_run(line, pos)
+                    match_at = matching_backtick_run(line, pos + run_len, run_len)
+                    if (match_at > 0) {
+                        out = out "x"
+                        pos = match_at + run_len
+                        continue
+                    }
+                    code_span_len = run_len
+                    return out "x"
+                }
+                if (substr(line, pos, 4) == "<!--" && !is_escaped(line, pos)) {
+                    close_at = index(substr(line, pos + 4), "-->")
+                    if (close_at == 0) {
+                        in_comment = 1
+                        return out
+                    }
+                    pos = pos + close_at + 6
+                    continue
+                }
+                out = out substr(line, pos, 1)
+                pos++
+            }
+            return out
+        }
+
+        function backtick_run(line, pos,    run_len) {
+            run_len = 0
+            while (substr(line, pos + run_len, 1) == "`") run_len++
+            return run_len
+        }
+
+        function matching_backtick_run(line, pos, expected,    run_len) {
+            while (pos <= length(line)) {
+                if (substr(line, pos, 1) != "`") {
+                    pos++
+                    continue
+                }
+                run_len = backtick_run(line, pos)
+                if (run_len == expected) return pos
+                pos += run_len
+            }
+            return 0
+        }
+
+        function is_escaped(line, pos,    slash_count) {
+            slash_count = 0
+            pos--
+            while (pos > 0 && substr(line, pos, 1) == "\\") {
+                slash_count++
+                pos--
+            }
+            return (slash_count % 2) == 1
         }
 
         function fence_candidate(line,    i) {
@@ -497,8 +553,19 @@ parse_items() {
         }
 
         function emit_item(    ovr_len) {
-            if (wish_id == "") {
+            if (wish_id_count == 0 || wish_id == "") {
                 printf "ERROR: %s: item %d missing wish_id\n", f, current_item > "/dev/stderr"
+                errors++
+            } else if (wish_id_count > 1) {
+                printf "ERROR: %s: item %d duplicate wish_id field\n", f, current_item > "/dev/stderr"
+                errors++
+            } else if (wish_id !~ /^[A-Za-z0-9А-Яа-яЁё]+(-[A-Za-z0-9А-Яа-яЁё]+)*$/) {
+                printf "ERROR: %s: item %d wish_id must be a kebab slug: %s\n", \
+                    f, current_item, wish_id > "/dev/stderr"
+                errors++
+            } else if (seen_wish_id[wish_id]++) {
+                printf "ERROR: %s: item %d duplicate wish_id value '\''%s'\''\n", \
+                    f, current_item, wish_id > "/dev/stderr"
                 errors++
             }
             if (!has_history_heading) {

--- a/dev-tools/check-expectations-checklist.sh
+++ b/dev-tools/check-expectations-checklist.sh
@@ -842,15 +842,27 @@ validate_single_task() {
     fi
 
     parent_init_task=$(extract_frontmatter_field "$file" "parent_init_task")
-    if [ -n "$parent_init_task" ] && [ "$parent_init_task" != "${id}-init-task.md" ]; then
-        echo "ERROR: $file: parent_init_task must equal ${id}-init-task.md, got '$parent_init_task'" >&2
-        errors=$(( errors + 1 ))
+    if [ -n "$parent_init_task" ]; then
+        if [ "$schema_v" = "4" ] && [ "$parent_init_task" != "${id}-init-task.md" ]; then
+            echo "ERROR: $file: parent_init_task must equal ${id}-init-task.md, got '$parent_init_task'" >&2
+            errors=$(( errors + 1 ))
+        elif [ "$schema_v" != "4" ] && [ "$parent_init_task" != "${id}-init-task.md" ] \
+             && [ "$parent_init_task" != "datarim/tasks/${id}-init-task.md" ]; then
+            echo "ERROR: $file: legacy parent_init_task must be task-bound, got '$parent_init_task'" >&2
+            errors=$(( errors + 1 ))
+        fi
     fi
 
     parent_prd=$(extract_frontmatter_field "$file" "parent_prd")
-    if [ -n "$parent_prd" ] && [ "$parent_prd" != "../prd/PRD-${id}.md" ]; then
-        echo "ERROR: $file: parent_prd must equal ../prd/PRD-${id}.md, got '$parent_prd'" >&2
-        errors=$(( errors + 1 ))
+    if [ -n "$parent_prd" ]; then
+        if [ "$schema_v" = "4" ] && [ "$parent_prd" != "../prd/PRD-${id}.md" ]; then
+            echo "ERROR: $file: parent_prd must equal ../prd/PRD-${id}.md, got '$parent_prd'" >&2
+            errors=$(( errors + 1 ))
+        elif [ "$schema_v" != "4" ] && [ "$parent_prd" != "../prd/PRD-${id}.md" ] \
+             && [ "$parent_prd" != "datarim/prd/PRD-${id}.md" ]; then
+            echo "ERROR: $file: legacy parent_prd must be task-bound, got '$parent_prd'" >&2
+            errors=$(( errors + 1 ))
+        fi
     fi
 
     # Item-level parse is the single comment-normalized authority for the

--- a/dev-tools/check-expectations-checklist.sh
+++ b/dev-tools/check-expectations-checklist.sh
@@ -161,6 +161,23 @@ extract_frontmatter_field() {
     ' "$file"
 }
 
+duplicate_frontmatter_fields() {
+    local file="$1"
+    awk '
+        /^---[ \t]*$/ {
+            if (in_fm) exit
+            in_fm = 1
+            next
+        }
+        in_fm && match($0, /^[A-Za-z_][A-Za-z0-9_-]*[ \t]*:/) {
+            key = substr($0, 1, index($0, ":") - 1)
+            sub(/[ \t]+$/, "", key)
+            seen[key]++
+            if (seen[key] == 2) print key
+        }
+    ' "$file"
+}
+
 days_between() {
     local from="$1" to="$2"
     local from_epoch to_epoch
@@ -546,7 +563,13 @@ validate_single_task() {
         return 1
     fi
 
-    local errors=0 val schema_v customer_binding_from artifact_status
+    local errors=0 val schema_v customer_binding_from artifact_status duplicate_field
+
+    while IFS= read -r duplicate_field; do
+        [ -z "$duplicate_field" ] && continue
+        echo "ERROR: $file: duplicate frontmatter field '$duplicate_field'" >&2
+        errors=$(( errors + 1 ))
+    done < <(duplicate_frontmatter_fields "$file")
 
     for field in task_id artifact schema_version captured_at captured_by status; do
         val=$(extract_frontmatter_field "$file" "$field")
@@ -590,13 +613,9 @@ validate_single_task() {
         errors=$(( errors + 1 ))
     fi
 
-    if ! grep -q '^## Ожидания[[:space:]]*$' "$file"; then
-        echo "ERROR: $file: missing required heading '## Ожидания'" >&2
-        errors=$(( errors + 1 ))
-    fi
-
-    # Item-level parse — emits to stdout (captured here for v3 post-parse) + stderr.
-    # schema_v passed through to enable evidence_type/verification_mode checks.
+    # Item-level parse is the single comment-normalized authority for the
+    # required heading and its items. It emits to stdout (captured here for v3
+    # post-parse) + stderr. schema_v enables evidence_type/verification checks.
     local items_out
     items_out=$(parse_items "$file" "${schema_v:-1}" "$id" 2>/tmp/_cec_stderr_$$) || errors=$(( errors + 1 ))
     # Pipe parse stderr to our stderr so callers see it.

--- a/dev-tools/check-expectations-checklist.sh
+++ b/dev-tools/check-expectations-checklist.sh
@@ -445,6 +445,13 @@ parse_items() {
             }
             # v4 schema: every wish at or after the declared cutover explicitly
             # declares customer derivation. Earlier wishes are preserved legacy.
+            if (schema == "4" && !binding_started && wish_id != cutover \
+                    && customer_derived_count + requirement_id_count + surface_class_count \
+                    + visitor_visible_count + delivery_receipt_count > 0) {
+                printf "ERROR: %s: item %d customer binding field appears before customer_binding_from\n", \
+                    f, current_item > "/dev/stderr"
+                errors++
+            }
             if (schema == "4" && wish_id == cutover) {
                 binding_started = 1
                 cutover_seen = 1

--- a/dev-tools/check-expectations-checklist.sh
+++ b/dev-tools/check-expectations-checklist.sh
@@ -579,14 +579,14 @@ parse_items() {
             if (wish_id_count == 0 || wish_id == "") {
                 printf "ERROR: %s: item %d missing wish_id\n", f, current_item > "/dev/stderr"
                 errors++
-            } else if (wish_id_count > 1) {
+            } else if (schema == "4" && wish_id_count > 1) {
                 printf "ERROR: %s: item %d duplicate wish_id field\n", f, current_item > "/dev/stderr"
                 errors++
-            } else if (wish_id !~ /^[A-Za-z0-9А-Яа-яЁё]+(-[A-Za-z0-9А-Яа-яЁё]+)*$/) {
+            } else if (schema == "4" && wish_id !~ /^[A-Za-z0-9А-Яа-яЁё]+(-[A-Za-z0-9А-Яа-яЁё]+)*$/) {
                 printf "ERROR: %s: item %d wish_id must be a kebab slug: %s\n", \
                     f, current_item, wish_id > "/dev/stderr"
                 errors++
-            } else if (seen_wish_id[wish_id]++) {
+            } else if (schema == "4" && seen_wish_id[wish_id]++) {
                 printf "ERROR: %s: item %d duplicate wish_id value '\''%s'\''\n", \
                     f, current_item, wish_id > "/dev/stderr"
                 errors++

--- a/dev-tools/check-expectations-checklist.sh
+++ b/dev-tools/check-expectations-checklist.sh
@@ -178,6 +178,30 @@ frontmatter_field_inventory() {
     ' "$file"
 }
 
+valid_gregorian_date() {
+    local value="$1"
+    local year month day max_day
+    if ! [[ "$value" =~ ^([0-9]{4})-([0-9]{2})-([0-9]{2})$ ]]; then
+        return 1
+    fi
+    year=$((10#${BASH_REMATCH[1]}))
+    month=$((10#${BASH_REMATCH[2]}))
+    day=$((10#${BASH_REMATCH[3]}))
+    [ "$year" -ge 1 ] || return 1
+    case "$month" in
+        1|3|5|7|8|10|12) max_day=31 ;;
+        4|6|9|11) max_day=30 ;;
+        2)
+            max_day=28
+            if (( year % 400 == 0 || (year % 4 == 0 && year % 100 != 0) )); then
+                max_day=29
+            fi
+            ;;
+        *) return 1 ;;
+    esac
+    [ "$day" -ge 1 ] && [ "$day" -le "$max_day" ]
+}
+
 days_between() {
     local from="$1" to="$2"
     local from_epoch to_epoch
@@ -606,6 +630,16 @@ validate_single_task() {
     fi
 
     local errors=0 val schema_v artifact_status frontmatter_field field_count
+    local first_line captured_at captured_by agent parent_init_task parent_prd
+
+    first_line=$(sed -n '1p' "$file")
+    if [ "$first_line" != "---" ]; then
+        echo "ERROR: $file: frontmatter opener must be the first line" >&2
+        errors=$(( errors + 1 ))
+    elif ! awk 'NR > 1 && $0 == "---" { found=1; exit } END { if (!found) exit 1 }' "$file"; then
+        echo "ERROR: $file: frontmatter missing closing delimiter" >&2
+        errors=$(( errors + 1 ))
+    fi
 
     while IFS='|' read -r frontmatter_field field_count; do
         [ -z "$frontmatter_field" ] && continue
@@ -661,6 +695,41 @@ validate_single_task() {
     val=$(extract_frontmatter_field "$file" "task_id")
     if [ -n "$val" ] && ! [[ "$val" =~ ^[A-Z]{2,10}-[0-9]{4}(-[A-Za-z0-9]+)*$ ]]; then
         echo "ERROR: $file: task_id '$val' does not match {PREFIX-NNNN} or {PREFIX-NNNN-suffix...}" >&2
+        errors=$(( errors + 1 ))
+    fi
+    if [ -n "$val" ] && [ "$val" != "$id" ]; then
+        echo "ERROR: $file: frontmatter task_id must equal requested task '$id', got '$val'" >&2
+        errors=$(( errors + 1 ))
+    fi
+
+    captured_at=$(extract_frontmatter_field "$file" "captured_at")
+    if [ -n "$captured_at" ] && ! valid_gregorian_date "$captured_at"; then
+        echo "ERROR: $file: captured_at must be a real Gregorian YYYY-MM-DD date, got '$captured_at'" >&2
+        errors=$(( errors + 1 ))
+    fi
+
+    captured_by=$(extract_frontmatter_field "$file" "captured_by")
+    if [ -n "$captured_by" ] && [ "$captured_by" != "/dr-init" ] \
+       && [ "$captured_by" != "/dr-prd" ] && [ "$captured_by" != "/dr-plan" ]; then
+        echo "ERROR: $file: captured_by must be /dr-init, /dr-prd, or /dr-plan, got '$captured_by'" >&2
+        errors=$(( errors + 1 ))
+    fi
+
+    agent=$(extract_frontmatter_field "$file" "agent")
+    if [ -n "$agent" ] && [ "$agent" != "architect" ] && [ "$agent" != "planner" ]; then
+        echo "ERROR: $file: agent must be architect or planner, got '$agent'" >&2
+        errors=$(( errors + 1 ))
+    fi
+
+    parent_init_task=$(extract_frontmatter_field "$file" "parent_init_task")
+    if [ -n "$parent_init_task" ] && [ "$parent_init_task" != "${id}-init-task.md" ]; then
+        echo "ERROR: $file: parent_init_task must equal ${id}-init-task.md, got '$parent_init_task'" >&2
+        errors=$(( errors + 1 ))
+    fi
+
+    parent_prd=$(extract_frontmatter_field "$file" "parent_prd")
+    if [ -n "$parent_prd" ] && [ "$parent_prd" != "../prd/PRD-${id}.md" ]; then
+        echo "ERROR: $file: parent_prd must equal ../prd/PRD-${id}.md, got '$parent_prd'" >&2
         errors=$(( errors + 1 ))
     fi
 

--- a/dev-tools/check-expectations-checklist.sh
+++ b/dev-tools/check-expectations-checklist.sh
@@ -57,11 +57,10 @@ Options:
   --version            Print version and exit 0.
 
 Schema v4 fields (current default; required per wish):
-  customer_binding_from: <wish_id> (required frontmatter cutover marker)
   customer_derived: true | false
-    Every wish from the cutover marker onward declares whether it came from a
-    customer requirement. true requires requirement_id, surface_class,
-    visitor_visible, and delivery_receipt; false forbids those four fields.
+    Every wish declares whether it came from a customer requirement. true
+    requires requirement_id, surface_class, visitor_visible, and
+    delivery_receipt; false forbids those four fields.
 
 Schema v3 fields (also supported by v4):
   verification_mode: one-off | reproducible
@@ -210,10 +209,7 @@ parse_items() {
     local file="$1"
     local schema="${2:-1}"
     local task_id="${3:-}"
-    local cutover="${4:-}"
-    local artifact_status="${5:-}"
-    awk -v f="$file" -v schema="$schema" -v task="$task_id" \
-        -v cutover="$cutover" -v artifact_status="$artifact_status" '
+    awk -v f="$file" -v schema="$schema" -v task="$task_id" '
         BEGIN {
             in_section = 0; current_item = 0; total_items = 0; errors = 0
             wish_id = ""; status = ""; override_text = ""; evidence_type = ""
@@ -224,8 +220,7 @@ parse_items() {
             customer_derived_count = 0
             requirement_id_count = 0; surface_class_count = 0
             visitor_visible_count = 0; delivery_receipt_count = 0
-            in_comment = 0; binding_started = 0; cutover_seen = 0
-            first_wish_id = ""
+            in_comment = 0
             history_count = 0; has_history_heading = 0; has_status_heading = 0
             in_history = 0; in_status = 0
         }
@@ -274,7 +269,6 @@ parse_items() {
                 if (match($0, /^  - wish_id:[ \t]*/)) {
                     wish_id = substr($0, RLENGTH + 1)
                     sub(/[ \t]+$/, "", wish_id)
-                    if (current_item == 1) first_wish_id = wish_id
                     in_history = 0; in_status = 0; next
                 }
                 if (match($0, /^  - evidence_type:[ \t]*/)) {
@@ -378,16 +372,6 @@ parse_items() {
                 printf "ERROR: %s: no items found under ## Ожидания (file appears empty)\n", f > "/dev/stderr"
                 errors++
             }
-            if (schema == "4" && cutover != "" && !cutover_seen) {
-                printf "ERROR: %s: customer_binding_from does not name a wish_id: %s\n", f, cutover > "/dev/stderr"
-                errors++
-            }
-            if (schema == "4" && artifact_status == "canonical" && first_wish_id != "" \
-                    && cutover != first_wish_id) {
-                printf "ERROR: %s: canonical schema v4 must start customer binding at its first wish: %s\n", \
-                    f, first_wish_id > "/dev/stderr"
-                errors++
-            }
             exit (errors > 0 ? 1 : 0)
         }
 
@@ -443,20 +427,8 @@ parse_items() {
                     errors++
                 }
             }
-            # v4 schema: every wish at or after the declared cutover explicitly
-            # declares customer derivation. Earlier wishes are preserved legacy.
-            if (schema == "4" && !binding_started && wish_id != cutover \
-                    && customer_derived_count + requirement_id_count + surface_class_count \
-                    + visitor_visible_count + delivery_receipt_count > 0) {
-                printf "ERROR: %s: item %d customer binding field appears before customer_binding_from\n", \
-                    f, current_item > "/dev/stderr"
-                errors++
-            }
-            if (schema == "4" && wish_id == cutover) {
-                binding_started = 1
-                cutover_seen = 1
-            }
-            if (schema == "4" && binding_started) {
+            # v4 schema: every wish explicitly declares customer derivation.
+            if (schema == "4") {
                 if (customer_derived_count == 0) {
                     printf "ERROR: %s: item %d missing customer_derived\n", f, current_item > "/dev/stderr"
                     errors++
@@ -581,8 +553,12 @@ validate_single_task() {
     fi
     customer_binding_from=$(extract_frontmatter_field "$file" "customer_binding_from")
     artifact_status=$(extract_frontmatter_field "$file" "status")
-    if [ "$schema_v" = "4" ] && [ -z "$customer_binding_from" ]; then
-        echo "ERROR: $file: frontmatter missing required field 'customer_binding_from' for schema_version=4" >&2
+    if [ -n "$artifact_status" ] && [ "$artifact_status" != "canonical" ] && [ "$artifact_status" != "amended" ]; then
+        echo "ERROR: $file: frontmatter status must be 'canonical' or 'amended', got '$artifact_status'" >&2
+        errors=$(( errors + 1 ))
+    fi
+    if [ "$schema_v" = "4" ] && [ -n "$customer_binding_from" ]; then
+        echo "ERROR: $file: customer_binding_from is obsolete in schema_version=4; every wish is governed" >&2
         errors=$(( errors + 1 ))
     fi
     # v1 legacy deprecation warning (TUNE-0266: 12-month sunset, see
@@ -605,7 +581,7 @@ validate_single_task() {
     # Item-level parse — emits to stdout (captured here for v3 post-parse) + stderr.
     # schema_v passed through to enable evidence_type/verification_mode checks.
     local items_out
-    items_out=$(parse_items "$file" "${schema_v:-1}" "$id" "$customer_binding_from" "$artifact_status" 2>/tmp/_cec_stderr_$$) || errors=$(( errors + 1 ))
+    items_out=$(parse_items "$file" "${schema_v:-1}" "$id" 2>/tmp/_cec_stderr_$$) || errors=$(( errors + 1 ))
     # Pipe parse stderr to our stderr so callers see it.
     cat /tmp/_cec_stderr_$$ >&2 2>/dev/null || true
     rm -f /tmp/_cec_stderr_$$
@@ -700,12 +676,10 @@ verify_routing() {
         return 1
     fi
 
-    local schema_v customer_binding_from artifact_status
+    local schema_v
     schema_v=$(extract_frontmatter_field "$file" "schema_version")
-    customer_binding_from=$(extract_frontmatter_field "$file" "customer_binding_from")
-    artifact_status=$(extract_frontmatter_field "$file" "status")
     local items
-    items=$(parse_items "$file" "${schema_v:-1}" "$id" "$customer_binding_from" "$artifact_status" 2>/dev/null) || true
+    items=$(parse_items "$file" "${schema_v:-1}" "$id" 2>/dev/null) || true
 
     local blocking=()
     local has_partial_or_missed=0

--- a/dev-tools/check-expectations-checklist.sh
+++ b/dev-tools/check-expectations-checklist.sh
@@ -237,14 +237,25 @@ parse_items() {
             customer_derived_count = 0
             requirement_id_count = 0; surface_class_count = 0
             visitor_visible_count = 0; delivery_receipt_count = 0
-            in_comment = 0
+            in_comment = 0; in_fence = 0; fence_char = ""; fence_len = 0
             history_count = 0; has_history_heading = 0; has_status_heading = 0
             in_history = 0; in_status = 0
         }
 
         {
+            if (in_fence) {
+                fence_line = fence_candidate($0)
+                if (is_fence_close(fence_line)) {
+                    in_fence = 0
+                    fence_char = ""
+                    fence_len = 0
+                }
+                next
+            }
             $0 = strip_html_comments($0)
             if ($0 ~ /^[ \t]*$/) next
+            fence_line = fence_candidate($0)
+            if (start_fence(fence_line)) next
         }
 
         /^## Ожидания[ \t]*$/ {
@@ -407,6 +418,37 @@ parse_items() {
                 }
                 line = prefix substr(tail, close_at + 3)
             }
+        }
+
+        function fence_candidate(line,    i) {
+            for (i = 0; i < 3 && substr(line, 1, 1) == " "; i++) {
+                line = substr(line, 2)
+            }
+            return line
+        }
+
+        function start_fence(line,    marker, run_len, suffix) {
+            marker = substr(line, 1, 1)
+            if (marker != "`" && marker != "~") return 0
+            run_len = 0
+            while (substr(line, run_len + 1, 1) == marker) run_len++
+            if (run_len < 3) return 0
+            suffix = substr(line, run_len + 1)
+            if (marker == "`" && index(suffix, "`") > 0) return 0
+            in_fence = 1
+            fence_char = marker
+            fence_len = run_len
+            return 1
+        }
+
+        function is_fence_close(line,    marker, run_len, suffix) {
+            marker = substr(line, 1, 1)
+            if (marker != fence_char) return 0
+            run_len = 0
+            while (substr(line, run_len + 1, 1) == marker) run_len++
+            if (run_len < fence_len) return 0
+            suffix = substr(line, run_len + 1)
+            return suffix ~ /^[ \t]*$/
         }
 
         function emit_item(    ovr_len) {

--- a/dev-tools/check-expectations-checklist.sh
+++ b/dev-tools/check-expectations-checklist.sh
@@ -437,6 +437,10 @@ parse_items() {
 
         END {
             if (current_item) emit_item()
+            if (code_span_len > 0) {
+                printf "ERROR: %s: unclosed inline code span\n", f > "/dev/stderr"
+                errors++
+            }
             if (total_items == 0) {
                 printf "ERROR: %s: no items found under ## Ожидания (file appears empty)\n", f > "/dev/stderr"
                 errors++
@@ -456,8 +460,8 @@ parse_items() {
             pos = 1
             if (code_span_len > 0) {
                 match_at = matching_backtick_run(line, pos, code_span_len)
-                if (match_at == 0) return "x"
-                out = "x"
+                if (match_at == 0) return "<>"
+                out = "<>"
                 pos = match_at + code_span_len
                 code_span_len = 0
             }
@@ -466,12 +470,12 @@ parse_items() {
                     run_len = backtick_run(line, pos)
                     match_at = matching_backtick_run(line, pos + run_len, run_len)
                     if (match_at > 0) {
-                        out = out "x"
+                        out = out "<>"
                         pos = match_at + run_len
                         continue
                     }
                     code_span_len = run_len
-                    return out "x"
+                    return out "<>"
                 }
                 if (substr(line, pos, 4) == "<!--" && !is_escaped(line, pos)) {
                     close_at = index(substr(line, pos + 4), "-->")

--- a/dev-tools/check-expectations-checklist.sh
+++ b/dev-tools/check-expectations-checklist.sh
@@ -289,24 +289,25 @@ parse_items() {
             if ($0 ~ /^[ \t]*$/) next
             fence_line = fence_candidate($0)
             if (start_fence(fence_line)) next
-        }
-
-        /^## Ожидания[ \t]*$/ {
-            expectations_heading_count++
-            if (expectations_heading_count > 1) {
+            if (is_expectations_heading(fence_line)) {
+                expectations_heading_count++
+                if (expectations_heading_count > 1) {
+                    if (current_item) emit_item()
+                    current_item = 0
+                    printf "ERROR: %s: duplicate active ## Ожидания heading\n", f > "/dev/stderr"
+                    errors++
+                }
+                in_section = 1
+                next
+            }
+            if (fence_line ~ /^##[ \t]+/ && in_section) {
                 if (current_item) emit_item()
                 current_item = 0
-                printf "ERROR: %s: duplicate active ## Ожидания heading\n", f > "/dev/stderr"
-                errors++
+                in_section = 0
+                in_history = 0
+                in_status = 0
+                next
             }
-            in_section = 1; next
-        }
-        /^## / && in_section {
-            if (current_item) emit_item()
-            current_item = 0
-            in_section = 0
-            in_history = 0; in_status = 0
-            next
         }
 
         in_section {
@@ -465,6 +466,10 @@ parse_items() {
                 line = substr(line, 2)
             }
             return line
+        }
+
+        function is_expectations_heading(line) {
+            return line ~ /^##[ \t]+Ожидания([ \t]+#+)?[ \t]*$/
         }
 
         function start_fence(line,    marker, run_len, suffix) {

--- a/dev-tools/check-expectations-checklist.sh
+++ b/dev-tools/check-expectations-checklist.sh
@@ -226,14 +226,8 @@ parse_items() {
         }
 
         {
-            if (in_comment) {
-                if ($0 ~ /-->/) in_comment = 0
-                next
-            }
-            if ($0 ~ /<!--/) {
-                if ($0 !~ /-->/) in_comment = 1
-                next
-            }
+            $0 = strip_html_comments($0)
+            if ($0 ~ /^[ \t]*$/) next
         }
 
         /^## Ожидания[ \t]*$/ {
@@ -373,6 +367,29 @@ parse_items() {
                 errors++
             }
             exit (errors > 0 ? 1 : 0)
+        }
+
+        function strip_html_comments(line,    open_at, close_at, prefix, tail) {
+            while (1) {
+                if (in_comment) {
+                    close_at = index(line, "-->")
+                    if (close_at == 0) return ""
+                    line = substr(line, close_at + 3)
+                    in_comment = 0
+                }
+
+                open_at = index(line, "<!--")
+                if (open_at == 0) return line
+
+                prefix = substr(line, 1, open_at - 1)
+                tail = substr(line, open_at + 4)
+                close_at = index(tail, "-->")
+                if (close_at == 0) {
+                    in_comment = 1
+                    return prefix
+                }
+                line = prefix substr(tail, close_at + 3)
+            }
         }
 
         function emit_item(    ovr_len) {

--- a/dev-tools/check-expectations-checklist.sh
+++ b/dev-tools/check-expectations-checklist.sh
@@ -286,6 +286,12 @@ parse_items() {
                 }
                 next
             }
+            if (code_span_len > 0 && is_inline_block_boundary($0)) {
+                printf "ERROR: %s: unclosed inline code span before block boundary\n", \
+                    f > "/dev/stderr"
+                errors++
+                code_span_len = 0
+            }
             # Block fences take precedence over inline parsing, unless the
             # line continues an already-open HTML comment or code span.
             fence_line = fence_candidate($0)
@@ -522,6 +528,16 @@ parse_items() {
                 pos--
             }
             return (slash_count % 2) == 1
+        }
+
+        function is_inline_block_boundary(line,    candidate) {
+            if (line ~ /^[ \t]*$/) return 1
+            if (line ~ /^[ \t]*[-+*][ \t]+/) return 1
+            if (line ~ /^[ \t]*[0-9]+[.)][ \t]+/) return 1
+            candidate = fence_candidate(line)
+            if (candidate ~ /^#{1,6}([ \t]|$)/) return 1
+            if (candidate ~ /^```/ || candidate ~ /^~~~/) return 1
+            return 0
         }
 
         function fence_candidate(line,    i) {

--- a/documentation/reference/skills.md
+++ b/documentation/reference/skills.md
@@ -36,7 +36,7 @@ Alphabetical. "Loaded by" names the commands, agents, or trigger conditions that
 | dream | Task | Knowledge base maintenance rules | librarian |
 | evolution | Task | Framework self-update rules | /dr-archive (Step 0.5 via reflecting skill), /dr-optimize |
 | executing-plans | Reference | Execute a written implementation plan in a separate session with review checkpoints | on demand, when a plan artefact exists |
-| expectations-checklist | Reference | Operator wishlist artefact (flat markdown) — `wish_id` slug, status-history and current-status blocks, override semantics. Schema v2 adds a mandatory `evidence_type: empirical \| static \| measurement` per wish; mandate scope covers all of L1-L4 | /dr-init Step 4.7 (skeleton, L1-L4); /dr-prd, /dr-plan (append-merge); /dr-qa, /dr-compliance (verify + per-wish block in the QA report) |
+| expectations-checklist | Reference | Operator wishlist artefact (flat markdown) — `wish_id` slug, status history, current status, and override semantics. Schema v4 requires explicit customer derivation on every wish and a delivery binding for customer-derived wishes; v1-v3 remain frozen legacy inputs | /dr-init Step 4.7 (skeleton, L1-L4); /dr-prd, /dr-plan (append-merge); /dr-qa, /dr-compliance (verify + per-wish block in the QA report) |
 | factcheck | Task | Fact verification for publications | editor, on demand |
 | file-sync-config | Reference | Pre-flight checklist + ignore patterns for file-sync (Syncthing/rclone) | on demand for sync setup |
 | finishing-a-development-branch | Reference | Decide how to integrate completed work — merge, PR, or cleanup — via structured options, once implementation is done and tests pass | on demand at end of branch work |

--- a/documentation/reference/skills.md
+++ b/documentation/reference/skills.md
@@ -1,10 +1,10 @@
 # Skills Reference
 
-Datarim includes 72 reusable skill modules. Skills provide rules, patterns, and guidelines loaded on demand by agents and commands. Each skill is a directory under `skills/` containing a `SKILL.md` plus any supporting fragment files.
+Datarim includes 73 reusable skill modules. Skills provide rules, patterns, and guidelines loaded on demand by agents and commands. Each skill is a directory under `skills/` containing a `SKILL.md` plus any supporting fragment files.
 
 Skills are split into two categories:
-- **Reference skills** — rules and patterns the caller applies inline. No `model` field in frontmatter, so they inherit the caller's model. 49 of the 68.
-- **Task skills** — perform an action when invoked. Carry an explicit `model` field per the [Model Assignment Convention](../../skills/datarim-system/SKILL.md). 19 of the 68.
+- **Reference skills** — rules and patterns the caller applies inline. No `model` field in frontmatter, so they inherit the caller's model. 53 of the 73.
+- **Task skills** — perform an action when invoked. Carry an explicit `model` field per the [Model Assignment Convention](../../skills/datarim-system/SKILL.md). 20 of the 73.
 
 Every shipped skill resolves to `inherit` — the operator's session model wins. Pinning a concrete model generation in a skill breaks under runtimes that do not offer it; express capability intent with `metadata.model_tier:` (resolved through `config/model-tiers.yaml`) instead.
 
@@ -24,6 +24,7 @@ Alphabetical. "Loaded by" names the commands, agents, or trigger conditions that
 | coworker-context | Reference | Conventions an external LLM (via coworker delegation) must follow when generating or editing Datarim artifacts — stage header, frontmatter, and so on | coworker `datarim` write profile, /dr-write, /dr-archive |
 | cron-agent-patterns | Reference | Layered timeout defense for cron-orchestrated agents making external calls (LLM CLI / HTTP / subprocess) — strictly-nested tiers, anti-patterns, symmetric deadline guards with explicit next-tier headroom | on demand for cron / timer agents with external API calls |
 | cta-format | Reference | Canonical CTA "Next Step" block format | planner, architect, developer, reviewer, compliance |
+| customer-delivery | Reference | Trace verbatim customer requirements through pre-work knowledge binding, implementation, production evidence, and disposition without treating enabling output as delivery | customer-facing work |
 | datarim-doctor | Reference | /dr-doctor schema and migration semantics (thin one-liner contract) | /dr-doctor, /dr-init self-heal, /dr-archive line-format gate |
 | datarim-system | Reference | Core workflow rules, path resolution, file locations | All commands (mandatory) |
 | edge-case-hunter | Reference | Enumerates boundary, degenerate, and failure inputs an artifact does not visibly handle | /dr-plan, /dr-qa |
@@ -87,7 +88,7 @@ Alphabetical. "Loaded by" names the commands, agents, or trigger conditions that
 | writing | Task | Content creation and editorial workflow | writer, editor |
 | writing-plans | Reference | Turn a spec or set of requirements for a multi-step task into a written plan, before touching code | on demand, before implementation |
 
-**Distribution:** 50 reference skills (no `model` field — inherit the caller), 19 task skills (explicit `model: inherit`).
+**Distribution:** 53 reference skills (no `model` field — inherit the caller), 20 task skills (explicit `model: inherit`).
 
 ## Loading Hierarchy
 

--- a/skills/customer-delivery/SKILL.md
+++ b/skills/customer-delivery/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: customer-delivery
-description: Enforce traceable delivery from a verbatim customer requirement through pre-work knowledge selection, implementation, production evidence, and customer disposition. Use for customer-facing work; enabling artifacts alone are outside its closure semantics.
+description: Enforce delivery from a verbatim requirement through pre-work knowledge selection, production evidence, and disposition; excludes enabling-only closure.
 ---
 
 # Customer Delivery

--- a/skills/customer-delivery/SKILL.md
+++ b/skills/customer-delivery/SKILL.md
@@ -1,0 +1,157 @@
+---
+name: customer-delivery
+description: Enforce traceable delivery from a verbatim customer requirement through pre-work knowledge selection, implementation, production evidence, and customer disposition. Use for customer-facing work; enabling artifacts alone are outside its closure semantics.
+---
+
+# Customer Delivery
+
+A user-facing requirement is delivered only when a verbatim customer statement
+flows through pinned knowledge, an implementation delta, red/green evidence, a
+merged revision, a deployed revision, live production evidence, and an explicit
+operator visual disposition — in that order, with no missing edge.
+
+Enabling artifacts — tools, documentation, tests, CI runs, ledger entries,
+receipts — support closure but never substitute for it.
+
+## U1. Verbatim atomic requirements
+
+- Store every customer remark verbatim; a paraphrase is metadata, never the
+  source of truth.
+- Decompose each remark into atomic, stable Requirement IDs.
+- Corrections are append-only: record the superseding statement and retain the
+  superseded one.
+
+**Fail** if a requirement cites a paraphrase, an aggregate summary, or an
+unstable ID as its origin.
+
+## U2. Acceptance tuple
+
+Every Requirement ID carries:
+
+- originating source and exact quotation;
+- affected product and surface or route (surface class);
+- locale, viewport, and theme dimensions when applicable;
+- observable before-state and required after-state;
+- evidence method and responsible owner;
+- applicable role, skill, blueprint, constraint, policy, and success criterion;
+- delivery task, code/content paths, and target environment;
+- customer disposition: pending, accepted, rejected, or superseded;
+- visibility classification: enabling or visitor-visible;
+- receipt pointer to its coverage receipt.
+
+At least one acceptance criterion must assert an observable visitor-facing
+change on the live production product. A rendered test-environment comparison
+is mandatory supporting evidence but cannot replace the live result.
+
+**Fail** if a user-facing requirement is satisfied only by knowledge,
+documentation, test, CI, or ledger output.
+
+## U3. Pre-work knowledge pinning
+
+- The applicable knowledge is selected before implementation starts. Before
+  `implementation_started_at`, the issued contract pins current
+  admissible revisions of the applicable role, skill, blueprint, constraint,
+  policy, and success criterion — each with an immutable revision, digest, and
+  timestamp.
+- `Gap` or `Unbound` may authorize research or capability creation but may
+  never be represented as blueprint-applied product delivery.
+- Selection after implementation start is post-hoc attribution and fails.
+
+**Fail** if any required knowledge kind is missing, `Gap`/`Unbound` stands in
+for a delivery-bound contract, or a revision is selected after work began.
+
+## U4. Coverage receipt
+
+Emit a machine-readable acyclic mapping per delivery:
+
+`Requirement -> selected knowledge revisions -> implementation delta ->
+red/green evidence -> merged revision -> deployed revision -> live evidence ->
+customer disposition`
+
+- A missing edge means `NOT MET`.
+- Receipts are deterministic and mutation tested: removal of any required edge
+  must turn the gate red.
+
+**Fail** on a cycle, a missing edge, a mutable revision reference, or a receipt
+that cannot fail when an edge is removed.
+
+## U5. Closure semantics
+
+A user-facing task or epic cannot close while:
+
+- any originating customer review is open or changes-requested;
+- any required live evidence is absent;
+- production is behind the accepted revision; or
+- operator visual acceptance is pending.
+
+Executable rules, not guidance:
+
+- `green CI != deployed`
+- `deployed != visually accepted`
+- `enabling work != customer outcome`
+
+Epic state is derived from the Requirement graph and child acceptance states,
+never from an independently authored prose status.
+
+**Fail** if a task closes on CI, merge, or internal review alone.
+
+## U6. Review-to-evolution
+
+Classify every review finding exactly one of:
+
+`ABSENT`, `WEAK`, `STALE`, `MIS_SCOPED`, `NOT_BOUND`, `NO_CANON_CHANGE`
+
+- The first five require an artifact revision or new artifact plus a
+  red-capable enforcement change.
+- `NO_CANON_CHANGE` requires evidence and reviewer approval.
+- Evolution never replaces the associated product fix.
+
+**Fail** on a classified finding with no enforcement change, an unapproved
+`NO_CANON_CHANGE`, or an evolution-only closure of the product requirement.
+
+## U7. Visible-output accounting
+
+Every user-facing epic reports two separately counted lists:
+
+- enabling changes;
+- visitor-visible changes.
+
+An epic with zero visitor-visible changes cannot satisfy a user-facing parent
+requirement. Narrow enabling tasks may close individually but contribute no
+completion weight to the visible outcome.
+
+**Fail** if an epic closes with an empty visitor-visible list, or enabling
+weight is counted as visible completion.
+
+## U8. Painted-surface visual acceptance
+
+Capture affected web page classes as painted surfaces across:
+
+- RU and EN;
+- mobile and desktop;
+- light and dark.
+
+Automated structural, WCAG, overflow, contrast, and mutation checks are
+required but cannot replace the operator's visual disposition when the source
+requirement is qualitative.
+
+**Fail** if a qualitative requirement closes on automated assertions alone,
+without an explicit operator disposition for every required surface cell.
+
+## Hard rules
+
+1. Tools, docs, tests, CI, and ledger output cannot satisfy user-facing
+   delivery.
+2. `Gap` and `Unbound` authorize research or capability creation only.
+3. Post-hoc knowledge attribution fails.
+4. Production must match the accepted merged revision.
+5. Operator-only approvals remain operator-only: prepare evidence and stop at
+   the hard gate.
+
+## Definition of met
+
+A user-facing deliverable is met when every originating requirement has a
+complete, mutation-tested coverage receipt; every required change is deployed
+and live; all originating reviews have evidence-backed dispositions; every
+painted-surface cell carries an explicit operator disposition; and the operator
+accepts the production result. Anything less is in progress.

--- a/skills/customer-delivery/SKILL.md
+++ b/skills/customer-delivery/SKILL.md
@@ -39,10 +39,10 @@ Every Requirement ID carries:
 - visibility classification: enabling or visitor-visible;
 - receipt pointer to its coverage receipt.
 
-Bind expectations through schema v4: set `customer_binding_from` to the first
-governed wish and declare `customer_derived` on that wish and every later one.
-A `true` declaration carries the Requirement ID, surface class, visibility,
-and receipt pointer; a `false` declaration carries none of those four fields.
+Bind expectations through schema v4 by declaring `customer_derived` on every
+wish. A `true` declaration carries the Requirement ID, surface class,
+visibility, and receipt pointer; a `false` declaration carries none of those
+four fields.
 
 At least one acceptance criterion must assert an observable visitor-facing
 change on the live production product. A rendered test-environment comparison

--- a/skills/customer-delivery/SKILL.md
+++ b/skills/customer-delivery/SKILL.md
@@ -39,6 +39,11 @@ Every Requirement ID carries:
 - visibility classification: enabling or visitor-visible;
 - receipt pointer to its coverage receipt.
 
+Bind expectations through schema v4: set `customer_binding_from` to the first
+governed wish and declare `customer_derived` on that wish and every later one.
+A `true` declaration carries the Requirement ID, surface class, visibility,
+and receipt pointer; a `false` declaration carries none of those four fields.
+
 At least one acceptance criterion must assert an observable visitor-facing
 change on the live production product. A rendered test-environment comparison
 is mandatory supporting evidence but cannot replace the live result.

--- a/skills/expectations-checklist/SKILL.md
+++ b/skills/expectations-checklist/SKILL.md
@@ -62,7 +62,6 @@ Required YAML frontmatter (closed schema):
 task_id: <TASK-ID>          # ^[A-Z]{2,10}-[0-9]{4}$ — required
 artifact: expectations      # literal — required
 schema_version: 4           # integer — required (current: 4; legacy: 1-3)
-customer_binding_from: <wish_id> # first wish governed by v4 customer binding
 captured_at: <YYYY-MM-DD>   # date of first write — required
 captured_by: /dr-init       # /dr-init | /dr-prd | /dr-plan — required
 status: canonical           # canonical | amended — required (flips on first append)
@@ -72,10 +71,10 @@ parent_prd: <path>          # relative path to PRD file when one exists
 ---
 ```
 
-**Schema v4 (current default):** requires `customer_binding_from` in
-frontmatter and exactly one `customer_derived: true | false` field on every
-wish from that marker onward. A new file sets the marker to its first
-`wish_id`. See § Customer-requirement binding.
+**Schema v4 (current default):** requires exactly one
+`customer_derived: true | false` field on every wish. The obsolete
+`customer_binding_from` marker is rejected because a movable prefix can exempt
+previously governed wishes. See § Customer-requirement binding.
 
 **Schema v3 (legacy, accepted):** adds optional per-wish `verification_mode` and
 `evidence_artifact` fields distinguishing a one-off manual check from a
@@ -94,13 +93,13 @@ invocation. Migration recipe: add `evidence_type: empirical` (or
 
 **Migration note — author new files at v4.** `/dr-prd` (and `/dr-plan` for the
 L2-no-PRD path) MUST create new expectations files at `schema_version: 4`.
-For the first append to a v1-v3 file, change the version to 4, set
-`customer_binding_from` to the first appended wish, and leave every older wish
-block untouched. The validator applies v4 binding only from that marker onward.
-Pre-cutover wishes MUST contain none of the v4 discriminator or binding fields;
-this makes moving the marker forward fail closed instead of silently exempting
-an already-governed wish.
-v1-v3 remain accepted without customer-binding fields; v1 keeps its
+v1-v3 remain accepted for read and verification without customer-binding
+fields, but MUST NOT receive new wishes. Before the first append, perform an
+explicit metadata-only migration: preserve every existing body, title, history,
+order, and `wish_id`; add `evidence_type` where v1 lacks it; add
+`customer_derived` to every wish and the conditional binding quartet to each
+`true` wish; then bump to schema v4, set `status: amended`, and record the
+migration in the append-log. Only then append the new wish. v1 keeps its
 **2027-05-23** sunset and deprecation warning.
 
 ## Body shape
@@ -116,7 +115,7 @@ v1-v3 remain accepted without customer-binding fields; v1 keeps its
   - Как проверить (success criterion): <one concrete signal — file path,
     command output, visible behaviour>
   - Связанный AC из PRD: V-AC-<N> или «—»
-  - customer_derived: <true | false>  # v4 — required at/after cutover
+  - customer_derived: <true | false>  # v4 — required on every wish
   - requirement_id: <req-NNNN>
   - surface_class: <VISITOR_VISIBLE | ENABLING>
   - visitor_visible: <true | false>
@@ -139,8 +138,7 @@ _(empty on first write)_
 
 ### Customer-requirement binding
 
-Every schema-v4 wish at or after `customer_binding_from` MUST carry exactly one
-discriminator:
+Every schema-v4 wish MUST carry exactly one discriminator:
 
 ```yaml
   - customer_derived: <true | false>
@@ -172,11 +170,10 @@ For a visitor-visible wish, the success criterion MUST assert observable live
 production behaviour. Documentation, knowledge, tests, CI, ledgers, and other
 enabling outputs may support the evidence but cannot satisfy the wish.
 
-Legacy expectations files at v1-v3 remain valid without these fields. On the
-first append, use the v4 cutover migration above; do not rewrite or renumber old
-wish blocks solely to add customer-delivery metadata. The marker is monotonic in
-the current artifact: it cannot move past any wish that already carries v4
-customer-binding metadata.
+Legacy expectations files at v1-v3 remain valid without these fields for read
+and verification. They are frozen against new wishes until the full metadata
+migration above is complete; the migration preserves the content and identity
+of old wish blocks while adding v4 metadata to every one.
 
 ### `override` indent — concrete syntax
 

--- a/skills/expectations-checklist/SKILL.md
+++ b/skills/expectations-checklist/SKILL.md
@@ -97,6 +97,9 @@ L2-no-PRD path) MUST create new expectations files at `schema_version: 4`.
 For the first append to a v1-v3 file, change the version to 4, set
 `customer_binding_from` to the first appended wish, and leave every older wish
 block untouched. The validator applies v4 binding only from that marker onward.
+Pre-cutover wishes MUST contain none of the v4 discriminator or binding fields;
+this makes moving the marker forward fail closed instead of silently exempting
+an already-governed wish.
 v1-v3 remain accepted without customer-binding fields; v1 keeps its
 **2027-05-23** sunset and deprecation warning.
 
@@ -171,7 +174,9 @@ enabling outputs may support the evidence but cannot satisfy the wish.
 
 Legacy expectations files at v1-v3 remain valid without these fields. On the
 first append, use the v4 cutover migration above; do not rewrite or renumber old
-wish blocks solely to add customer-delivery metadata.
+wish blocks solely to add customer-delivery metadata. The marker is monotonic in
+the current artifact: it cannot move past any wish that already carries v4
+customer-binding metadata.
 
 ### `override` indent — concrete syntax
 

--- a/skills/expectations-checklist/SKILL.md
+++ b/skills/expectations-checklist/SKILL.md
@@ -61,7 +61,8 @@ Required YAML frontmatter (closed schema):
 ---
 task_id: <TASK-ID>          # ^[A-Z]{2,10}-[0-9]{4}$ — required
 artifact: expectations      # literal — required
-schema_version: 2           # integer — required (current: 2; legacy: 1, sunset 2027-05-23)
+schema_version: 4           # integer — required (current: 4; legacy: 1-3)
+customer_binding_from: <wish_id> # first wish governed by v4 customer binding
 captured_at: <YYYY-MM-DD>   # date of first write — required
 captured_by: /dr-init       # /dr-init | /dr-prd | /dr-plan — required
 status: canonical           # canonical | amended — required (flips on first append)
@@ -71,12 +72,17 @@ parent_prd: <path>          # relative path to PRD file when one exists
 ---
 ```
 
-**Schema v3 (opt-in):** adds optional per-wish `verification_mode` and
+**Schema v4 (current default):** requires `customer_binding_from` in
+frontmatter and exactly one `customer_derived: true | false` field on every
+wish from that marker onward. A new file sets the marker to its first
+`wish_id`. See § Customer-requirement binding.
+
+**Schema v3 (legacy, accepted):** adds optional per-wish `verification_mode` and
 `evidence_artifact` fields distinguishing a one-off manual check from a
 reproducible/wired check. See § `verification_mode` axis. Only active when the
-file declares `schema_version: 3`; all sub-v3 files are UNCHANGED.
+file declares `schema_version: 3` or `4`; all sub-v3 files are unchanged.
 
-**Schema v2 (current default):** adds required `evidence_type` field per wish item
+**Schema v2 (legacy, accepted):** adds required `evidence_type` field per wish item
 (enum: `empirical | static | measurement`). Validator
 (`"${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-expectations-checklist.sh"`) rejects items without
 `evidence_type` in v2 mode.
@@ -86,12 +92,13 @@ from the v1→v2 migration archive). Deprecation warning emitted on every valida
 invocation. Migration recipe: add `evidence_type: empirical` (or
 `static`/`measurement`) to each wish; bump `schema_version: 2`.
 
-**Migration note — author new files at v2.** `/dr-prd` (and `/dr-plan` for the
-L2-no-PRD path) MUST create new expectations files at `schema_version: 2`
-directly — never author a v1 file and migrate it afterwards. v1 is deprecated
-(sunset **2027-05-23**) and emits a per-invocation deprecation warning, so
-starting at v2 avoids a needless migration and a noisy validator. Schema v3
-stays opt-in per the note above; the default first-write target is v2.
+**Migration note — author new files at v4.** `/dr-prd` (and `/dr-plan` for the
+L2-no-PRD path) MUST create new expectations files at `schema_version: 4`.
+For the first append to a v1-v3 file, change the version to 4, set
+`customer_binding_from` to the first appended wish, and leave every older wish
+block untouched. The validator applies v4 binding only from that marker onward.
+v1-v3 remain accepted without customer-binding fields; v1 keeps its
+**2027-05-23** sunset and deprecation warning.
 
 ## Body shape
 
@@ -106,11 +113,12 @@ stays opt-in per the note above; the default first-write target is v2.
   - Как проверить (success criterion): <one concrete signal — file path,
     command output, visible behaviour>
   - Связанный AC из PRD: V-AC-<N> или «—»
+  - customer_derived: <true | false>  # v4 — required at/after cutover
   - requirement_id: <req-NNNN>
   - surface_class: <VISITOR_VISIBLE | ENABLING>
   - visitor_visible: <true | false>
   - delivery_receipt: <datarim/receipts/{TASK-ID}-customer-delivery.yaml>
-  - evidence_type: <empirical | static | measurement>  # v2 — required
+  - evidence_type: <empirical | static | measurement>  # v2+ — required
   - override: <optional reason text, only used when status flips to
     partial/missed and the deferral is genuinely legitimate>
   - override_by: <agent | operator>            # who authored the override
@@ -128,7 +136,15 @@ _(empty on first write)_
 
 ### Customer-requirement binding
 
-Every new wish derived from a customer remark MUST carry these four fields:
+Every schema-v4 wish at or after `customer_binding_from` MUST carry exactly one
+discriminator:
+
+```yaml
+  - customer_derived: <true | false>
+```
+
+When `customer_derived: true`, the wish MUST carry exactly one of each binding
+field:
 
 ```yaml
   - requirement_id: <req-NNNN>
@@ -145,14 +161,17 @@ eventually prove the complete delivery chain. A pointer may identify its
 planned canonical path before the receipt exists, but an absent or incomplete
 receipt can never satisfy closure.
 
+When `customer_derived: false`, all four binding fields MUST be absent. A later
+canonical requirements cross-check may reject a false classification; this
+local schema gate only makes the declaration explicit and non-ambiguous.
+
 For a visitor-visible wish, the success criterion MUST assert observable live
 production behaviour. Documentation, knowledge, tests, CI, ledgers, and other
 enabling outputs may support the evidence but cannot satisfy the wish.
 
-Legacy expectations files remain valid without these fields. Do not rewrite
-or renumber existing wish blocks solely to add customer-delivery metadata;
-apply the binding to new customer-derived wishes and preserve the existing
-append-merge contract.
+Legacy expectations files at v1-v3 remain valid without these fields. On the
+first append, use the v4 cutover migration above; do not rewrite or renumber old
+wish blocks solely to add customer-delivery metadata.
 
 ### `override` indent — concrete syntax
 
@@ -225,7 +244,7 @@ Incorrect (4-space, silently ignored by the validator):
   three `·` separators and the literal `reason:` token are required.
 - **`#### Текущий статус`** carries the current enum value. Allowed values: <!-- allow-non-ascii: russian-current-status-section-name-from-canonical-schema -->
   `pending`, `met`, `partial`, `missed`, `n-a`, `deleted`.
-- **`evidence_type`** (schema v2, required) declares what kind of evidence
+- **`evidence_type`** (schema v2+, required) declares what kind of evidence
   `/dr-qa` must produce for this wish at Layer 3b. Allowed enum:
   - **`empirical`** — runtime check: command invocation, smoke test, E2E
     test, integration probe. Per-wish QA report MUST contain actual
@@ -239,7 +258,7 @@ Incorrect (4-space, silently ignored by the validator):
     contain the measured value + comparison to expected (`X = 87ms <
     budget 100ms`).
 
-- **`verification_mode`** (schema v3, optional per-wish) closes the
+- **`verification_mode`** (schema v3+, optional per-wish) closes the
   "manual-check ≠ coded verification" error class (the motivating incident:
   an oral requirement closed by a one-off `curl` spot-check, never coded →
   regression later). Allowed enum:
@@ -257,7 +276,7 @@ Incorrect (4-space, silently ignored by the validator):
     `evidence_artifact:` (see below); the validator exits 1 on the
     `verification-not-wired` error if it is missing.
 
-- **`evidence_artifact`** (schema v3, required when `verification_mode:
+- **`evidence_artifact`** (schema v3+, required when `verification_mode:
   reproducible`) names the concrete check: a relative file path, an
   absolute path, a test-id string, or a CI-job name. Resolution is
   deterministic and repo-root anchored (two-tier):
@@ -280,7 +299,7 @@ Incorrect (4-space, silently ignored by the validator):
   the stub. Operator must verify stub coverage during `/dr-qa` review.
 <!-- /gate:example-only -->
 
-  **Heuristic advisory (sub-v3 and v3, NEVER hard):** for schema v3
+  **Heuristic advisory (sub-v3 and v3+, NEVER hard):** for schema v3 or v4
   wishes where `verification_mode` is ABSENT and `evidence_type:
   empirical`, the validator runs a narrow deterministic case-insensitive
   regex over the "Как проверить (success criterion)" text for world-state <!-- allow-non-ascii: russian-expectations-field-name-cited-verbatim-as-validator-regex-target -->

--- a/skills/expectations-checklist/SKILL.md
+++ b/skills/expectations-checklist/SKILL.md
@@ -198,8 +198,9 @@ Incorrect (4-space, silently ignored by the validator):
 
 ### Item rules
 
-- **`wish_id`** is a kebab-slug derived from the title. Cyrillic letters,
-  ASCII letters, digits, and hyphens are allowed. Used as the focus key in
+- **`wish_id`** occurs exactly once per item and is unique across the file. It
+  is a kebab-slug derived from the title: non-empty segments of Cyrillic
+  letters, ASCII letters, or digits, separated by single hyphens. Used as the focus key in
   FAIL-Routing CTA (`/dr-do <ID> --focus-items <wish_id_1,...,N>`).
 - **`Связанный AC из PRD`** is advisory for L1-L2. For L3-L4 current, <!-- allow-non-ascii: canonical-russian-expectations-field-name -->
   non-overridden wishes it is required when spec-graph hard mode is active:

--- a/skills/expectations-checklist/SKILL.md
+++ b/skills/expectations-checklist/SKILL.md
@@ -202,6 +202,8 @@ Incorrect (4-space, silently ignored by the validator):
   is a kebab-slug derived from the title: non-empty segments of Cyrillic
   letters, ASCII letters, or digits, separated by single hyphens. Used as the focus key in
   FAIL-Routing CTA (`/dr-do <ID> --focus-items <wish_id_1,...,N>`).
+- Inline code spans use exact matching backtick-run delimiters. An unmatched
+  delimiter fails structural validation instead of suppressing later wishes.
 - **`Связанный AC из PRD`** is advisory for L1-L2. For L3-L4 current, <!-- allow-non-ascii: canonical-russian-expectations-field-name -->
   non-overridden wishes it is required when spec-graph hard mode is active:
   the value MUST be `V-AC-N`, not «—». Deleted, superseded, or operator-overridden

--- a/skills/expectations-checklist/SKILL.md
+++ b/skills/expectations-checklist/SKILL.md
@@ -106,6 +106,10 @@ stays opt-in per the note above; the default first-write target is v2.
   - Как проверить (success criterion): <one concrete signal — file path,
     command output, visible behaviour>
   - Связанный AC из PRD: V-AC-<N> или «—»
+  - requirement_id: <req-NNNN>
+  - surface_class: <VISITOR_VISIBLE | ENABLING>
+  - visitor_visible: <true | false>
+  - delivery_receipt: <datarim/receipts/{TASK-ID}-customer-delivery.yaml>
   - evidence_type: <empirical | static | measurement>  # v2 — required
   - override: <optional reason text, only used when status flips to
     partial/missed and the deferral is genuinely legitimate>
@@ -121,6 +125,34 @@ stays opt-in per the note above; the default first-write target is v2.
 
 _(empty on first write)_
 ```
+
+### Customer-requirement binding
+
+Every new wish derived from a customer remark MUST carry these four fields:
+
+```yaml
+  - requirement_id: <req-NNNN>
+  - surface_class: <VISITOR_VISIBLE | ENABLING>
+  - visitor_visible: <true | false>
+  - delivery_receipt: <datarim/receipts/{TASK-ID}-customer-delivery.yaml>
+```
+
+`requirement_id` is the stable foreign key into the customer-requirement
+artifact; it is not interchangeable with `wish_id`. `surface_class` and
+`visitor_visible` MUST agree: `VISITOR_VISIBLE` requires `true`, and `ENABLING`
+requires `false`. `delivery_receipt` names the deterministic receipt that must
+eventually prove the complete delivery chain. A pointer may identify its
+planned canonical path before the receipt exists, but an absent or incomplete
+receipt can never satisfy closure.
+
+For a visitor-visible wish, the success criterion MUST assert observable live
+production behaviour. Documentation, knowledge, tests, CI, ledgers, and other
+enabling outputs may support the evidence but cannot satisfy the wish.
+
+Legacy expectations files remain valid without these fields. Do not rewrite
+or renumber existing wish blocks solely to add customer-delivery metadata;
+apply the binding to new customer-derived wishes and preserve the existing
+append-merge contract.
 
 ### `override` indent — concrete syntax
 

--- a/templates/expectations-template.md
+++ b/templates/expectations-template.md
@@ -2,7 +2,6 @@
 task_id: {TASK-ID}
 artifact: expectations
 schema_version: 4
-customer_binding_from: {kebab-slug-of-first-wish}
 captured_at: {YYYY-MM-DD}
 captured_by: {/dr-init | /dr-prd | /dr-plan}
 status: canonical

--- a/templates/expectations-template.md
+++ b/templates/expectations-template.md
@@ -34,6 +34,10 @@ parent_prd: ../prd/PRD-{TASK-ID}.md
   - Как проверить (success criterion): {конкретный сигнал — путь к файлу,
     вывод команды, видимое поведение}
   - Связанный AC из PRD: {V-AC-N или «—»}
+  - requirement_id: {req-NNNN}
+  - surface_class: {VISITOR_VISIBLE | ENABLING}
+  - visitor_visible: {true | false}
+  - delivery_receipt: {datarim/receipts/{TASK-ID}-customer-delivery.yaml}
   - evidence_type: {empirical | static | measurement}
   - #### История статусов
     - {ISO 8601} / {local-time} · {/dr-init | /dr-prd | /dr-plan} · pending → pending · reason: пункт создан при формировании контракта ожиданий
@@ -45,6 +49,10 @@ parent_prd: ../prd/PRD-{TASK-ID}.md
   - Что хочу проверить: {…}
   - Как проверить (success criterion): {…}
   - Связанный AC из PRD: {V-AC-N или «—»}
+  - requirement_id: {req-NNNN}
+  - surface_class: {VISITOR_VISIBLE | ENABLING}
+  - visitor_visible: {true | false}
+  - delivery_receipt: {datarim/receipts/{TASK-ID}-customer-delivery.yaml}
   - evidence_type: {empirical | static | measurement}
   - #### История статусов
     - {ISO 8601} / {local-time} · {/dr-init | /dr-prd | /dr-plan} · pending → pending · reason: пункт создан при формировании контракта ожиданий

--- a/templates/expectations-template.md
+++ b/templates/expectations-template.md
@@ -1,7 +1,8 @@
 ---
 task_id: {TASK-ID}
 artifact: expectations
-schema_version: 2
+schema_version: 4
+customer_binding_from: {kebab-slug-of-first-wish}
 captured_at: {YYYY-MM-DD}
 captured_by: {/dr-init | /dr-prd | /dr-plan}
 status: canonical
@@ -34,6 +35,7 @@ parent_prd: ../prd/PRD-{TASK-ID}.md
   - Как проверить (success criterion): {конкретный сигнал — путь к файлу,
     вывод команды, видимое поведение}
   - Связанный AC из PRD: {V-AC-N или «—»}
+  - customer_derived: true
   - requirement_id: {req-NNNN}
   - surface_class: {VISITOR_VISIBLE | ENABLING}
   - visitor_visible: {true | false}
@@ -49,6 +51,7 @@ parent_prd: ../prd/PRD-{TASK-ID}.md
   - Что хочу проверить: {…}
   - Как проверить (success criterion): {…}
   - Связанный AC из PRD: {V-AC-N или «—»}
+  - customer_derived: true
   - requirement_id: {req-NNNN}
   - surface_class: {VISITOR_VISIBLE | ENABLING}
   - visitor_visible: {true | false}
@@ -63,9 +66,9 @@ parent_prd: ../prd/PRD-{TASK-ID}.md
      валидатор проверяет наличие wish_id, формат строки История статусов и
      значение Текущий статус. -->
 
-<!-- OPTIONAL: verification_mode axis (schema v3 only).
+<!-- OPTIONAL: verification_mode axis (schema v3 and v4).
      Distinguishes a one-off manual check from a reproducible/wired check.
-     To opt in: bump schema_version to 3 in frontmatter, then add:
+     Available in schema v3 and inherited by the v4 default. Add:
 
   - verification_mode: reproducible          # one-off | reproducible
   - evidence_artifact: tests/my-suite.bats   # path, test-id, or CI-job-name

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -23,7 +23,8 @@ template_has_exact_binding_bullets() {
 
     item_count="$(grep -cE '^- \*\*[0-9]+\. ' "$file")"
     [ "$item_count" -gt 0 ] || return 1
-    for field in customer_requirement requirement_id surface_class visitor_visible delivery_receipt; do
+    [ "$(grep -cE '^customer_binding_from:' "$file")" -eq 1 ] || return 1
+    for field in customer_derived requirement_id surface_class visitor_visible delivery_receipt; do
         [ "$(grep -cE "^  - ${field}:" "$file")" -eq "$item_count" ] || return 1
     done
 }
@@ -44,6 +45,7 @@ write_expectations() {
 task_id: $id
 artifact: expectations
 schema_version: $schema
+$(if [ "$schema" -eq 4 ]; then printf '%s\n' 'customer_binding_from: customer-outcome'; fi)
 captured_at: 2026-08-24
 captured_by: /dr-prd
 status: canonical
@@ -71,7 +73,7 @@ EOF
 valid_customer_binding() {
     local id="$1"
     cat <<EOF
-  - customer_requirement: customer-derived
+  - customer_derived: true
   - requirement_id: req-0001
   - surface_class: VISITOR_VISIBLE
   - visitor_visible: true
@@ -160,7 +162,7 @@ EOF
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 1 ] \
-        && [[ "$output" == *"missing customer_requirement"* ]] \
+        && [[ "$output" == *"missing customer_derived"* ]] \
         && [[ "$output" != *"schema_version must"* ]]
 }
 
@@ -182,7 +184,7 @@ EOF
     local id
     local binding
     local root
-    for field in customer_requirement requirement_id surface_class visitor_visible delivery_receipt; do
+    for field in customer_derived requirement_id surface_class visitor_visible delivery_receipt; do
         id="BIND-0004"
         binding="$(valid_customer_binding "$id" | sed -E "/^  - ${field}:/d")"
         root="$(write_expectations "$id" 4 "$binding")"
@@ -195,23 +197,23 @@ EOF
     done
 }
 
-@test "schema v4 not-applicable wish requires a reason and passes without binding fields" {
+@test "schema v4 non-customer wish passes without customer binding fields" {
     local id="BIND-0005"
     local root
-    root="$(write_expectations "$id" 4 $'  - customer_requirement: not-applicable\n  - customer_requirement_reason: Internal framework-only wish')"
+    root="$(write_expectations "$id" 4 '  - customer_derived: false')"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 0 ]
 }
 
-@test "schema v4 not-applicable wish without a reason fails closed" {
+@test "schema v4 wish without customer discriminator fails closed" {
     local id="BIND-0006"
     local root
-    root="$(write_expectations "$id" 4 '  - customer_requirement: not-applicable')"
+    root="$(write_expectations "$id" 4)"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 1 ] \
-        && [[ "$output" == *"missing customer_requirement_reason"* ]]
+        && [[ "$output" == *"missing customer_derived"* ]]
 }
 
 @test "schema v4 rejects inconsistent visitor visibility" {
@@ -224,6 +226,103 @@ EOF
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 1 ] \
         && [[ "$output" == *"surface_class and visitor_visible disagree"* ]]
+}
+
+@test "schema v4 legacy cutover preserves old wishes and governs appended wishes" {
+    local id="BIND-0008"
+    local root="${BATS_TEST_TMPDIR}/${id}"
+    local file="${root}/datarim/tasks/${id}-expectations.md"
+    mkdir -p "$(dirname "$file")"
+    cat > "$file" <<EOF
+---
+task_id: $id
+artifact: expectations
+schema_version: 4
+customer_binding_from: appended-customer-wish
+captured_at: 2026-05-14
+captured_by: /dr-prd
+status: amended
+---
+
+## Ожидания
+
+- **1. Preserved legacy wish.**
+  - wish_id: preserved-legacy-wish
+  - evidence_type: static
+  - #### История статусов
+    - 2026-05-14T00:00:00Z / 2026-05-14 00:00 (UTC) · pending → pending · /dr-prd · reason: item created
+  - #### Текущий статус
+    - pending
+
+- **2. Appended customer wish.**
+  - wish_id: appended-customer-wish
+$(valid_customer_binding "$id")
+  - evidence_type: static
+  - #### История статусов
+    - 2026-08-24T00:00:00Z / 2026-08-24 00:00 (UTC) · pending → pending · /dr-prd · reason: item appended
+  - #### Текущий статус
+    - pending
+EOF
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 0 ]
+}
+
+@test "schema v4 rejects a cutover marker that names no wish" {
+    local id="BIND-0009"
+    local root
+    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+    sed -i 's/customer_binding_from: customer-outcome/customer_binding_from: missing-wish/' \
+        "$root/datarim/tasks/${id}-expectations.md"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"customer_binding_from does not name a wish_id"* ]]
+}
+
+@test "schema v4 rejects duplicate customer binding fields" {
+    local id="BIND-0010"
+    local binding
+    local root
+    binding="$(valid_customer_binding "$id")"$'\n  - requirement_id: req-0002'
+    root="$(write_expectations "$id" 4 "$binding")"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"duplicate requirement_id"* ]]
+}
+
+@test "schema v4 rejects invalid ID boolean and receipt values" {
+    local id="BIND-0011"
+    local field
+    local replacement
+    local expected
+    local binding
+    local root
+    while IFS='|' read -r field replacement expected; do
+        binding="$(valid_customer_binding "$id" | sed -E "s@^(  - ${field}:).*@\\1 ${replacement}@")"
+        root="$(write_expectations "$id" 4 "$binding")"
+        run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"${expected}"* ]]; then
+            echo "invalid-value mutant survived for ${field}: ${output}" >&2
+            return 1
+        fi
+        rm -rf "$root"
+    done <<EOF
+requirement_id|REQ-1|requirement_id must match req-NNNN
+visitor_visible|yes|visitor_visible must be boolean true|false
+delivery_receipt|other.yaml|delivery_receipt must be datarim/receipts/${id}-customer-delivery.yaml
+EOF
+}
+
+@test "schema v4 ignores binding fields inside multiline HTML comments" {
+    local id="BIND-0012"
+    local root
+    root="$(write_expectations "$id" 4 $'  - customer_derived: true\n<!--\n  - requirement_id: req-0001\n  - surface_class: VISITOR_VISIBLE\n  - visitor_visible: true\n  - delivery_receipt: datarim/receipts/BIND-0012-customer-delivery.yaml\n-->')"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"missing requirement_id"* ]]
 }
 
 @test "legacy schema versions v1 through v3 remain valid without customer binding" {
@@ -243,7 +342,8 @@ EOF
 
 @test "expectations contract makes customer binding mandatory without invalidating legacy files" {
     assert_contains "$EXPECTATIONS_SKILL" 'schema_version: 4'
-    assert_contains "$EXPECTATIONS_SKILL" 'customer_requirement'
+    assert_contains "$EXPECTATIONS_SKILL" 'customer_binding_from'
+    assert_contains "$EXPECTATIONS_SKILL" 'customer_derived'
     assert_contains "$EXPECTATIONS_SKILL" 'requirement_id'
     assert_contains "$EXPECTATIONS_SKILL" 'surface_class'
     assert_contains "$EXPECTATIONS_SKILL" 'visitor_visible'

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -41,6 +41,8 @@ assert_no_direct_in_place_sed() {
                          count, i, expect_command, sed_command, wrapper,
                          skip_wrapper_arg, skip_redirection_arg, in_backtick,
                          pending_outer_quote, backtick_outer_quote, resume_quote,
+                         outer_expect_command, outer_sed_command, outer_wrapper,
+                         outer_skip_wrapper_arg, outer_skip_redirection_arg,
                          values, kinds) {
             line_len = length(line)
             pos = 1
@@ -62,7 +64,7 @@ assert_no_direct_in_place_sed() {
                         resume_quote = backtick_outer_quote
                         backtick_outer_quote = ""
                     } else {
-                        kinds[count] = "separator"
+                        kinds[count] = "substitution_open"
                         in_backtick = 1
                         backtick_outer_quote = pending_outer_quote
                     }
@@ -118,12 +120,25 @@ assert_no_direct_in_place_sed() {
             skip_wrapper_arg = 0
             skip_redirection_arg = 0
             for (i = 1; i <= count; i++) {
-                if (kinds[i] == "substitution_close") {
-                    expect_command = 0
+                if (kinds[i] == "substitution_open") {
+                    outer_expect_command = expect_command
+                    outer_sed_command = sed_command
+                    outer_wrapper = wrapper
+                    outer_skip_wrapper_arg = skip_wrapper_arg
+                    outer_skip_redirection_arg = skip_redirection_arg
+                    expect_command = 1
                     sed_command = 0
                     wrapper = ""
                     skip_wrapper_arg = 0
                     skip_redirection_arg = 0
+                    continue
+                }
+                if (kinds[i] == "substitution_close") {
+                    expect_command = outer_expect_command
+                    sed_command = outer_sed_command
+                    wrapper = outer_wrapper
+                    skip_wrapper_arg = outer_skip_wrapper_arg
+                    skip_redirection_arg = outer_skip_redirection_arg
                     continue
                 }
                 if (kinds[i] == "separator") {
@@ -1681,6 +1696,9 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     printf 'ignored=\140sed --in-place -e "s/x/y/" mutant\140\n' >> "$mutant_suite"
     printf 'quoted="\140sed -i.bak s/x/y/ mutant\140"\n' >> "$mutant_suite"
     printf 'sequential="before \140printf ok\140 middle \140sed -i.bak s/x/y/ mutant\140 after"\n' >> "$mutant_suite"
+    printf '\140true\140 sed -i.bak s/x/y/ mutant\n' >> "$mutant_suite"
+    printf 'MODE=\140true\140 sed -i.bak s/x/y/ mutant\n' >> "$mutant_suite"
+    printf '\140true\140sed -i.bak s/x/y/ mutant\n' >> "$mutant_suite"
     run assert_no_direct_in_place_sed "$mutant_suite"
     if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
         echo "legacy backtick sed mutants were not rejected (status=${status}): ${output}" >&2
@@ -1706,6 +1724,7 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     printf 'escaped=\134\140sed --in-place -e s/x/y/ mutant\134\140\n' >> "$mutant_suite"
     printf 'message="before \140printf ok\140 sed -i.bak is literal prose"\n' >> "$mutant_suite"
     printf 'escaped_message="before \134\140sed -i.bak\134\140 after"\n' >> "$mutant_suite"
+    printf 'echo \140true\140 sed -i.bak is literal prose\n' >> "$mutant_suite"
     run assert_no_direct_in_place_sed "$mutant_suite"
     if [ "$status" -ne 0 ]; then
         echo "inert sed prose was treated as executable (status=${status}): ${output}" >&2

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -673,6 +673,48 @@ EOF
         && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
 }
 
+@test "inline code cannot become a valid wish_id placeholder" {
+    local id="COMM-0004"
+    local root
+    local file
+    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i 's/wish_id: customer-outcome/wish_id: `not a kebab slug`/' "$file"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] && [[ "$output" == *"wish_id must be a kebab slug"* ]] || return 1
+
+    run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
+}
+
+@test "an unclosed code delimiter cannot hide a later schema v4 wish" {
+    local id="COMM-0005"
+    local root
+    local file
+    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    cat >> "$file" <<'EOF'
+
+` unmatched inline delimiter
+- **2. Hidden unbound wish.**
+  - wish_id: hidden-unbound-wish
+  - evidence_type: static
+  - #### История статусов
+    - 2026-08-24T00:00:00Z / 2026-08-24 00:00 (UTC) · pending → pending · /dr-prd · reason: item created
+  - #### Текущий статус
+    - pending
+EOF
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] && [[ "$output" == *"unclosed inline code span"* ]] || return 1
+
+    run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
+}
+
 @test "schema validation rejects duplicate frontmatter keys in task and verify modes" {
     local id
     local root

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -569,11 +569,117 @@ EOF
     root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
     file="$root/datarim/tasks/${id}-expectations.md"
     sed -i '/^status: canonical$/a agent: planner\
-parent_init_task: datarim/tasks/ALWD-0001-init-task.md\
-parent_prd: datarim/prd/PRD-ALWD-0001.md' "$file"
+parent_init_task: ALWD-0001-init-task.md\
+parent_prd: ../prd/PRD-ALWD-0001.md' "$file"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 0 ]
+}
+
+@test "frontmatter envelope rejects a preamble and missing closing delimiter in both modes" {
+    local variant
+    local id
+    local root
+    local file
+    local expected
+    for variant in preamble missing_close; do
+        id="ENVE-0001"
+        root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+        file="$root/datarim/tasks/${id}-expectations.md"
+        case "$variant" in
+            preamble)
+                sed -i '1i arbitrary preamble' "$file"
+                expected="frontmatter opener must be the first line"
+                ;;
+            missing_close)
+                sed -i '8d' "$file"
+                expected="frontmatter missing closing delimiter"
+                ;;
+        esac
+
+        run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"${expected}"* ]]; then
+            echo "${variant} envelope passed task validation: ${output}" >&2
+            return 1
+        fi
+
+        run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"BLOCKED: expectations file fails structural validation"* ]]; then
+            echo "${variant} envelope passed verify validation: ${output}" >&2
+            return 1
+        fi
+        rm -rf "$root"
+    done
+}
+
+@test "frontmatter identity and value domains fail closed in both modes" {
+    local id="DOMN-0001"
+    local field
+    local replacement
+    local expected
+    local root
+    local file
+    while IFS='|' read -r field replacement expected; do
+        root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+        file="$root/datarim/tasks/${id}-expectations.md"
+        sed -i "s@^${field}:.*@${field}: ${replacement}@" "$file"
+
+        run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"${expected}"* ]]; then
+            echo "invalid ${field} domain passed task validation: ${output}" >&2
+            return 1
+        fi
+
+        run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"BLOCKED: expectations file fails structural validation"* ]]; then
+            echo "invalid ${field} domain passed verify validation: ${output}" >&2
+            return 1
+        fi
+        rm -rf "$root"
+    done <<EOF
+task_id|OTHR-0001|frontmatter task_id must equal requested task 'DOMN-0001'
+captured_at|2025-02-29|captured_at must be a real Gregorian YYYY-MM-DD date
+captured_at|2026-04-31|captured_at must be a real Gregorian YYYY-MM-DD date
+captured_by|/dr-do|captured_by must be /dr-init, /dr-prd, or /dr-plan
+EOF
+
+    for field in agent parent_init_task parent_prd; do
+        root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+        file="$root/datarim/tasks/${id}-expectations.md"
+        case "$field" in
+            agent) replacement="reviewer"; expected="agent must be architect or planner" ;;
+            parent_init_task) replacement="../tasks/OTHR-0001-init-task.md"; expected="parent_init_task must equal DOMN-0001-init-task.md" ;;
+            parent_prd) replacement="../../other/PRD-OTHR-0001.md"; expected="parent_prd must equal ../prd/PRD-DOMN-0001.md" ;;
+        esac
+        sed -i "/^status: canonical$/a ${field}: ${replacement}" "$file"
+
+        run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"${expected}"* ]]; then
+            echo "invalid ${field} domain passed task validation: ${output}" >&2
+            return 1
+        fi
+
+        run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+        [ "$status" -eq 1 ] || return 1
+        rm -rf "$root"
+    done
+}
+
+@test "frontmatter accepts a Gregorian leap day and task-bound canonical parents" {
+    local id="LEAP-0001"
+    local root
+    local file
+    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i 's/^captured_at:.*/captured_at: 2024-02-29/' "$file"
+    sed -i '/^status: canonical$/a agent: architect\
+parent_init_task: LEAP-0001-init-task.md\
+parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 0 ] || return 1
+    run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+    [ "$status" -eq 0 ] && [[ "$output" == *"PASS"* ]]
 }
 
 @test "active expectations heading with a trailing HTML comment passes both modes" {

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -288,7 +288,9 @@ EOF
 @test "schema v4 amended file rejects moving cutover forward past a bound wish" {
     local id="BIND-0017"
     local root
-    root="$(write_cutover_expectations "$id" appended-internal-wish)"
+    root="$(write_cutover_expectations "$id")"
+    sed -i 's/customer_binding_from: appended-customer-wish/customer_binding_from: appended-internal-wish/' \
+        "$root/datarim/tasks/${id}-expectations.md"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 1 ] \
@@ -298,7 +300,9 @@ EOF
 @test "verify mode blocks a schema v4 cutover moved past a bound wish" {
     local id="BIND-0019"
     local root
-    root="$(write_cutover_expectations "$id" appended-internal-wish)"
+    root="$(write_cutover_expectations "$id")"
+    sed -i 's/customer_binding_from: appended-customer-wish/customer_binding_from: appended-internal-wish/' \
+        "$root/datarim/tasks/${id}-expectations.md"
 
     run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
     [ "$status" -eq 1 ] \

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -18,6 +18,10 @@ portable_sed_in_place() {
     [ "$last_index" -gt 0 ] || return 2
     unset 'args[$last_index]'
     temp_file="$(mktemp "${file}.sed.XXXXXX")" || return 1
+    if ! cp -p "$file" "$temp_file"; then
+        rm -f "$temp_file"
+        return 1
+    fi
     if ! sed "${args[@]}" "$file" > "$temp_file"; then
         rm -f "$temp_file"
         return 1
@@ -1421,6 +1425,28 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     [[ "$documented_count" -eq "$disk_count" ]]
 }
 
+@test "portable sed helper preserves bytes mode and sibling cleanliness" {
+    local fixture_dir="${BATS_TEST_TMPDIR}/portable-editor"
+    local fixture="${fixture_dir}/sample.txt"
+    local mode
+
+    mkdir -p "$fixture_dir"
+    printf 'alpha\n' > "$fixture"
+    chmod 640 "$fixture"
+
+    portable_sed_in_place 's/alpha/beta/' "$fixture"
+
+    [ "$(cat "$fixture")" = "beta" ] || return 1
+    [ "$(wc -c < "$fixture" | tr -d '[:space:]')" -eq 5 ] || return 1
+    if stat -c '%a' "$fixture" >/dev/null 2>&1; then
+        mode="$(stat -c '%a' "$fixture")"
+    else
+        mode="$(stat -f '%Lp' "$fixture")"
+    fi
+    [ "$mode" = "640" ] || return 1
+    [ "$(find "$fixture_dir" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d '[:space:]')" -eq 1 ]
+}
+
 @test "focused customer binding tests are BSD-portable and run in macOS CI" {
     local focused_suite="${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats"
     local workflow="${REPO_ROOT}/.github/workflows/bats.yml"
@@ -1574,16 +1600,17 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
 
     cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
     portable_sed_in_place "/^[[:space:]]*if ! sed /i\\
-    local editor=${command_token}
+    local editor
+    editor=\"\$(portable_editor_word)\"
 " "$mutant_suite"
     portable_sed_in_place \
         "s/if ! sed /if ! \"\\\$editor\" ${short_option} /" \
         "$mutant_suite"
-    run assert_no_direct_in_place_sed "$mutant_suite"
-    if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
-        echo "two-line real-helper editor alias passed (status=${status}): ${output}" >&2
-        return 1
-    fi
+    run bats --filter \
+        'portable sed helper preserves bytes mode and sibling cleanliness' \
+        "$mutant_suite"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"not ok 1 portable sed helper preserves bytes mode and sibling cleanliness"* ]]
 }
 
 @test "portability anti-decay rejects in-place option variants and commented macOS wiring" {

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -32,6 +32,81 @@ assert_contains() {
     grep -Fq -- "$literal" "$file"
 }
 
+assert_no_direct_in_place_sed() {
+    local file="$1"
+    local violations
+
+    if ! violations="$(awk '
+        {
+            line = $0
+            if (!match(line, /(^|[;&|()[:space:]])([^[:space:]]*\/)?sed[[:space:]]+/)) {
+                next
+            }
+            args = substr(line, RSTART + RLENGTH)
+            count = split(args, tokens, /[[:space:]]+/)
+            for (i = 1; i <= count; i++) {
+                token = tokens[i]
+                if (token ~ /^--in-place(=.*)?$/ || token ~ /^-[A-Za-z]*i/) {
+                    print FNR ":" $0
+                    next
+                }
+            }
+        }
+    ' "$file")"; then
+        echo "failed to inspect focused suite for direct in-place sed syntax" >&2
+        return 1
+    fi
+
+    if [ -n "$violations" ]; then
+        echo "focused suite contains direct in-place sed syntax:" >&2
+        echo "$violations" >&2
+        return 1
+    fi
+}
+
+workflow_run_block_has_suite() {
+    local workflow="$1"
+    local suite="$2"
+
+    awk -v suite="$suite" '
+        /^      - name: Run portability-sensitive suites[[:space:]]*$/ {
+            in_step = 1
+            next
+        }
+        in_step && /^      - name:/ {
+            exit
+        }
+        in_step && /^        run:[[:space:]]*\|[[:space:]]*$/ {
+            in_run = 1
+            next
+        }
+        in_run {
+            text = $0
+            sub(/^[[:space:]]+/, "", text)
+            if (text ~ /^#/) {
+                next
+            }
+            if (text ~ /^bats[[:space:]]*\\[[:space:]]*$/) {
+                in_bats = 1
+                next
+            }
+            if (in_bats) {
+                continued = text ~ /\\[[:space:]]*$/
+                sub(/[[:space:]]*\\[[:space:]]*$/, "", text)
+                if (text == suite) {
+                    found = 1
+                }
+                if (!continued) {
+                    in_bats = 0
+                }
+            }
+        }
+        END {
+            exit(found ? 0 : 1)
+        }
+    ' "$workflow"
+}
+
 template_has_exact_binding_bullets() {
     local file="$1"
     local item_count
@@ -1274,9 +1349,39 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     local focused_suite="${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats"
     local workflow="${REPO_ROOT}/.github/workflows/bats.yml"
 
-    if grep -Eq 'sed (-E )?-i([^A-Za-z]|$)' "$focused_suite"; then
-        echo "focused suite contains GNU-only sed in-place syntax" >&2
-        return 1
-    fi
-    grep -Fq 'tests/customer-requirement-expectations-binding.bats' "$workflow"
+    assert_no_direct_in_place_sed "$focused_suite" || return 1
+    workflow_run_block_has_suite \
+        "$workflow" \
+        'tests/customer-requirement-expectations-binding.bats'
+}
+
+@test "portability anti-decay rejects in-place option variants and commented macOS wiring" {
+    local mutant_suite="${BATS_TEST_TMPDIR}/customer-binding-mutant.bats"
+    local mutant_workflow="${BATS_TEST_TMPDIR}/bats-mutant.yml"
+    local direct_command
+
+    cp "${REPO_ROOT}/.github/workflows/bats.yml" "$mutant_workflow"
+    portable_sed_in_place '/^[[:space:]]*tests\/customer-requirement-expectations-binding\.bats/c\
+            # tests/customer-requirement-expectations-binding.bats' "$mutant_workflow"
+
+    for direct_command in \
+        "sed --in-place -E 's/x/y/' mutant" \
+        "sed --in-place=.bak 's/x/y/' mutant" \
+        "sed -Ei 's/x/y/' mutant" \
+        "sed -iE 's/x/y/' mutant" \
+        "sed -i.bak 's/x/y/' mutant" \
+        "sed -i'' 's/x/y/' mutant"; do
+        cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
+        printf '%s\n' "$direct_command" >> "$mutant_suite"
+        run assert_no_direct_in_place_sed "$mutant_suite"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
+            echo "in-place sed mutant was not rejected (${direct_command}; status=${status}): ${output}" >&2
+            return 1
+        fi
+    done
+
+    run workflow_run_block_has_suite \
+        "$mutant_workflow" \
+        'tests/customer-requirement-expectations-binding.bats'
+    [ "$status" -eq 1 ]
 }

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -657,6 +657,28 @@ EOF
     }
 }
 
+@test "multiline inline-code fields cannot satisfy schema bindings" {
+    local id="COMM-0009"
+    local root
+    local file
+    root="$(write_expectations "$id" 4 '  - customer_derived: true')"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i '/success criterion/c\
+  - Как проверить (success criterion): These ``fields are examples:\
+  - requirement_id: req-0001\
+  - surface_class: VISITOR_VISIBLE\
+  - visitor_visible: true\
+  - delivery_receipt: datarim/receipts/COMM-0009-customer-delivery.yaml\
+`` and are not active bindings.' "$file"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] && [[ "$output" == *"missing requirement_id"* ]] || return 1
+
+    run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
+}
+
 @test "an escaped backtick does not neutralize a real HTML comment" {
     local id="COMM-0003"
     local root
@@ -687,6 +709,54 @@ EOF
     run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
     [ "$status" -eq 1 ] \
         && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
+}
+
+@test "inline code cannot self-resolve a nonexistent evidence artifact" {
+    local id="COMM-0006"
+    local root
+    local file
+    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i '/evidence_type: static/i\
+  - verification_mode: reproducible\
+  - evidence_artifact: `not-real`' "$file"
+    printf '%s\n' 'structured-value collision `not-real`' > "$root/sentinel.sh"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] && [[ "$output" == *"verification-not-wired"* ]] || return 1
+
+    run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
+}
+
+@test "inline code remains visible in override length" {
+    local id="COMM-0007"
+    local root
+    local file
+    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i '/evidence_type: static/i\
+  - override: See `FOLLOW-1234`\
+  - override_by: operator' "$file"
+    sed -i '/^    - pending$/s/pending/partial/' "$file"
+
+    run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+    [ "$status" -eq 0 ] && [[ "$output" == *"CONDITIONAL_PASS"* ]]
+}
+
+@test "inline code remains visible to the world-state advisory" {
+    local id="COMM-0008"
+    local root
+    local file
+    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i 's/A deterministic signal passes./The `https:\/\/prod.example.test\/status` endpoint passes./' "$file"
+    sed -i 's/evidence_type: static/evidence_type: empirical/' "$file"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 0 ] \
+        && [[ "$output" == *"verification-mode-suggested-reproducible"* ]]
 }
 
 @test "an unclosed code delimiter cannot hide a later schema v4 wish" {

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -32,11 +32,16 @@ assert_contains() {
     grep -Fq -- "$literal" "$file"
 }
 
+portable_editor_word() {
+    printf '%s%s' s ed
+}
+
 assert_no_direct_in_place_sed() {
     local file="$1"
-    local sed_word="s""ed"
+    local sed_word
     local long_option="--in""-place"
     local violations
+    sed_word="$(portable_editor_word)"
 
     # Deliberately lexical and fail-closed: this controlled suite may not carry
     # the command token followed by a GNU-only in-place option on one logical
@@ -49,6 +54,21 @@ assert_no_direct_in_place_sed() {
             gsub(/^[!$<>;|&(){}]+/, "", token)
             gsub(/[;|&(){}]+$/, "", token)
             return token
+        }
+        function is_sed_assignment(token, value) {
+            value = token
+            gsub(/["\047`]/, "", value)
+            gsub(/\\/, "", value)
+            if (value !~ /^[A-Za-z_][A-Za-z0-9_]*=/) {
+                return 0
+            }
+            sub(/^[A-Za-z_][A-Za-z0-9_]*=/, "", value)
+            if (value ~ /^[$][(]/) {
+                return 0
+            }
+            gsub(/^[!$<>;|&(){}]+/, "", value)
+            gsub(/[;|&(){}]+$/, "", value)
+            return value == sed_word || value ~ ("/" sed_word "$")
         }
         function is_sed_token(token, value) {
             value = canonical_token(token)
@@ -63,6 +83,10 @@ assert_no_direct_in_place_sed() {
             count = split(line, fields, /[[:space:]]+/)
             saw_sed = 0
             for (i = 1; i <= count; i++) {
+                if (is_sed_assignment(fields[i])) {
+                    print line_number ":" line
+                    return
+                }
                 if (!saw_sed && is_sed_token(fields[i])) {
                     saw_sed = 1
                     continue
@@ -1409,8 +1433,9 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
 
 @test "portability source convention rejects forbidden tokens even in inert prose" {
     local mutant_suite="${BATS_TEST_TMPDIR}/customer-binding-lexical-prose.bats"
-    local command_token="s""ed"
+    local command_token
     local short_option="-""i.bak"
+    command_token="$(portable_editor_word)"
 
     cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
     printf '# inert prose: %s %s must still be rejected\n' \
@@ -1423,10 +1448,11 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
 
 @test "portability source convention is independent of substitution shell state" {
     local mutant_suite="${BATS_TEST_TMPDIR}/customer-binding-lexical-state.bats"
-    local command_token="s""ed"
+    local command_token
     local short_option="-""i.bak"
     local tick
     local payload
+    command_token="$(portable_editor_word)"
     tick="$(printf '\140')"
 
     for payload in \
@@ -1446,11 +1472,13 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
 
 @test "portability source convention recognizes modern substitution prefixes" {
     local mutant_suite="${BATS_TEST_TMPDIR}/customer-binding-modern-substitution.bats"
-    local command_token="s""ed"
-    local path_token="/usr/bin/${command_token}"
+    local command_token
+    local path_token
     local short_option="-""i.bak"
     local dollar_sign='$'
     local payload
+    command_token="$(portable_editor_word)"
+    path_token="/usr/bin/${command_token}"
 
     for payload in \
         "${dollar_sign}(${command_token} ${short_option} 's/x/y/' mutant)" \
@@ -1470,8 +1498,9 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
 
 @test "portability source convention concatenates shell continuations byte-exactly" {
     local mutant_suite="${BATS_TEST_TMPDIR}/customer-binding-continuation.bats"
-    local command_token="s""ed"
+    local command_token
     local short_option="-""i.bak"
+    command_token="$(portable_editor_word)"
 
     cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
     printf '%s\\\n%s %s '\''s/x/y/'\'' mutant\n' \
@@ -1494,11 +1523,12 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
 
 @test "portability source convention canonicalizes ANSI-C and escaped command tokens" {
     local mutant_suite="${BATS_TEST_TMPDIR}/customer-binding-escaped-token.bats"
-    local command_token="s""ed"
+    local command_token
     local short_option="-""i.bak"
     local dollar_sign='$'
     local escape
     local payload
+    command_token="$(portable_editor_word)"
     escape="$(printf '\134')"
 
     for payload in \
@@ -1517,15 +1547,55 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     done
 }
 
+@test "portability source convention rejects literal editor aliases" {
+    local mutant_suite="${BATS_TEST_TMPDIR}/customer-binding-editor-alias.bats"
+    local command_head="s"
+    local command_tail="ed"
+    local command_token="${command_head}${command_tail}"
+    local short_option="-""i.bak"
+    local escape
+    local assignment
+    escape="$(printf '\134')"
+
+    for assignment in \
+        "local editor=${command_token}" \
+        "editor=\"${command_token}\"" \
+        "editor='/usr/bin/${command_token}'" \
+        "editor=s${escape}ed"; do
+        cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
+        printf '%s\n' "$assignment" >> "$mutant_suite"
+
+        run assert_no_direct_in_place_sed "$mutant_suite"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
+            echo "literal editor alias passed (status=${status}; assignment=${assignment}): ${output}" >&2
+            return 1
+        fi
+    done
+
+    cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
+    portable_sed_in_place "/^[[:space:]]*if ! sed /i\\
+    local editor=${command_token}
+" "$mutant_suite"
+    portable_sed_in_place \
+        "s/if ! sed /if ! \"\\\$editor\" ${short_option} /" \
+        "$mutant_suite"
+    run assert_no_direct_in_place_sed "$mutant_suite"
+    if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
+        echo "two-line real-helper editor alias passed (status=${status}): ${output}" >&2
+        return 1
+    fi
+}
+
 @test "portability anti-decay rejects in-place option variants and commented macOS wiring" {
     local mutant_suite="${BATS_TEST_TMPDIR}/customer-binding-mutant.bats"
     local mutant_workflow="${BATS_TEST_TMPDIR}/bats-mutant.yml"
-    local command_token="s""ed"
+    local command_token
     local short_option="-""i.bak"
     local combined_option="-E""i"
     local long_option="--in""-place"
     local tick
     local payload
+    command_token="$(portable_editor_word)"
     tick="$(printf '\140')"
 
     cp "${REPO_ROOT}/.github/workflows/bats.yml" "$mutant_workflow"

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -82,19 +82,19 @@ EOF
 }
 
 @test "customer delivery skill is a valid history-agnostic skill entrypoint" {
-    [[ -f "$DELIVERY_SKILL" ]]
-    assert_contains "$DELIVERY_SKILL" 'name: customer-delivery'
-    assert_contains "$DELIVERY_SKILL" 'description:'
+    [[ -f "$DELIVERY_SKILL" ]] || return 1
+    assert_contains "$DELIVERY_SKILL" 'name: customer-delivery' || return 1
+    assert_contains "$DELIVERY_SKILL" 'description:' || return 1
     description="$(sed -n 's/^description: //p' "$DELIVERY_SKILL")"
-    [[ "${#description}" -le 155 ]]
-    [[ "$(grep -cE '^## U[1-8]\.' "$DELIVERY_SKILL")" -eq 8 ]]
-    ! grep -Eq '[A-Z]{2,10}-[0-9]{4}' "$DELIVERY_SKILL"
+    [[ "${#description}" -le 155 ]] || return 1
+    [[ "$(grep -cE '^## U[1-8]\.' "$DELIVERY_SKILL")" -eq 8 ]] || return 1
+    if grep -Eq '[A-Z]{2,10}-[0-9]{4}' "$DELIVERY_SKILL"; then return 1; fi
 }
 
 @test "customer delivery skill preserves verbatim remarks under atomic stable requirement IDs" {
-    assert_contains "$DELIVERY_SKILL" 'verbatim'
-    assert_contains "$DELIVERY_SKILL" 'atomic'
-    assert_contains "$DELIVERY_SKILL" 'stable Requirement ID'
+    assert_contains "$DELIVERY_SKILL" 'verbatim' || return 1
+    assert_contains "$DELIVERY_SKILL" 'atomic' || return 1
+    assert_contains "$DELIVERY_SKILL" 'stable Requirement ID' || return 1
     assert_contains "$DELIVERY_SKILL" 'paraphrase'
 }
 
@@ -104,7 +104,7 @@ EOF
         'role' 'skill' 'blueprint' 'constraint' 'policy' 'success criterion' \
         'selected before implementation starts' 'post-hoc attribution' \
         'Gap' 'Unbound'; do
-        assert_contains "$DELIVERY_SKILL" "$literal"
+        assert_contains "$DELIVERY_SKILL" "$literal" || return 1
     done
 }
 
@@ -115,20 +115,20 @@ EOF
         'green CI != deployed' 'deployed != visually accepted' \
         'enabling work != customer outcome' 'derived from the Requirement graph' \
         'ABSENT' 'WEAK' 'STALE' 'MIS_SCOPED' 'NOT_BOUND' 'NO_CANON_CHANGE'; do
-        assert_contains "$DELIVERY_SKILL" "$literal"
+        assert_contains "$DELIVERY_SKILL" "$literal" || return 1
     done
 }
 
 @test "customer delivery skill separates enabling and visitor-visible output" {
-    assert_contains "$DELIVERY_SKILL" 'enabling changes'
-    assert_contains "$DELIVERY_SKILL" 'visitor-visible changes'
-    assert_contains "$DELIVERY_SKILL" 'zero visitor-visible changes'
+    assert_contains "$DELIVERY_SKILL" 'enabling changes' || return 1
+    assert_contains "$DELIVERY_SKILL" 'visitor-visible changes' || return 1
+    assert_contains "$DELIVERY_SKILL" 'zero visitor-visible changes' || return 1
     assert_contains "$DELIVERY_SKILL" 'cannot satisfy'
 }
 
 @test "customer delivery skill requires the complete painted visual matrix" {
     for literal in 'RU' 'EN' 'mobile' 'desktop' 'light' 'dark' 'operator'; do
-        assert_contains "$DELIVERY_SKILL" "$literal"
+        assert_contains "$DELIVERY_SKILL" "$literal" || return 1
     done
     assert_contains "$DELIVERY_SKILL" 'cannot replace'
 }
@@ -228,7 +228,7 @@ EOF
         && [[ "$output" == *"surface_class and visitor_visible disagree"* ]]
 }
 
-@test "schema v4 legacy cutover preserves old wishes and governs appended wishes" {
+@test "schema v4 legacy cutover preserves old wishes and governs mixed appended wishes" {
     local id="BIND-0008"
     local root="${BATS_TEST_TMPDIR}/${id}"
     local file="${root}/datarim/tasks/${id}-expectations.md"
@@ -262,6 +262,15 @@ $(valid_customer_binding "$id")
     - 2026-08-24T00:00:00Z / 2026-08-24 00:00 (UTC) · pending → pending · /dr-prd · reason: item appended
   - #### Текущий статус
     - pending
+
+- **3. Appended non-customer wish.**
+  - wish_id: appended-internal-wish
+  - customer_derived: false
+  - evidence_type: static
+  - #### История статусов
+    - 2026-08-24T00:00:00Z / 2026-08-24 00:00 (UTC) · pending → pending · /dr-prd · reason: item appended
+  - #### Текущий статус
+    - pending
 EOF
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
@@ -280,6 +289,47 @@ EOF
         && [[ "$output" == *"customer_binding_from does not name a wish_id"* ]]
 }
 
+@test "schema v4 canonical file requires cutover at the first wish" {
+    local id="BIND-0015"
+    local root="${BATS_TEST_TMPDIR}/${id}"
+    local file="${root}/datarim/tasks/${id}-expectations.md"
+    mkdir -p "$(dirname "$file")"
+    cat > "$file" <<EOF
+---
+task_id: $id
+artifact: expectations
+schema_version: 4
+customer_binding_from: second-wish
+captured_at: 2026-08-24
+captured_by: /dr-prd
+status: canonical
+---
+
+## Ожидания
+
+- **1. First wish.**
+  - wish_id: first-wish
+  - evidence_type: static
+  - #### История статусов
+    - 2026-08-24T00:00:00Z / 2026-08-24 00:00 (UTC) · pending → pending · /dr-prd · reason: item created
+  - #### Текущий статус
+    - pending
+
+- **2. Second wish.**
+  - wish_id: second-wish
+$(valid_customer_binding "$id")
+  - evidence_type: static
+  - #### История статусов
+    - 2026-08-24T00:00:00Z / 2026-08-24 00:00 (UTC) · pending → pending · /dr-prd · reason: item created
+  - #### Текущий статус
+    - pending
+EOF
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"canonical schema v4 must start customer binding at its first wish"* ]]
+}
+
 @test "schema v4 rejects duplicate customer binding fields" {
     local id="BIND-0010"
     local binding
@@ -290,6 +340,16 @@ EOF
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 1 ] \
         && [[ "$output" == *"duplicate requirement_id"* ]]
+}
+
+@test "schema v4 customer_derived false forbids customer binding fields" {
+    local id="BIND-0013"
+    local root
+    root="$(write_expectations "$id" 4 $'  - customer_derived: false\n  - requirement_id: req-0001')"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"customer_derived=false must omit customer binding fields"* ]]
 }
 
 @test "schema v4 rejects invalid ID boolean and receipt values" {
@@ -309,7 +369,9 @@ EOF
         fi
         rm -rf "$root"
     done <<EOF
+customer_derived|maybe|customer_derived must be boolean true|false
 requirement_id|REQ-1|requirement_id must match req-NNNN
+surface_class|INTERNAL|surface_class not in enum
 visitor_visible|yes|visitor_visible must be boolean true|false
 delivery_receipt|other.yaml|delivery_receipt must be datarim/receipts/${id}-customer-delivery.yaml
 EOF
@@ -323,6 +385,28 @@ EOF
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 1 ] \
         && [[ "$output" == *"missing requirement_id"* ]]
+}
+
+@test "schema v4 ignores an item header inside an HTML comment" {
+    local id="BIND-0014"
+    local root
+    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+    sed -E -i 's/^(- \*\*1\. Customer outcome\.\*\*)$/<!-- \1 -->/' \
+        "$root/datarim/tasks/${id}-expectations.md"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"no items found"* ]]
+}
+
+@test "verify mode blocks a structurally invalid schema v4 artifact" {
+    local id="BIND-0016"
+    local root
+    root="$(write_expectations "$id" 4)"
+
+    run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
 }
 
 @test "legacy schema versions v1 through v3 remain valid without customer binding" {
@@ -341,19 +425,19 @@ EOF
 }
 
 @test "expectations contract makes customer binding mandatory without invalidating legacy files" {
-    assert_contains "$EXPECTATIONS_SKILL" 'schema_version: 4'
-    assert_contains "$EXPECTATIONS_SKILL" 'customer_binding_from'
-    assert_contains "$EXPECTATIONS_SKILL" 'customer_derived'
-    assert_contains "$EXPECTATIONS_SKILL" 'requirement_id'
-    assert_contains "$EXPECTATIONS_SKILL" 'surface_class'
-    assert_contains "$EXPECTATIONS_SKILL" 'visitor_visible'
-    assert_contains "$EXPECTATIONS_SKILL" 'delivery_receipt'
-    assert_contains "$EXPECTATIONS_SKILL" 'Legacy expectations files'
+    assert_contains "$EXPECTATIONS_SKILL" 'schema_version: 4' || return 1
+    assert_contains "$EXPECTATIONS_SKILL" 'customer_binding_from' || return 1
+    assert_contains "$EXPECTATIONS_SKILL" 'customer_derived' || return 1
+    assert_contains "$EXPECTATIONS_SKILL" 'requirement_id' || return 1
+    assert_contains "$EXPECTATIONS_SKILL" 'surface_class' || return 1
+    assert_contains "$EXPECTATIONS_SKILL" 'visitor_visible' || return 1
+    assert_contains "$EXPECTATIONS_SKILL" 'delivery_receipt' || return 1
+    assert_contains "$EXPECTATIONS_SKILL" 'Legacy expectations files' || return 1
     assert_contains "$EXPECTATIONS_SKILL" 'remain valid without these fields'
 }
 
 @test "customer delivery skill is registered in the canonical skills inventory" {
-    assert_contains "$SKILLS_REFERENCE" '| customer-delivery | Reference |'
+    assert_contains "$SKILLS_REFERENCE" '| customer-delivery | Reference |' || return 1
 
     disk_count="$(find "${REPO_ROOT}/skills" -mindepth 2 -maxdepth 2 -name SKILL.md | wc -l | tr -d '[:space:]')"
     documented_count="$(sed -nE 's/^Datarim includes ([0-9]+) reusable skill modules\..*/\1/p' "$SKILLS_REFERENCE")"

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -562,6 +562,42 @@ EOF
         && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
 }
 
+@test "closed expectations schema rejects noncanonical YAML constructs in both modes" {
+    local id="YAML-0001"
+    local construct
+    local root
+    local file
+    while IFS= read -r construct; do
+        root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+        file="$root/datarim/tasks/${id}-expectations.md"
+        if [ "$construct" = "__NESTED__" ]; then
+            sed -i '/^status: canonical$/a\
+  nested: must-not-pass' "$file"
+        else
+            sed -i "/^status: canonical$/a ${construct}" "$file"
+        fi
+
+        run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"invalid frontmatter line"* ]]; then
+            echo "noncanonical YAML passed task validation (${construct}): ${output}" >&2
+            return 1
+        fi
+
+        run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"BLOCKED: expectations file fails structural validation"* ]]; then
+            echo "noncanonical YAML passed verify validation (${construct}): ${output}" >&2
+            return 1
+        fi
+        rm -rf "$root"
+    done <<'EOF'
+"surprise_key": must-not-pass
+<<: {surprise_key: must-not-pass}
+- stray-sequence-entry
+__NESTED__
+parent_prd: |
+EOF
+}
+
 @test "closed expectations schema accepts every documented optional frontmatter key" {
     local id="ALWD-0001"
     local root
@@ -696,6 +732,23 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
     [ "$status" -eq 0 ] \
         && [[ "$output" == *"PASS"* ]]
+}
+
+@test "a second active expectations heading cannot backfill an incomplete wish" {
+    local id="HEAD-0002"
+    local root
+    local file
+    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i '/^  - customer_derived:/i ## Ожидания' "$file"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"duplicate active ## Ожидания heading"* ]] || return 1
+
+    run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
 }
 
 @test "schema v4 ignores an expectations section inside a backtick fence" {

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -38,7 +38,8 @@ assert_no_direct_in_place_sed() {
 
     if ! violations="$(awk '
         function inspect(line, line_number, line_len, pos, char, quote, value,
-                         count, i, expect_command, sed_command, values, kinds) {
+                         count, i, expect_command, sed_command, wrapper,
+                         skip_wrapper_arg, skip_redirection_arg, values, kinds) {
             line_len = length(line)
             pos = 1
             count = 0
@@ -90,10 +91,16 @@ assert_no_direct_in_place_sed() {
 
             expect_command = 1
             sed_command = 0
+            wrapper = ""
+            skip_wrapper_arg = 0
+            skip_redirection_arg = 0
             for (i = 1; i <= count; i++) {
                 if (kinds[i] == "separator") {
                     expect_command = 1
                     sed_command = 0
+                    wrapper = ""
+                    skip_wrapper_arg = 0
+                    skip_redirection_arg = 0
                     continue
                 }
                 value = values[i]
@@ -107,8 +114,81 @@ assert_no_direct_in_place_sed() {
                 if (!expect_command) {
                     continue
                 }
+                if (skip_wrapper_arg) {
+                    skip_wrapper_arg = 0
+                    continue
+                }
+                if (skip_redirection_arg) {
+                    skip_redirection_arg = 0
+                    continue
+                }
+
+                if (wrapper == "env") {
+                    if (value == "--") {
+                        wrapper = ""
+                        continue
+                    }
+                    if (value ~ /^(-u|-C|-S|--unset|--chdir|--split-string)$/) {
+                        skip_wrapper_arg = 1
+                        continue
+                    }
+                    if (value ~ /^(-i|-0|-v|--ignore-environment|--null|--debug)$/ ||
+                        value ~ /^--(unset|chdir|split-string)=/) {
+                        continue
+                    }
+                    if (value ~ /^[A-Za-z_][A-Za-z0-9_]*=/) {
+                        continue
+                    }
+                    wrapper = ""
+                } else if (wrapper == "command") {
+                    if (value ~ /^(--|-p)$/) {
+                        continue
+                    }
+                    if (value ~ /^-[vV]$/) {
+                        expect_command = 0
+                        wrapper = ""
+                        continue
+                    }
+                    wrapper = ""
+                } else if (wrapper == "time") {
+                    if (value ~ /^(--|-p)$/) {
+                        continue
+                    }
+                    wrapper = ""
+                } else if (wrapper == "sudo") {
+                    if (value == "--") {
+                        wrapper = ""
+                        continue
+                    }
+                    if (value ~ /^(-u|-g|-h|-p|-C|-T|-R|-D|-t|-r|-c|--user|--group|--host|--prompt|--close-from|--command-timeout|--chroot|--chdir|--type|--role)$/) {
+                        skip_wrapper_arg = 1
+                        continue
+                    }
+                    if (value ~ /^(-[ughpCTRDtrc].+|--(user|group|host|prompt|close-from|command-timeout|chroot|chdir|type|role)=)/) {
+                        continue
+                    }
+                    if (value ~ /^-/) {
+                        continue
+                    }
+                    wrapper = ""
+                }
+
+                if (value ~ /^[0-9]*(>>?|<<?|<>|>&|<&)/) {
+                    if (value ~ /^[0-9]*(>>?|<<?|<>|>&|<&)$/) {
+                        skip_redirection_arg = 1
+                    }
+                    continue
+                }
                 if (value ~ /^[A-Za-z_][A-Za-z0-9_]*=/ ||
-                    value ~ /^(if|then|elif|while|until|do|!|run|command|env|sudo|builtin|exec|time)$/) {
+                    value ~ /^(if|then|elif|while|until|do|!)$/) {
+                    continue
+                }
+                if (value ~ /^(run|builtin|exec)$/) {
+                    wrapper = "command"
+                    continue
+                }
+                if (value ~ /^(command|env|sudo|time)$/) {
+                    wrapper = value
                     continue
                 }
                 if (value == "sed" || value ~ /\/sed$/) {
@@ -1500,6 +1580,11 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     printf '%s\n' 'echo setup; sed -Ei '\''s/x/y/'\'' mutant' >> "$mutant_suite"
     printf '%s\n' 'run "sed" --in-place '\''s/x/y/'\'' mutant' >> "$mutant_suite"
     printf '%s\n' 'env MODE=test /usr/bin/sed -i '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    printf '%s\n' 'env -i sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    printf '%s\n' 'command -- sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    printf '%s\n' 'time -p sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    printf '%s\n' 'sudo -u nobody sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    printf '%s\n' '>/tmp/customer-binding-mutant sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
     run assert_no_direct_in_place_sed "$mutant_suite"
     if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
         echo "wrapped in-place sed mutants were not rejected (status=${status}): ${output}" >&2
@@ -1512,6 +1597,10 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     printf '%s\n' 'printf '\''%s\n'\'' '\''sed -i.bak is forbidden'\''' >> "$mutant_suite"
     printf '%s\n' 'message="sed -i.bak is forbidden"' >> "$mutant_suite"
     printf '%s\n' 'echo "quoted separator; sed -i.bak is forbidden"' >> "$mutant_suite"
+    printf '%s\n' 'env -u sed echo allowed' >> "$mutant_suite"
+    printf '%s\n' 'command -v sed' >> "$mutant_suite"
+    printf '%s\n' 'sudo -u sed echo allowed' >> "$mutant_suite"
+    printf '%s\n' 'time -p echo sed -i.bak is forbidden' >> "$mutant_suite"
     run assert_no_direct_in_place_sed "$mutant_suite"
     if [ "$status" -ne 0 ]; then
         echo "inert sed prose was treated as executable (status=${status}): ${output}" >&2

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -1433,6 +1433,70 @@ EOF
         && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
 }
 
+@test "every tracked base-accepted legacy expectations artifact remains readable" {
+    local expected_tracked_ids
+    local base_accepted_ids
+    local actual_tracked_ids=""
+    local file
+    local schema
+    local id
+    expected_tracked_ids="$(printf '%s\n' \
+        TUNE-0516 TUNE-0517 TUNE-0530 TUNE-0574 TUNE-0581)"
+    base_accepted_ids="$(printf '%s\n' \
+        TUNE-0516 TUNE-0517 TUNE-0530 TUNE-0574)"
+
+    for file in "$REPO_ROOT"/datarim/tasks/*-expectations.md; do
+        schema="$(sed -nE 's/^schema_version:[[:space:]]*([123])$/\1/p' "$file")"
+        [ -n "$schema" ] || continue
+        id="$(sed -nE 's/^task_id:[[:space:]]*([^[:space:]]+)$/\1/p' "$file")"
+        actual_tracked_ids="${actual_tracked_ids}${actual_tracked_ids:+$'\n'}${id}"
+        printf '%s\n' "$base_accepted_ids" | grep -qxF "$id" || continue
+
+        run "$CHECK_EXPECTATIONS" --task "$id" --root "$REPO_ROOT"
+        if [ "$status" -ne 0 ]; then
+            echo "tracked legacy ${id} failed task validation: ${output}" >&2
+            return 1
+        fi
+        run "$CHECK_EXPECTATIONS" --verify "$id" --root "$REPO_ROOT"
+        if [ "$status" -ne 0 ]; then
+            echo "tracked legacy ${id} failed verify validation: ${output}" >&2
+            return 1
+        fi
+    done
+
+    [ "$actual_tracked_ids" = "$expected_tracked_ids" ] || {
+        echo "tracked legacy manifest drifted; expected: ${expected_tracked_ids}; actual: ${actual_tracked_ids}" >&2
+        return 1
+    }
+}
+
+@test "legacy wish identifiers retain pre-v4 cardinality and shape compatibility" {
+    local schema
+    local id
+    local root
+    local file
+
+    for schema in 1 2 3; do
+        id="LWID-000${schema}"
+        root="$(write_expectations "$id" "$schema")"
+        file="$root/datarim/tasks/${id}-expectations.md"
+        portable_sed_in_place 's/^  - wish_id: customer-outcome$/  - wish_id: historical focus key\
+  - wish_id: historical focus key/' "$file"
+
+        run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+        if [ "$status" -ne 0 ]; then
+            echo "legacy schema v${schema} rejected a pre-v4 wish identifier: ${output}" >&2
+            return 1
+        fi
+        run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+        if [ "$status" -ne 0 ] || [[ "$output" != *"PASS"* ]]; then
+            echo "legacy schema v${schema} verify rejected a pre-v4 wish identifier: ${output}" >&2
+            return 1
+        fi
+        rm -rf "$root"
+    done
+}
+
 @test "legacy schema versions v1 through v3 remain valid without customer binding" {
     local schema
     local id

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -500,6 +500,53 @@ EOF
         && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
 }
 
+@test "schema validation rejects duplicate frontmatter keys in task and verify modes" {
+    local id
+    local root
+    local file
+    local key
+    local duplicate
+    for key in schema_version status; do
+        id="DUPF-0001"
+        root="$(write_expectations "$id" 3)"
+        file="$root/datarim/tasks/${id}-expectations.md"
+        case "$key" in
+            schema_version) duplicate='schema_version: 4' ;;
+            status) duplicate='status: canonica1' ;;
+        esac
+        sed -i "/^${key}:/a ${duplicate}" "$file"
+
+        run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"duplicate frontmatter field '${key}'"* ]]; then
+            echo "duplicate ${key} passed task validation: ${output}" >&2
+            return 1
+        fi
+
+        run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"BLOCKED: expectations file fails structural validation"* ]]; then
+            echo "duplicate ${key} passed verify validation: ${output}" >&2
+            return 1
+        fi
+        rm -rf "$root"
+    done
+}
+
+@test "active expectations heading with a trailing HTML comment passes both modes" {
+    local id="HEAD-0001"
+    local root
+    local file
+    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i 's/^## Ожидания$/& <!-- active heading trailing comment -->/' "$file"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 0 ] || return 1
+
+    run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+    [ "$status" -eq 0 ] \
+        && [[ "$output" == *"PASS"* ]]
+}
+
 @test "verify mode blocks a structurally invalid schema v4 artifact" {
     local id="BIND-0016"
     local root
@@ -559,6 +606,8 @@ EOF
 
 @test "customer delivery skill is registered in the canonical skills inventory" {
     assert_contains "$SKILLS_REFERENCE" '| customer-delivery | Reference |' || return 1
+    assert_contains "$SKILLS_REFERENCE" '| expectations-checklist | Reference | Operator wishlist artefact' || return 1
+    assert_contains "$SKILLS_REFERENCE" 'Schema v4 requires explicit customer derivation' || return 1
 
     disk_count="$(find "${REPO_ROOT}/skills" -mindepth 2 -maxdepth 2 -name SKILL.md | wc -l | tr -d '[:space:]')"
     documented_count="$(sed -nE 's/^Datarim includes ([0-9]+) reusable skill modules\..*/\1/p' "$SKILLS_REFERENCE")"

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -37,19 +37,36 @@ assert_no_direct_in_place_sed() {
     local violations
 
     if ! violations="$(awk '
-        {
-            line = $0
-            if (!match(line, /(^|[;&|()[:space:]])([^[:space:]]*\/)?sed[[:space:]]+/)) {
-                next
+        function inspect(line, line_number, args, count, i, token, tokens) {
+            if (!match(line, /(^|[;&|()[:space:]])(([^[:space:]"]*\/)?sed|"([^"]*\/)?sed"|\047([^\047]*\/)?sed\047)[[:space:]]+/)) {
+                return
             }
             args = substr(line, RSTART + RLENGTH)
             count = split(args, tokens, /[[:space:]]+/)
             for (i = 1; i <= count; i++) {
                 token = tokens[i]
                 if (token ~ /^--in-place(=.*)?$/ || token ~ /^-[A-Za-z]*i/) {
-                    print FNR ":" $0
-                    next
+                    print line_number ":" line
+                    return
                 }
+            }
+        }
+        {
+            if (logical_line == "") {
+                logical_line = $0
+                logical_line_number = FNR
+            } else {
+                logical_line = logical_line "\n" $0
+            }
+            if ($0 ~ /\\[[:space:]]*$/) {
+                next
+            }
+            inspect(logical_line, logical_line_number)
+            logical_line = ""
+        }
+        END {
+            if (logical_line != "") {
+                inspect(logical_line, logical_line_number)
             }
         }
     ' "$file")"; then
@@ -1379,6 +1396,31 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
             return 1
         fi
     done
+
+    cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
+    printf '%s\n' 'sed \' '    -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    run assert_no_direct_in_place_sed "$mutant_suite"
+    if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
+        echo "continued in-place sed mutant was not rejected (status=${status}): ${output}" >&2
+        return 1
+    fi
+
+    cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
+    printf '%s\n' '"sed" -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    run assert_no_direct_in_place_sed "$mutant_suite"
+    if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
+        echo "quoted in-place sed mutant was not rejected (status=${status}): ${output}" >&2
+        return 1
+    fi
+
+    cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
+    printf '%s\n' "'sed' -i.bak 's/x/y/' mutant" >> "$mutant_suite"
+    printf '%s\n' '"/usr/bin/sed" -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    run assert_no_direct_in_place_sed "$mutant_suite"
+    if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
+        echo "quoted sed path mutants were not rejected (status=${status}): ${output}" >&2
+        return 1
+    fi
 
     run workflow_run_block_has_suite \
         "$mutant_workflow" \

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -1437,6 +1437,7 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     local original_path="$PATH"
 
     real_editor="$(command -v "$(portable_editor_word)")"
+    [[ "$real_editor" = /* && -x "$real_editor" ]] || return 1
     shim="${shim_dir}/$(portable_editor_word)"
     mkdir -p "$fixture_dir" "$shim_dir"
     printf 'alpha\n' > "$fixture"
@@ -1452,12 +1453,11 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
         '            exit 97' \
         '            ;;' \
         '    esac' \
-        'done' \
-        'exec "$REAL_SED" "$@"' > "$shim"
+        'done' > "$shim"
+    printf 'exec %q "$@"\n' "$real_editor" >> "$shim"
     chmod +x "$shim"
 
     run env \
-        REAL_SED="$real_editor" \
         SED_SHIM_LOG="$shim_log" \
         PATH="${shim_dir}:${PATH}" \
         "$(portable_editor_word)" "$long_option" 's/x/y/' "$fixture"
@@ -1466,14 +1466,14 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
 
     : > "$shim_log"
     run env \
-        REAL_SED="$real_editor" \
         SED_SHIM_LOG="$shim_log" \
         PATH="${shim_dir}:${PATH}" \
         "$(portable_editor_word)" -n 's/^alpha$/alpha/p' "$fixture"
     [ "$status" -eq 0 ] && [ "$output" = "alpha" ] || return 1
     [ ! -s "$shim_log" ] || return 1
 
-    export REAL_SED="$real_editor" SED_SHIM_LOG="$shim_log"
+    unset REAL_SED
+    export SED_SHIM_LOG="$shim_log"
     PATH="${shim_dir}:${PATH}"
     export PATH
     portable_sed_in_place 's/alpha/beta/' "$fixture"
@@ -1648,7 +1648,7 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
         's/^[[:space:]]*local temp_file$/    local temp_file editor/' \
         "$mutant_suite"
     portable_sed_in_place '/^[[:space:]]*if ! sed "${args\[@\]}" "$file" > "$temp_file"; then$/i\
-    editor="$(portable_editor_word)"
+    editor="${REAL_SED:-$(command -v "$(portable_editor_word)")}"
 ' "$mutant_suite"
     portable_sed_in_place \
         's|^[[:space:]]*if ! sed "${args\[@\]}" "$file" > "$temp_file"; then$|    if ! "$editor" '"${short_option}"' "${args[@]}" "$temp_file"; then|' \

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -133,7 +133,7 @@ assert_no_direct_in_place_sed() {
                         continue
                     }
                     if (value ~ /^(-i|-0|-v|--ignore-environment|--null|--debug)$/ ||
-                        value ~ /^--(unset|chdir|split-string)=/) {
+                        value ~ /^-[uCS].+/ || value ~ /^--(unset|chdir|split-string)=/) {
                         continue
                     }
                     if (value ~ /^[A-Za-z_][A-Za-z0-9_]*=/) {
@@ -152,6 +152,24 @@ assert_no_direct_in_place_sed() {
                     wrapper = ""
                 } else if (wrapper == "time") {
                     if (value ~ /^(--|-p)$/) {
+                        continue
+                    }
+                    wrapper = ""
+                } else if (wrapper == "run") {
+                    if (value == "!" || value ~ /^-[0-9]+$/ ||
+                        value ~ /^(--separate-stderr|--keep-empty-lines)$/) {
+                        continue
+                    }
+                    wrapper = ""
+                } else if (wrapper == "exec") {
+                    if (value ~ /^(--|-c|-l)$/) {
+                        continue
+                    }
+                    if (value == "-a") {
+                        skip_wrapper_arg = 1
+                        continue
+                    }
+                    if (value ~ /^-a.+/) {
                         continue
                     }
                     wrapper = ""
@@ -183,7 +201,15 @@ assert_no_direct_in_place_sed() {
                     value ~ /^(if|then|elif|while|until|do|!)$/) {
                     continue
                 }
-                if (value ~ /^(run|builtin|exec)$/) {
+                if (value == "run") {
+                    wrapper = "run"
+                    continue
+                }
+                if (value == "exec") {
+                    wrapper = "exec"
+                    continue
+                }
+                if (value == "builtin") {
                     wrapper = "command"
                     continue
                 }
@@ -1581,8 +1607,15 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     printf '%s\n' 'run "sed" --in-place '\''s/x/y/'\'' mutant' >> "$mutant_suite"
     printf '%s\n' 'env MODE=test /usr/bin/sed -i '\''s/x/y/'\'' mutant' >> "$mutant_suite"
     printf '%s\n' 'env -i sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    printf '%s\n' 'env -uPATH sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    printf '%s\n' 'env -C/tmp sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
     printf '%s\n' 'command -- sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
     printf '%s\n' 'time -p sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    printf '%s\n' 'run -127 sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    printf '%s\n' 'run --separate-stderr sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    printf '%s\n' 'run --keep-empty-lines sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    printf '%s\n' 'exec -c sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    printf '%s\n' 'exec -a replacement sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
     printf '%s\n' 'sudo -u nobody sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
     printf '%s\n' '>/tmp/customer-binding-mutant sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
     run assert_no_direct_in_place_sed "$mutant_suite"
@@ -1598,9 +1631,12 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     printf '%s\n' 'message="sed -i.bak is forbidden"' >> "$mutant_suite"
     printf '%s\n' 'echo "quoted separator; sed -i.bak is forbidden"' >> "$mutant_suite"
     printf '%s\n' 'env -u sed echo allowed' >> "$mutant_suite"
+    printf '%s\n' 'env -used echo allowed' >> "$mutant_suite"
     printf '%s\n' 'command -v sed' >> "$mutant_suite"
     printf '%s\n' 'sudo -u sed echo allowed' >> "$mutant_suite"
     printf '%s\n' 'time -p echo sed -i.bak is forbidden' >> "$mutant_suite"
+    printf '%s\n' 'run -127 echo sed -i.bak is forbidden' >> "$mutant_suite"
+    printf '%s\n' 'exec -a sed echo allowed' >> "$mutant_suite"
     run assert_no_direct_in_place_sed "$mutant_suite"
     if [ "$status" -ne 0 ]; then
         echo "inert sed prose was treated as executable (status=${status}): ${output}" >&2

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -297,6 +297,36 @@ EOF
         && [[ "$output" == *"customer binding field appears before customer_binding_from"* ]]
 }
 
+@test "schema v4 rejects coordinated binding strip and cutover advance" {
+    local id="BIND-0020"
+    local root
+    local file
+    root="$(write_cutover_expectations "$id")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i 's/customer_binding_from: appended-customer-wish/customer_binding_from: appended-internal-wish/' "$file"
+    sed -E -i.bak '/^- \*\*2\./,/^- \*\*3\./ { /^  - (customer_derived|requirement_id|surface_class|visitor_visible|delivery_receipt):/d; }' "$file"
+    rm -f "${file}.bak"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"schema v4 must start customer binding at its first wish"* ]]
+}
+
+@test "verify blocks coordinated binding strip and cutover advance" {
+    local id="BIND-0021"
+    local root
+    local file
+    root="$(write_cutover_expectations "$id")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i 's/customer_binding_from: appended-customer-wish/customer_binding_from: appended-internal-wish/' "$file"
+    sed -E -i.bak '/^- \*\*2\./,/^- \*\*3\./ { /^  - (customer_derived|requirement_id|surface_class|visitor_visible|delivery_receipt):/d; }' "$file"
+    rm -f "${file}.bak"
+
+    run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
+}
+
 @test "verify mode blocks a schema v4 cutover moved past a bound wish" {
     local id="BIND-0019"
     local root
@@ -370,6 +400,32 @@ EOF
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 1 ] \
         && [[ "$output" == *"canonical schema v4 must start customer binding at its first wish"* ]]
+}
+
+@test "schema v4 rejects an invalid frontmatter status" {
+    local id="BIND-0022"
+    local root
+    local file
+    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i 's/status: canonical/status: canonica1/' "$file"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"frontmatter status must be 'canonical' or 'amended'"* ]]
+}
+
+@test "verify blocks an invalid frontmatter status" {
+    local id="BIND-0023"
+    local root
+    local file
+    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i 's/status: canonical/status: canonica1/' "$file"
+
+    run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
 }
 
 @test "schema v4 rejects duplicate customer binding fields" {

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -751,6 +751,57 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
         && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
 }
 
+@test "CommonMark closing hashes cannot hide later unbound wishes" {
+    local id="HEAD-0003"
+    local suffix
+    local root
+    local file
+    for suffix in '##' '## <!-- trailing heading comment -->'; do
+        root="$(write_migrated_expectations "$id")"
+        file="$root/datarim/tasks/${id}-expectations.md"
+        sed -i "/^- \*\*2\. Appended customer wish\.\*\*$/i ## Ожидания ${suffix}" "$file"
+        sed -i '/^  - customer_derived: true$/,/^  - delivery_receipt:/d' "$file"
+
+        run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"duplicate active ## Ожидания heading"* ]]; then
+            echo "closing-hash heading hid an unbound wish (${suffix}): ${output}" >&2
+            return 1
+        fi
+
+        run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"BLOCKED: expectations file fails structural validation"* ]]; then
+            echo "closing-hash heading passed verify (${suffix}): ${output}" >&2
+            return 1
+        fi
+        rm -rf "$root"
+    done
+}
+
+@test "a single CommonMark-equivalent expectations heading remains active" {
+    local id="HEAD-0004"
+    local heading
+    local root
+    local file
+    for heading in '## Ожидания ##' $'   ##\tОжидания ###'; do
+        root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+        file="$root/datarim/tasks/${id}-expectations.md"
+        sed -i "s/^## Ожидания$/${heading}/" "$file"
+
+        run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+        if [ "$status" -ne 0 ]; then
+            echo "valid CommonMark heading rejected (${heading}): ${output}" >&2
+            return 1
+        fi
+
+        run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+        if [ "$status" -ne 0 ] || [[ "$output" != *"PASS"* ]]; then
+            echo "valid CommonMark heading failed verify (${heading}): ${output}" >&2
+            return 1
+        fi
+        rm -rf "$root"
+    done
+}
+
 @test "schema v4 ignores an expectations section inside a backtick fence" {
     local id="FENC-0001"
     local root

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -482,6 +482,24 @@ EOF
         && [[ "$output" == *"no items found"* ]]
 }
 
+@test "schema v4 validates an active item header with a trailing HTML comment" {
+    local id="BIND-0015"
+    local root
+    local file
+    root="$(write_migrated_expectations "$id")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i 's/^- \*\*2\. Appended customer wish\.\*\*$/& <!-- active header trailing comment -->/' "$file"
+    sed -i '/^  - customer_derived: true$/,/^  - delivery_receipt:/d' "$file"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"item 2 missing customer_derived"* ]] || return 1
+
+    run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
+}
+
 @test "verify mode blocks a structurally invalid schema v4 artifact" {
     local id="BIND-0016"
     local root

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -439,6 +439,89 @@ EOF
         && [[ "$output" == *"duplicate requirement_id"* ]]
 }
 
+@test "wish_id is a unique kebab focus key in task and verify modes" {
+    local id="WISH-0001"
+    local variant
+    local expected
+    local root
+    local file
+    for variant in invalid_space invalid_underscore invalid_empty_segment invalid_separator invalid_other_script duplicate_field duplicate_value; do
+        if [ "$variant" = "duplicate_value" ]; then
+            root="$(write_migrated_expectations "$id")"
+            file="$root/datarim/tasks/${id}-expectations.md"
+            sed -i 's/wish_id: appended-internal-wish/wish_id: preserved-legacy-wish/' "$file"
+            expected="duplicate wish_id value 'preserved-legacy-wish'"
+        else
+            root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+            file="$root/datarim/tasks/${id}-expectations.md"
+            case "$variant" in
+                invalid_space)
+                    sed -i 's/wish_id: customer-outcome/wish_id: not a kebab slug/' "$file"
+                    expected="wish_id must be a kebab slug"
+                    ;;
+                invalid_underscore)
+                    sed -i 's/wish_id: customer-outcome/wish_id: not_a_kebab_slug/' "$file"
+                    expected="wish_id must be a kebab slug"
+                    ;;
+                invalid_empty_segment)
+                    sed -i 's/wish_id: customer-outcome/wish_id: empty--segment/' "$file"
+                    expected="wish_id must be a kebab slug"
+                    ;;
+                invalid_separator)
+                    sed -i 's@wish_id: customer-outcome@wish_id: path/segment@' "$file"
+                    expected="wish_id must be a kebab slug"
+                    ;;
+                invalid_other_script)
+                    sed -i 's/wish_id: customer-outcome/wish_id: δοκιμή/' "$file"
+                    expected="wish_id must be a kebab slug"
+                    ;;
+                duplicate_field)
+                    sed -i '/wish_id: customer-outcome/a\
+  - wish_id: second-focus-key' "$file"
+                    expected="duplicate wish_id field"
+                    ;;
+            esac
+        fi
+
+        run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"${expected}"* ]]; then
+            echo "wish_id ${variant} passed task validation: ${output}" >&2
+            return 1
+        fi
+
+        run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"BLOCKED: expectations file fails structural validation"* ]]; then
+            echo "wish_id ${variant} passed verify validation: ${output}" >&2
+            return 1
+        fi
+        rm -rf "$root"
+    done
+}
+
+@test "wish_id accepts ASCII and Cyrillic kebab segments" {
+    local id="WISH-0002"
+    local slug
+    local root
+    local file
+    for slug in 'Outcome-2' 'сохранение-исходного-промпта'; do
+        root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+        file="$root/datarim/tasks/${id}-expectations.md"
+        sed -i "s/wish_id: customer-outcome/wish_id: ${slug}/" "$file"
+        run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+        if [ "$status" -ne 0 ]; then
+            echo "valid wish_id rejected (${slug}): ${output}" >&2
+            return 1
+        fi
+
+        run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+        if [ "$status" -ne 0 ] || [[ "$output" != *"PASS"* ]]; then
+            echo "valid wish_id failed verify (${slug}): ${output}" >&2
+            return 1
+        fi
+        rm -rf "$root"
+    done
+}
+
 @test "schema v4 customer_derived false forbids customer binding fields" {
     local id="BIND-0013"
     local root
@@ -508,6 +591,82 @@ EOF
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 1 ] \
         && [[ "$output" == *"item 2 missing customer_derived"* ]] || return 1
+
+    run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
+}
+
+@test "inline code and escaped comment openers remain literal active prose" {
+    local id="COMM-0001"
+    local variant
+    local root
+    local file
+    for variant in single_tick delimiter_run escaped; do
+        root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+        file="$root/datarim/tasks/${id}-expectations.md"
+        case "$variant" in
+            single_tick)
+                sed -i '/success criterion/s/$/ `<!--` literal/' "$file"
+                ;;
+            delimiter_run)
+                sed -i '/success criterion/s/$/ ``short ` then <!-- `` literal/' "$file"
+                ;;
+            escaped)
+                sed -i '/success criterion/s/$/ \\<!-- literal/' "$file"
+                grep -Fq '\<!-- literal' "$file" || return 1
+                ;;
+        esac
+
+        run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+        if [ "$status" -ne 0 ]; then
+            echo "literal comment opener rejected (${variant}): ${output}" >&2
+            return 1
+        fi
+
+        run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+        if [ "$status" -ne 0 ] || [[ "$output" != *"PASS"* ]]; then
+            echo "literal comment opener failed verify (${variant}): ${output}" >&2
+            return 1
+        fi
+        rm -rf "$root"
+    done
+}
+
+@test "multiline code spans preserve literal comments until an exact delimiter closes" {
+    local id="COMM-0002"
+    local root
+    local file
+    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i '/success criterion/c\
+  - Как проверить (success criterion): A ``span opens\
+<!-- remains literal before ` shorter delimiter\
+`` span closes before active bindings.' "$file"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 0 ] || {
+        echo "multiline code span rejected in task mode: ${output}" >&2
+        return 1
+    }
+
+    run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+    [ "$status" -eq 0 ] && [[ "$output" == *"PASS"* ]] || {
+        echo "multiline code span rejected in verify mode: ${output}" >&2
+        return 1
+    }
+}
+
+@test "an escaped backtick does not neutralize a real HTML comment" {
+    local id="COMM-0003"
+    local root
+    local file
+    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i '/success criterion/s/$/ \\`<!--`/' "$file"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] && [[ "$output" == *"missing customer_derived"* ]] || return 1
 
     run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
     [ "$status" -eq 1 ] \

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -44,8 +44,9 @@ assert_no_direct_in_place_sed() {
     if ! violations="$(LC_ALL=C awk -v sed_word="$sed_word" -v long_option="$long_option" '
         function canonical_token(token) {
             gsub(/["\047`]/, "", token)
+            gsub(/\\/, "", token)
             sub(/^[A-Za-z_][A-Za-z0-9_]*=/, "", token)
-            gsub(/^[!;|&(){}]+/, "", token)
+            gsub(/^[!$<>;|&(){}]+/, "", token)
             gsub(/[;|&(){}]+$/, "", token)
             return token
         }
@@ -82,7 +83,7 @@ assert_no_direct_in_place_sed() {
                 logical_line = physical_line
                 logical_line_number = FNR
             } else {
-                logical_line = logical_line " " physical_line
+                logical_line = logical_line physical_line
             }
             if (continued) {
                 next
@@ -1438,6 +1439,79 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
         run assert_no_direct_in_place_sed "$mutant_suite"
         if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
             echo "substitution-state lexical mutant passed (status=${status}; payload=${payload}): ${output}" >&2
+            return 1
+        fi
+    done
+}
+
+@test "portability source convention recognizes modern substitution prefixes" {
+    local mutant_suite="${BATS_TEST_TMPDIR}/customer-binding-modern-substitution.bats"
+    local command_token="s""ed"
+    local path_token="/usr/bin/${command_token}"
+    local short_option="-""i.bak"
+    local dollar_sign='$'
+    local payload
+
+    for payload in \
+        "${dollar_sign}(${command_token} ${short_option} 's/x/y/' mutant)" \
+        "value=${dollar_sign}(${command_token} ${short_option} 's/x/y/' mutant)" \
+        "<(${command_token} ${short_option} 's/x/y/' mutant)" \
+        "${dollar_sign}(${path_token} ${short_option} 's/x/y/' mutant)"; do
+        cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
+        printf '%s\n' "$payload" >> "$mutant_suite"
+
+        run assert_no_direct_in_place_sed "$mutant_suite"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
+            echo "modern substitution lexical mutant passed (status=${status}; payload=${payload}): ${output}" >&2
+            return 1
+        fi
+    done
+}
+
+@test "portability source convention concatenates shell continuations byte-exactly" {
+    local mutant_suite="${BATS_TEST_TMPDIR}/customer-binding-continuation.bats"
+    local command_token="s""ed"
+    local short_option="-""i.bak"
+
+    cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
+    printf '%s\\\n%s %s '\''s/x/y/'\'' mutant\n' \
+        's' 'ed' "$short_option" >> "$mutant_suite"
+    run assert_no_direct_in_place_sed "$mutant_suite"
+    if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
+        echo "continued command token mutant passed (status=${status}): ${output}" >&2
+        return 1
+    fi
+
+    cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
+    printf '%s -\\\n%s '\''s/x/y/'\'' mutant\n' \
+        "$command_token" 'i.bak' >> "$mutant_suite"
+    run assert_no_direct_in_place_sed "$mutant_suite"
+    if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
+        echo "continued option token mutant passed (status=${status}): ${output}" >&2
+        return 1
+    fi
+}
+
+@test "portability source convention canonicalizes ANSI-C and escaped command tokens" {
+    local mutant_suite="${BATS_TEST_TMPDIR}/customer-binding-escaped-token.bats"
+    local command_token="s""ed"
+    local short_option="-""i.bak"
+    local dollar_sign='$'
+    local escape
+    local payload
+    escape="$(printf '\134')"
+
+    for payload in \
+        "${dollar_sign}'${command_token}' ${short_option} 's/x/y/' mutant" \
+        "${dollar_sign}'s''ed' ${short_option} 's/x/y/' mutant" \
+        "${escape}s${escape}ed ${short_option} 's/x/y/' mutant" \
+        "/usr/bin/s${escape}ed ${short_option} 's/x/y/' mutant"; do
+        cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
+        printf '%s\n' "$payload" >> "$mutant_suite"
+
+        run assert_no_direct_in_place_sed "$mutant_suite"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
+            echo "escaped command token mutant passed (status=${status}; payload=${payload}): ${output}" >&2
             return 1
         fi
     done

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -34,241 +34,42 @@ assert_contains() {
 
 assert_no_direct_in_place_sed() {
     local file="$1"
+    local sed_word="s""ed"
+    local long_option="--in""-place"
     local violations
 
-    if ! violations="$(LC_ALL=C awk '
-        function inspect(line, line_number, line_len, pos, char, quote, value,
-                         count, i, expect_command, sed_command, wrapper,
-                         skip_wrapper_arg, skip_redirection_arg, in_backtick,
-                         pending_outer_quote, backtick_outer_quote, resume_quote,
-                         outer_expect_command, outer_sed_command, outer_wrapper,
-                         outer_skip_wrapper_arg, outer_skip_redirection_arg,
-                         values, kinds) {
-            line_len = length(line)
-            pos = 1
-            count = 0
-            while (pos <= line_len) {
-                char = substr(line, pos, 1)
-                if (char ~ /[[:space:]]/) {
-                    pos++
-                    continue
-                }
-                if (char == "#") {
-                    break
-                }
-                if (char == "`") {
-                    values[++count] = char
-                    if (in_backtick) {
-                        kinds[count] = "substitution_close"
-                        in_backtick = 0
-                        resume_quote = backtick_outer_quote
-                        backtick_outer_quote = ""
-                    } else {
-                        kinds[count] = "substitution_open"
-                        in_backtick = 1
-                        backtick_outer_quote = pending_outer_quote
-                    }
-                    pending_outer_quote = ""
-                    pos++
-                    continue
-                }
-                if (char ~ /[;&|(){}]/) {
-                    values[++count] = char
-                    kinds[count] = "separator"
-                    pos++
-                    continue
-                }
-
-                value = ""
-                quote = resume_quote
-                resume_quote = ""
-                while (pos <= line_len) {
-                    char = substr(line, pos, 1)
-                    if ((quote == "" && (char ~ /[[:space:]]/ || char ~ /[;&|(){}]/ || char == "`")) ||
-                        (quote == "\"" && char == "`")) {
-                        if (quote == "\"" && char == "`") {
-                            pending_outer_quote = quote
-                        }
-                        break
-                    }
-                    if (quote == "" && (char == "\"" || char == "\047")) {
-                        quote = char
-                        pos++
-                        continue
-                    }
-                    if (quote != "" && char == quote) {
-                        quote = ""
-                        pos++
-                        continue
-                    }
-                    if (quote != "\047" && char == "\\" && pos < line_len) {
-                        pos++
-                        value = value substr(line, pos, 1)
-                        pos++
-                        continue
-                    }
-                    value = value char
-                    pos++
-                }
-                values[++count] = value
-                kinds[count] = "word"
-            }
-
-            expect_command = 1
-            sed_command = 0
-            wrapper = ""
-            skip_wrapper_arg = 0
-            skip_redirection_arg = 0
+    # Deliberately lexical and fail-closed: this controlled suite may not carry
+    # the command token followed by a GNU-only in-place option on one logical
+    # line, even inside comments, strings, wrappers, or substitutions.
+    if ! violations="$(LC_ALL=C awk -v sed_word="$sed_word" -v long_option="$long_option" '
+        function canonical_token(token) {
+            gsub(/["\047`]/, "", token)
+            sub(/^[A-Za-z_][A-Za-z0-9_]*=/, "", token)
+            gsub(/^[!;|&(){}]+/, "", token)
+            gsub(/[;|&(){}]+$/, "", token)
+            return token
+        }
+        function is_sed_token(token, value) {
+            value = canonical_token(token)
+            return value == sed_word || value ~ ("/" sed_word "$")
+        }
+        function is_in_place_option(token, value) {
+            value = canonical_token(token)
+            return value == long_option || index(value, long_option "=") == 1 ||
+                value ~ /^-[A-Za-z]*i([A-Za-z]*|[.].*)$/
+        }
+        function inspect(line, line_number, count, fields, i, saw_sed) {
+            count = split(line, fields, /[[:space:]]+/)
+            saw_sed = 0
             for (i = 1; i <= count; i++) {
-                if (kinds[i] == "substitution_open") {
-                    outer_expect_command = expect_command
-                    outer_sed_command = sed_command
-                    outer_wrapper = wrapper
-                    outer_skip_wrapper_arg = skip_wrapper_arg
-                    outer_skip_redirection_arg = skip_redirection_arg
-                    expect_command = 1
-                    sed_command = 0
-                    wrapper = ""
-                    skip_wrapper_arg = 0
-                    skip_redirection_arg = 0
+                if (!saw_sed && is_sed_token(fields[i])) {
+                    saw_sed = 1
                     continue
                 }
-                if (kinds[i] == "substitution_close") {
-                    expect_command = outer_expect_command
-                    sed_command = outer_sed_command
-                    wrapper = outer_wrapper
-                    skip_wrapper_arg = outer_skip_wrapper_arg
-                    skip_redirection_arg = outer_skip_redirection_arg
-                    continue
+                if (saw_sed && is_in_place_option(fields[i])) {
+                    print line_number ":" line
+                    return
                 }
-                if (kinds[i] == "separator") {
-                    expect_command = 1
-                    sed_command = 0
-                    wrapper = ""
-                    skip_wrapper_arg = 0
-                    skip_redirection_arg = 0
-                    continue
-                }
-                value = values[i]
-                if (sed_command) {
-                    if (value ~ /^--in-place(=.*)?$/ || value ~ /^-[A-Za-z]*i/) {
-                        print line_number ":" line
-                        return
-                    }
-                    continue
-                }
-                if (!expect_command) {
-                    continue
-                }
-                if (skip_wrapper_arg) {
-                    skip_wrapper_arg = 0
-                    continue
-                }
-                if (skip_redirection_arg) {
-                    skip_redirection_arg = 0
-                    continue
-                }
-
-                if (wrapper == "env") {
-                    if (value == "--") {
-                        wrapper = ""
-                        continue
-                    }
-                    if (value ~ /^(-u|-C|-S|--unset|--chdir|--split-string)$/) {
-                        skip_wrapper_arg = 1
-                        continue
-                    }
-                    if (value ~ /^(-i|-0|-v|--ignore-environment|--null|--debug)$/ ||
-                        value ~ /^-[uCS].+/ || value ~ /^--(unset|chdir|split-string)=/) {
-                        continue
-                    }
-                    if (value ~ /^[A-Za-z_][A-Za-z0-9_]*=/) {
-                        continue
-                    }
-                    wrapper = ""
-                } else if (wrapper == "command") {
-                    if (value ~ /^(--|-p)$/) {
-                        continue
-                    }
-                    if (value ~ /^-[vV]$/) {
-                        expect_command = 0
-                        wrapper = ""
-                        continue
-                    }
-                    wrapper = ""
-                } else if (wrapper == "time") {
-                    if (value ~ /^(--|-p)$/) {
-                        continue
-                    }
-                    wrapper = ""
-                } else if (wrapper == "run") {
-                    if (value ~ /^(--|!)$/ || value ~ /^-[0-9]+$/ ||
-                        value ~ /^(--separate-stderr|--keep-empty-lines)$/) {
-                        continue
-                    }
-                    wrapper = ""
-                } else if (wrapper == "exec") {
-                    if (value == "--" || value ~ /^-[cl]+$/) {
-                        continue
-                    }
-                    if (value == "-a" || value ~ /^-[cl]+a$/) {
-                        skip_wrapper_arg = 1
-                        continue
-                    }
-                    if (value ~ /^-[cl]*a.+/) {
-                        continue
-                    }
-                    wrapper = ""
-                } else if (wrapper == "sudo") {
-                    if (value == "--") {
-                        wrapper = ""
-                        continue
-                    }
-                    if (value ~ /^(-u|-g|-h|-p|-C|-T|-R|-D|-t|-r|-c|--user|--group|--host|--prompt|--close-from|--command-timeout|--chroot|--chdir|--type|--role)$/) {
-                        skip_wrapper_arg = 1
-                        continue
-                    }
-                    if (value ~ /^(-[ughpCTRDtrc].+|--(user|group|host|prompt|close-from|command-timeout|chroot|chdir|type|role)=)/) {
-                        continue
-                    }
-                    if (value ~ /^-/) {
-                        continue
-                    }
-                    wrapper = ""
-                }
-
-                if (value ~ /^[0-9]*(>>?|<<?|<>|>&|<&)/) {
-                    if (value ~ /^[0-9]*(>>?|<<?|<>|>&|<&)$/) {
-                        skip_redirection_arg = 1
-                    }
-                    continue
-                }
-                if (value ~ /^[A-Za-z_][A-Za-z0-9_]*=/ ||
-                    value ~ /^(if|then|elif|while|until|do|!)$/) {
-                    continue
-                }
-                if (value == "run") {
-                    wrapper = "run"
-                    continue
-                }
-                if (value == "exec") {
-                    wrapper = "exec"
-                    continue
-                }
-                if (value == "builtin") {
-                    wrapper = "command"
-                    continue
-                }
-                if (value ~ /^(command|env|sudo|time)$/) {
-                    wrapper = value
-                    continue
-                }
-                if (value == "sed" || value ~ /\/sed$/) {
-                    sed_command = 1
-                    expect_command = 0
-                    continue
-                }
-                expect_command = 0
             }
         }
         {
@@ -1605,10 +1406,53 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
         'tests/customer-requirement-expectations-binding.bats'
 }
 
+@test "portability source convention rejects forbidden tokens even in inert prose" {
+    local mutant_suite="${BATS_TEST_TMPDIR}/customer-binding-lexical-prose.bats"
+    local command_token="s""ed"
+    local short_option="-""i.bak"
+
+    cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
+    printf '# inert prose: %s %s must still be rejected\n' \
+        "$command_token" "$short_option" >> "$mutant_suite"
+
+    run assert_no_direct_in_place_sed "$mutant_suite"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"direct in-place sed syntax"* ]]
+}
+
+@test "portability source convention is independent of substitution shell state" {
+    local mutant_suite="${BATS_TEST_TMPDIR}/customer-binding-lexical-state.bats"
+    local command_token="s""ed"
+    local short_option="-""i.bak"
+    local tick
+    local payload
+    tick="$(printf '\140')"
+
+    for payload in \
+        "${tick}printf echo${tick} ${command_token} ${short_option} is literal echo prose" \
+        "> ${tick}printf /tmp/a4-out${tick} ${command_token} ${short_option} 's/x/y/' mutant" \
+        "sudo -u ${tick}printf nobody${tick} ${command_token} ${short_option} 's/x/y/' mutant"; do
+        cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
+        printf '%s\n' "$payload" >> "$mutant_suite"
+
+        run assert_no_direct_in_place_sed "$mutant_suite"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
+            echo "substitution-state lexical mutant passed (status=${status}; payload=${payload}): ${output}" >&2
+            return 1
+        fi
+    done
+}
+
 @test "portability anti-decay rejects in-place option variants and commented macOS wiring" {
     local mutant_suite="${BATS_TEST_TMPDIR}/customer-binding-mutant.bats"
     local mutant_workflow="${BATS_TEST_TMPDIR}/bats-mutant.yml"
-    local direct_command
+    local command_token="s""ed"
+    local short_option="-""i.bak"
+    local combined_option="-E""i"
+    local long_option="--in""-place"
+    local tick
+    local payload
+    tick="$(printf '\140')"
 
     cp "${REPO_ROOT}/.github/workflows/bats.yml" "$mutant_workflow"
     portable_sed_in_place '/^[[:space:]]*tests\/customer-requirement-expectations-binding\.bats/c\
@@ -1624,24 +1468,31 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
           PORTABILITY_DECOY_UNQUOTED\
 ' "$mutant_workflow"
 
-    for direct_command in \
-        "sed --in-place -E 's/x/y/' mutant" \
-        "sed --in-place=.bak 's/x/y/' mutant" \
-        "sed -Ei 's/x/y/' mutant" \
-        "sed -iE 's/x/y/' mutant" \
-        "sed -i.bak 's/x/y/' mutant" \
-        "sed -i'' 's/x/y/' mutant"; do
+    for payload in \
+        "${command_token} ${long_option} -E 's/x/y/' mutant" \
+        "${command_token} ${long_option}=.bak 's/x/y/' mutant" \
+        "${command_token} ${combined_option} 's/x/y/' mutant" \
+        "\"/usr/bin/${command_token}\" ${short_option} 's/x/y/' mutant" \
+        "run -- ${command_token} ${short_option} 's/x/y/' mutant" \
+        "env MODE=test ${command_token} ${short_option} 's/x/y/' mutant" \
+        "nice ${command_token} ${short_option} 's/x/y/' mutant" \
+        "nohup ${command_token} ${short_option} 's/x/y/' mutant" \
+        "xargs ${command_token} ${short_option}" \
+        "sh -c '${command_token} ${short_option} s/x/y/ mutant'" \
+        "ignored=${tick}${command_token} ${long_option} -e s/x/y/ mutant${tick}" \
+        "# inert prose: ${command_token} ${short_option} is forbidden"; do
         cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
-        printf '%s\n' "$direct_command" >> "$mutant_suite"
+        printf '%s\n' "$payload" >> "$mutant_suite"
         run assert_no_direct_in_place_sed "$mutant_suite"
         if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
-            echo "in-place sed mutant was not rejected (${direct_command}; status=${status}): ${output}" >&2
+            echo "lexical portability mutant passed (status=${status}; payload=${payload}): ${output}" >&2
             return 1
         fi
     done
 
     cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
-    printf '%s\n' 'sed \' '    -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    printf '%s \\\n    %s '\''s/x/y/'\'' mutant\n' \
+        "$command_token" "$short_option" >> "$mutant_suite"
     run assert_no_direct_in_place_sed "$mutant_suite"
     if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
         echo "continued in-place sed mutant was not rejected (status=${status}): ${output}" >&2
@@ -1649,85 +1500,12 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     fi
 
     cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
-    printf '%s\n' '"sed" -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    portable_sed_in_place \
+        "s/^[[:space:]]*portable_sed_in_place /    ${command_token} ${short_option} /" \
+        "$mutant_suite"
     run assert_no_direct_in_place_sed "$mutant_suite"
     if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
-        echo "quoted in-place sed mutant was not rejected (status=${status}): ${output}" >&2
-        return 1
-    fi
-
-    cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
-    printf '%s\n' "'sed' -i.bak 's/x/y/' mutant" >> "$mutant_suite"
-    printf '%s\n' '"/usr/bin/sed" -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
-    run assert_no_direct_in_place_sed "$mutant_suite"
-    if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
-        echo "quoted sed path mutants were not rejected (status=${status}): ${output}" >&2
-        return 1
-    fi
-
-    cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
-    printf '%s\n' 'if ! sed -i.bak '\''s/x/y/'\'' mutant; then exit 1; fi' >> "$mutant_suite"
-    printf '%s\n' 'echo setup; sed -Ei '\''s/x/y/'\'' mutant' >> "$mutant_suite"
-    printf '%s\n' 'run "sed" --in-place '\''s/x/y/'\'' mutant' >> "$mutant_suite"
-    printf '%s\n' 'env MODE=test /usr/bin/sed -i '\''s/x/y/'\'' mutant' >> "$mutant_suite"
-    printf '%s\n' 'env -i sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
-    printf '%s\n' 'env -uPATH sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
-    printf '%s\n' 'env -C/tmp sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
-    printf '%s\n' 'command -- sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
-    printf '%s\n' 'time -p sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
-    printf '%s\n' 'run -127 sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
-    printf '%s\n' 'run --separate-stderr sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
-    printf '%s\n' 'run --keep-empty-lines sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
-    printf '%s\n' 'run -- sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
-    printf '%s\n' 'exec -c sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
-    printf '%s\n' 'exec -cl sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
-    printf '%s\n' 'exec -lc sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
-    printf '%s\n' 'exec -a replacement sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
-    printf '%s\n' 'exec -cla replacement sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
-    printf '%s\n' 'sudo -u nobody sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
-    printf '%s\n' '>/tmp/customer-binding-mutant sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
-    run assert_no_direct_in_place_sed "$mutant_suite"
-    if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
-        echo "wrapped in-place sed mutants were not rejected (status=${status}): ${output}" >&2
-        return 1
-    fi
-
-    cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
-    printf 'ignored=\140sed --in-place -e "s/x/y/" mutant\140\n' >> "$mutant_suite"
-    printf 'quoted="\140sed -i.bak s/x/y/ mutant\140"\n' >> "$mutant_suite"
-    printf 'sequential="before \140printf ok\140 middle \140sed -i.bak s/x/y/ mutant\140 after"\n' >> "$mutant_suite"
-    printf '\140true\140 sed -i.bak s/x/y/ mutant\n' >> "$mutant_suite"
-    printf 'MODE=\140true\140 sed -i.bak s/x/y/ mutant\n' >> "$mutant_suite"
-    printf '\140true\140sed -i.bak s/x/y/ mutant\n' >> "$mutant_suite"
-    run assert_no_direct_in_place_sed "$mutant_suite"
-    if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
-        echo "legacy backtick sed mutants were not rejected (status=${status}): ${output}" >&2
-        return 1
-    fi
-
-    cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
-    printf '%s\n' '# Never use sed -i.bak here.' >> "$mutant_suite"
-    printf '%s\n' 'echo sed -i.bak is forbidden' >> "$mutant_suite"
-    printf '%s\n' 'printf '\''%s\n'\'' '\''sed -i.bak is forbidden'\''' >> "$mutant_suite"
-    printf '%s\n' 'message="sed -i.bak is forbidden"' >> "$mutant_suite"
-    printf '%s\n' 'echo "quoted separator; sed -i.bak is forbidden"' >> "$mutant_suite"
-    printf '%s\n' 'env -u sed echo allowed' >> "$mutant_suite"
-    printf '%s\n' 'env -used echo allowed' >> "$mutant_suite"
-    printf '%s\n' 'command -v sed' >> "$mutant_suite"
-    printf '%s\n' 'sudo -u sed echo allowed' >> "$mutant_suite"
-    printf '%s\n' 'time -p echo sed -i.bak is forbidden' >> "$mutant_suite"
-    printf '%s\n' 'run -127 echo sed -i.bak is forbidden' >> "$mutant_suite"
-    printf '%s\n' 'run -- echo sed -i.bak is forbidden' >> "$mutant_suite"
-    printf '%s\n' 'exec -a sed echo allowed' >> "$mutant_suite"
-    printf '%s\n' 'exec -cla sed echo allowed' >> "$mutant_suite"
-    printf "literal='\\140sed --in-place -e s/x/y/ mutant\\140'\n" >> "$mutant_suite"
-    printf 'escaped=\134\140sed --in-place -e s/x/y/ mutant\134\140\n' >> "$mutant_suite"
-    printf 'message="before \140printf ok\140 sed -i.bak is literal prose"\n' >> "$mutant_suite"
-    printf 'escaped_message="before \134\140sed -i.bak\134\140 after"\n' >> "$mutant_suite"
-    printf 'echo \140true\140 sed -i.bak is literal prose\n' >> "$mutant_suite"
-    run assert_no_direct_in_place_sed "$mutant_suite"
-    if [ "$status" -ne 0 ]; then
-        echo "inert sed prose was treated as executable (status=${status}): ${output}" >&2
+        echo "real portable helper mutation was not rejected (status=${status}): ${output}" >&2
         return 1
     fi
 
@@ -1738,7 +1516,8 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
         echo "byte-oriented scan rejected inert non-UTF-8 input (status=${status}): ${output}" >&2
         return 1
     fi
-    printf '%s\n' "sed --in-place -E 's/x/y/' mutant" >> "$mutant_suite"
+    printf '%s %s -E '\''s/x/y/'\'' mutant\n' \
+        "$command_token" "$long_option" >> "$mutant_suite"
     run assert_no_direct_in_place_sed "$mutant_suite"
     if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
         echo "byte-oriented scan missed executable sed (status=${status}): ${output}" >&2

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -37,28 +37,101 @@ assert_no_direct_in_place_sed() {
     local violations
 
     if ! violations="$(awk '
-        function inspect(line, line_number, args, count, i, token, tokens) {
-            if (!match(line, /(^|[;&|()[:space:]])(([^[:space:]"]*\/)?sed|"([^"]*\/)?sed"|\047([^\047]*\/)?sed\047)[[:space:]]+/)) {
-                return
-            }
-            args = substr(line, RSTART + RLENGTH)
-            count = split(args, tokens, /[[:space:]]+/)
-            for (i = 1; i <= count; i++) {
-                token = tokens[i]
-                if (token ~ /^--in-place(=.*)?$/ || token ~ /^-[A-Za-z]*i/) {
-                    print line_number ":" line
-                    return
+        function inspect(line, line_number, line_len, pos, char, quote, value,
+                         count, i, expect_command, sed_command, values, kinds) {
+            line_len = length(line)
+            pos = 1
+            count = 0
+            while (pos <= line_len) {
+                char = substr(line, pos, 1)
+                if (char ~ /[[:space:]]/) {
+                    pos++
+                    continue
                 }
+                if (char == "#") {
+                    break
+                }
+                if (char ~ /[;&|(){}]/) {
+                    values[++count] = char
+                    kinds[count] = "separator"
+                    pos++
+                    continue
+                }
+
+                value = ""
+                quote = ""
+                while (pos <= line_len) {
+                    char = substr(line, pos, 1)
+                    if (quote == "" && (char ~ /[[:space:]]/ || char ~ /[;&|(){}]/)) {
+                        break
+                    }
+                    if (quote == "" && (char == "\"" || char == "\047")) {
+                        quote = char
+                        pos++
+                        continue
+                    }
+                    if (quote != "" && char == quote) {
+                        quote = ""
+                        pos++
+                        continue
+                    }
+                    if (quote != "\047" && char == "\\" && pos < line_len) {
+                        pos++
+                        value = value substr(line, pos, 1)
+                        pos++
+                        continue
+                    }
+                    value = value char
+                    pos++
+                }
+                values[++count] = value
+                kinds[count] = "word"
+            }
+
+            expect_command = 1
+            sed_command = 0
+            for (i = 1; i <= count; i++) {
+                if (kinds[i] == "separator") {
+                    expect_command = 1
+                    sed_command = 0
+                    continue
+                }
+                value = values[i]
+                if (sed_command) {
+                    if (value ~ /^--in-place(=.*)?$/ || value ~ /^-[A-Za-z]*i/) {
+                        print line_number ":" line
+                        return
+                    }
+                    continue
+                }
+                if (!expect_command) {
+                    continue
+                }
+                if (value ~ /^[A-Za-z_][A-Za-z0-9_]*=/ ||
+                    value ~ /^(if|then|elif|while|until|do|!|run|command|env|sudo|builtin|exec|time)$/) {
+                    continue
+                }
+                if (value == "sed" || value ~ /\/sed$/) {
+                    sed_command = 1
+                    expect_command = 0
+                    continue
+                }
+                expect_command = 0
             }
         }
         {
+            physical_line = $0
+            continued = physical_line ~ /\\[[:space:]]*$/
+            if (continued) {
+                sub(/\\[[:space:]]*$/, "", physical_line)
+            }
             if (logical_line == "") {
-                logical_line = $0
+                logical_line = physical_line
                 logical_line_number = FNR
             } else {
-                logical_line = logical_line "\n" $0
+                logical_line = logical_line " " physical_line
             }
-            if ($0 ~ /\\[[:space:]]*$/) {
+            if (continued) {
                 next
             }
             inspect(logical_line, logical_line_number)
@@ -1419,6 +1492,29 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     run assert_no_direct_in_place_sed "$mutant_suite"
     if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
         echo "quoted sed path mutants were not rejected (status=${status}): ${output}" >&2
+        return 1
+    fi
+
+    cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
+    printf '%s\n' 'if ! sed -i.bak '\''s/x/y/'\'' mutant; then exit 1; fi' >> "$mutant_suite"
+    printf '%s\n' 'echo setup; sed -Ei '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    printf '%s\n' 'run "sed" --in-place '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    printf '%s\n' 'env MODE=test /usr/bin/sed -i '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    run assert_no_direct_in_place_sed "$mutant_suite"
+    if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
+        echo "wrapped in-place sed mutants were not rejected (status=${status}): ${output}" >&2
+        return 1
+    fi
+
+    cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
+    printf '%s\n' '# Never use sed -i.bak here.' >> "$mutant_suite"
+    printf '%s\n' 'echo sed -i.bak is forbidden' >> "$mutant_suite"
+    printf '%s\n' 'printf '\''%s\n'\'' '\''sed -i.bak is forbidden'\''' >> "$mutant_suite"
+    printf '%s\n' 'message="sed -i.bak is forbidden"' >> "$mutant_suite"
+    printf '%s\n' 'echo "quoted separator; sed -i.bak is forbidden"' >> "$mutant_suite"
+    run assert_no_direct_in_place_sed "$mutant_suite"
+    if [ "$status" -ne 0 ]; then
+        echo "inert sed prose was treated as executable (status=${status}): ${output}" >&2
         return 1
     fi
 

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -23,7 +23,8 @@ template_has_exact_binding_bullets() {
 
     item_count="$(grep -cE '^- \*\*[0-9]+\. ' "$file")"
     [ "$item_count" -gt 0 ] || return 1
-    [ "$(grep -cE '^customer_binding_from:' "$file")" -eq 1 ] || return 1
+    [ "$(grep -cE '^schema_version: 4$' "$file")" -eq 1 ] || return 1
+    [ "$(grep -cE '^customer_binding_from:' "$file")" -eq 0 ] || return 1
     for field in customer_derived requirement_id surface_class visitor_visible delivery_receipt; do
         [ "$(grep -cE "^  - ${field}:" "$file")" -eq "$item_count" ] || return 1
     done
@@ -45,7 +46,6 @@ write_expectations() {
 task_id: $id
 artifact: expectations
 schema_version: $schema
-$(if [ "$schema" -eq 4 ]; then printf '%s\n' 'customer_binding_from: customer-outcome'; fi)
 captured_at: 2026-08-24
 captured_by: /dr-prd
 status: canonical
@@ -81,9 +81,8 @@ valid_customer_binding() {
 EOF
 }
 
-write_cutover_expectations() {
+write_migrated_expectations() {
     local id="$1"
-    local marker="${2:-appended-customer-wish}"
     local root="${BATS_TEST_TMPDIR}/${id}"
     local file="${root}/datarim/tasks/${id}-expectations.md"
     mkdir -p "$(dirname "$file")"
@@ -92,7 +91,6 @@ write_cutover_expectations() {
 task_id: $id
 artifact: expectations
 schema_version: 4
-customer_binding_from: $marker
 captured_at: 2026-05-14
 captured_by: /dr-prd
 status: amended
@@ -102,6 +100,7 @@ status: amended
 
 - **1. Preserved legacy wish.**
   - wish_id: preserved-legacy-wish
+  - customer_derived: false
   - evidence_type: static
   - #### История статусов
     - 2026-05-14T00:00:00Z / 2026-05-14 00:00 (UTC) · pending → pending · /dr-prd · reason: item created
@@ -276,92 +275,79 @@ EOF
         && [[ "$output" == *"surface_class and visitor_visible disagree"* ]]
 }
 
-@test "schema v4 legacy cutover preserves old wishes and governs mixed appended wishes" {
+@test "schema v4 accepts a complete metadata-only migration with mixed wishes" {
     local id="BIND-0008"
     local root
-    root="$(write_cutover_expectations "$id")"
+    root="$(write_migrated_expectations "$id")"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 0 ]
 }
 
-@test "schema v4 amended file rejects moving cutover forward past a bound wish" {
+@test "schema v4 amended file rejects a missing preexisting discriminator" {
     local id="BIND-0017"
     local root
-    root="$(write_cutover_expectations "$id")"
-    sed -i 's/customer_binding_from: appended-customer-wish/customer_binding_from: appended-internal-wish/' \
-        "$root/datarim/tasks/${id}-expectations.md"
-
-    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
-    [ "$status" -eq 1 ] \
-        && [[ "$output" == *"customer binding field appears before customer_binding_from"* ]]
-}
-
-@test "schema v4 rejects coordinated binding strip and cutover advance" {
-    local id="BIND-0020"
-    local root
     local file
-    root="$(write_cutover_expectations "$id")"
+    root="$(write_migrated_expectations "$id")"
     file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i 's/customer_binding_from: appended-customer-wish/customer_binding_from: appended-internal-wish/' "$file"
-    sed -E -i.bak '/^- \*\*2\./,/^- \*\*3\./ { /^  - (customer_derived|requirement_id|surface_class|visitor_visible|delivery_receipt):/d; }' "$file"
+    sed -E -i.bak '/^- \*\*1\./,/^- \*\*2\./ { /^  - customer_derived:/d; }' "$file"
     rm -f "${file}.bak"
-
-    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
-    [ "$status" -eq 1 ] \
-        && [[ "$output" == *"schema v4 must start customer binding at its first wish"* ]]
-}
-
-@test "verify blocks coordinated binding strip and cutover advance" {
-    local id="BIND-0021"
-    local root
-    local file
-    root="$(write_cutover_expectations "$id")"
-    file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i 's/customer_binding_from: appended-customer-wish/customer_binding_from: appended-internal-wish/' "$file"
-    sed -E -i.bak '/^- \*\*2\./,/^- \*\*3\./ { /^  - (customer_derived|requirement_id|surface_class|visitor_visible|delivery_receipt):/d; }' "$file"
-    rm -f "${file}.bak"
-
-    run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
-    [ "$status" -eq 1 ] \
-        && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
-}
-
-@test "verify mode blocks a schema v4 cutover moved past a bound wish" {
-    local id="BIND-0019"
-    local root
-    root="$(write_cutover_expectations "$id")"
-    sed -i 's/customer_binding_from: appended-customer-wish/customer_binding_from: appended-internal-wish/' \
-        "$root/datarim/tasks/${id}-expectations.md"
-
-    run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
-    [ "$status" -eq 1 ] \
-        && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
-}
-
-@test "schema v4 amended file rejects moving cutover backward into a legacy wish" {
-    local id="BIND-0018"
-    local root
-    root="$(write_cutover_expectations "$id" preserved-legacy-wish)"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 1 ] \
         && [[ "$output" == *"missing customer_derived"* ]]
 }
 
-@test "schema v4 rejects a cutover marker that names no wish" {
-    local id="BIND-0009"
+@test "schema v4 rejects coordinated binding strip and cutover advance" {
+    local id="BIND-0020"
     local root
-    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
-    sed -i 's/customer_binding_from: customer-outcome/customer_binding_from: missing-wish/' \
-        "$root/datarim/tasks/${id}-expectations.md"
+    local file
+    root="$(write_migrated_expectations "$id")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i.bak '/^schema_version: 4$/a\
+customer_binding_from: appended-internal-wish' "$file"
+    rm -f "${file}.bak"
+    sed -E -i.bak '/^- \*\*2\./,/^- \*\*3\./ { /^  - (customer_derived|requirement_id|surface_class|visitor_visible|delivery_receipt):/d; }' "$file"
+    rm -f "${file}.bak"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 1 ] \
-        && [[ "$output" == *"customer_binding_from does not name a wish_id"* ]]
+        && [[ "$output" == *"customer_binding_from is obsolete in schema_version=4"* ]]
 }
 
-@test "schema v4 canonical file requires cutover at the first wish" {
+@test "verify blocks coordinated binding strip and cutover advance" {
+    local id="BIND-0021"
+    local root
+    local file
+    root="$(write_migrated_expectations "$id")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i.bak '/^schema_version: 4$/a\
+customer_binding_from: appended-internal-wish' "$file"
+    rm -f "${file}.bak"
+    sed -E -i.bak '/^- \*\*2\./,/^- \*\*3\./ { /^  - (customer_derived|requirement_id|surface_class|visitor_visible|delivery_receipt):/d; }' "$file"
+    rm -f "${file}.bak"
+
+    run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
+}
+
+@test "schema v4 rejects the obsolete customer binding marker" {
+    local id="BIND-0009"
+    local root
+    local file
+    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i.bak '/^schema_version: 4$/a\
+customer_binding_from: customer-outcome' "$file"
+    rm -f "${file}.bak"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"customer_binding_from is obsolete in schema_version=4"* ]]
+}
+
+@test "schema v4 canonical file governs its first wish" {
     local id="BIND-0015"
     local root="${BATS_TEST_TMPDIR}/${id}"
     local file="${root}/datarim/tasks/${id}-expectations.md"
@@ -371,7 +357,6 @@ EOF
 task_id: $id
 artifact: expectations
 schema_version: 4
-customer_binding_from: second-wish
 captured_at: 2026-08-24
 captured_by: /dr-prd
 status: canonical
@@ -399,7 +384,7 @@ EOF
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 1 ] \
-        && [[ "$output" == *"canonical schema v4 must start customer binding at its first wish"* ]]
+        && [[ "$output" == *"item 1 missing customer_derived"* ]]
 }
 
 @test "schema v4 rejects an invalid frontmatter status" {
@@ -522,6 +507,24 @@ EOF
     done
 }
 
+@test "legacy schema versions v1 through v3 reject an invalid frontmatter status" {
+    local schema
+    local id
+    local root
+    local file
+    for schema in 1 2 3; do
+        id="STAT-000${schema}"
+        root="$(write_expectations "$id" "$schema")"
+        file="$root/datarim/tasks/${id}-expectations.md"
+        sed -i 's/status: canonical/status: canonica1/' "$file"
+        run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"frontmatter status must be 'canonical' or 'amended'"* ]]; then
+            echo "legacy schema v${schema} accepted invalid status: ${output}" >&2
+            return 1
+        fi
+    done
+}
+
 @test "expectations contract makes customer binding mandatory without invalidating legacy files" {
     assert_contains "$EXPECTATIONS_SKILL" 'schema_version: 4' || return 1
     assert_contains "$EXPECTATIONS_SKILL" 'customer_binding_from' || return 1
@@ -531,6 +534,8 @@ EOF
     assert_contains "$EXPECTATIONS_SKILL" 'visitor_visible' || return 1
     assert_contains "$EXPECTATIONS_SKILL" 'delivery_receipt' || return 1
     assert_contains "$EXPECTATIONS_SKILL" 'Legacy expectations files' || return 1
+    assert_contains "$EXPECTATIONS_SKILL" 'MUST NOT receive new wishes' || return 1
+    assert_contains "$EXPECTATIONS_SKILL" 'metadata-only migration' || return 1
     assert_contains "$EXPECTATIONS_SKILL" 'remain valid without these fields'
 }
 

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -19,6 +19,8 @@ assert_contains() {
     [[ -f "$DELIVERY_SKILL" ]]
     assert_contains "$DELIVERY_SKILL" 'name: customer-delivery'
     assert_contains "$DELIVERY_SKILL" 'description:'
+    description="$(sed -n 's/^description: //p' "$DELIVERY_SKILL")"
+    [[ "${#description}" -le 155 ]]
     [[ "$(grep -cE '^## U[1-8]\.' "$DELIVERY_SKILL")" -eq 8 ]]
     ! grep -Eq '[A-Z]{2,10}-[0-9]{4}' "$DELIVERY_SKILL"
 }

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -52,7 +52,7 @@ assert_no_direct_in_place_sed() {
                 if (char == "#") {
                     break
                 }
-                if (char ~ /[;&|(){}]/) {
+                if (char ~ /[;&|(){}]/ || char == "`") {
                     values[++count] = char
                     kinds[count] = "separator"
                     pos++
@@ -63,7 +63,8 @@ assert_no_direct_in_place_sed() {
                 quote = ""
                 while (pos <= line_len) {
                     char = substr(line, pos, 1)
-                    if (quote == "" && (char ~ /[[:space:]]/ || char ~ /[;&|(){}]/)) {
+                    if ((quote == "" && (char ~ /[[:space:]]/ || char ~ /[;&|(){}]/ || char == "`")) ||
+                        (quote == "\"" && char == "`")) {
                         break
                     }
                     if (quote == "" && (char == "\"" || char == "\047")) {
@@ -279,10 +280,14 @@ workflow_run_block_has_suite() {
         in_run {
             text = $0
             sub(/^[[:space:]]+/, "", text)
-            if (text ~ /^#/) {
+            if (text == "" || text ~ /^#/) {
                 next
             }
-            if (text ~ /^bats[[:space:]]*\\[[:space:]]*$/) {
+            if (!command_seen && text == "set -euo pipefail") {
+                next
+            }
+            if (!command_seen && text ~ /^bats[[:space:]]*\\[[:space:]]*$/) {
+                command_seen = 1
                 in_bats = 1
                 next
             }
@@ -295,6 +300,10 @@ workflow_run_block_has_suite() {
                 if (!continued) {
                     in_bats = 0
                 }
+                next
+            }
+            if (!command_seen) {
+                exit 1
             }
         }
         END {
@@ -1559,6 +1568,16 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     cp "${REPO_ROOT}/.github/workflows/bats.yml" "$mutant_workflow"
     portable_sed_in_place '/^[[:space:]]*tests\/customer-requirement-expectations-binding\.bats/c\
             # tests/customer-requirement-expectations-binding.bats' "$mutant_workflow"
+    portable_sed_in_place '/^      - name: Run CI dependency and portability contracts/i\
+          cat <<'\''PORTABILITY_DECOY'\''\
+          bats \\\
+            tests/customer-requirement-expectations-binding.bats\
+          PORTABILITY_DECOY\
+          cat <<PORTABILITY_DECOY_UNQUOTED\
+          bats \\\
+            tests/customer-requirement-expectations-binding.bats\
+          PORTABILITY_DECOY_UNQUOTED\
+' "$mutant_workflow"
 
     for direct_command in \
         "sed --in-place -E 's/x/y/' mutant" \
@@ -1629,6 +1648,15 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     fi
 
     cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
+    printf 'ignored=\140sed --in-place -e "s/x/y/" mutant\140\n' >> "$mutant_suite"
+    printf 'quoted="\140sed -i.bak s/x/y/ mutant\140"\n' >> "$mutant_suite"
+    run assert_no_direct_in_place_sed "$mutant_suite"
+    if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
+        echo "legacy backtick sed mutants were not rejected (status=${status}): ${output}" >&2
+        return 1
+    fi
+
+    cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
     printf '%s\n' '# Never use sed -i.bak here.' >> "$mutant_suite"
     printf '%s\n' 'echo sed -i.bak is forbidden' >> "$mutant_suite"
     printf '%s\n' 'printf '\''%s\n'\'' '\''sed -i.bak is forbidden'\''' >> "$mutant_suite"
@@ -1643,6 +1671,8 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     printf '%s\n' 'run -- echo sed -i.bak is forbidden' >> "$mutant_suite"
     printf '%s\n' 'exec -a sed echo allowed' >> "$mutant_suite"
     printf '%s\n' 'exec -cla sed echo allowed' >> "$mutant_suite"
+    printf "literal='\\140sed --in-place -e s/x/y/ mutant\\140'\n" >> "$mutant_suite"
+    printf 'escaped=\134\140sed --in-place -e s/x/y/ mutant\134\140\n' >> "$mutant_suite"
     run assert_no_direct_in_place_sed "$mutant_suite"
     if [ "$status" -ne 0 ]; then
         echo "inert sed prose was treated as executable (status=${status}): ${output}" >&2

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -156,20 +156,20 @@ assert_no_direct_in_place_sed() {
                     }
                     wrapper = ""
                 } else if (wrapper == "run") {
-                    if (value == "!" || value ~ /^-[0-9]+$/ ||
+                    if (value ~ /^(--|!)$/ || value ~ /^-[0-9]+$/ ||
                         value ~ /^(--separate-stderr|--keep-empty-lines)$/) {
                         continue
                     }
                     wrapper = ""
                 } else if (wrapper == "exec") {
-                    if (value ~ /^(--|-c|-l)$/) {
+                    if (value == "--" || value ~ /^-[cl]+$/) {
                         continue
                     }
-                    if (value == "-a") {
+                    if (value == "-a" || value ~ /^-[cl]+a$/) {
                         skip_wrapper_arg = 1
                         continue
                     }
-                    if (value ~ /^-a.+/) {
+                    if (value ~ /^-[cl]*a.+/) {
                         continue
                     }
                     wrapper = ""
@@ -1614,8 +1614,12 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     printf '%s\n' 'run -127 sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
     printf '%s\n' 'run --separate-stderr sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
     printf '%s\n' 'run --keep-empty-lines sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    printf '%s\n' 'run -- sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
     printf '%s\n' 'exec -c sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    printf '%s\n' 'exec -cl sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    printf '%s\n' 'exec -lc sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
     printf '%s\n' 'exec -a replacement sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
+    printf '%s\n' 'exec -cla replacement sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
     printf '%s\n' 'sudo -u nobody sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
     printf '%s\n' '>/tmp/customer-binding-mutant sed -i.bak '\''s/x/y/'\'' mutant' >> "$mutant_suite"
     run assert_no_direct_in_place_sed "$mutant_suite"
@@ -1636,7 +1640,9 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     printf '%s\n' 'sudo -u sed echo allowed' >> "$mutant_suite"
     printf '%s\n' 'time -p echo sed -i.bak is forbidden' >> "$mutant_suite"
     printf '%s\n' 'run -127 echo sed -i.bak is forbidden' >> "$mutant_suite"
+    printf '%s\n' 'run -- echo sed -i.bak is forbidden' >> "$mutant_suite"
     printf '%s\n' 'exec -a sed echo allowed' >> "$mutant_suite"
+    printf '%s\n' 'exec -cla sed echo allowed' >> "$mutant_suite"
     run assert_no_direct_in_place_sed "$mutant_suite"
     if [ "$status" -ne 0 ]; then
         echo "inert sed prose was treated as executable (status=${status}): ${output}" >&2

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -672,7 +672,8 @@ EOF
 `` and are not active bindings.' "$file"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
-    [ "$status" -eq 1 ] && [[ "$output" == *"missing requirement_id"* ]] || return 1
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"unclosed inline code span before block boundary"* ]] || return 1
 
     run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
     [ "$status" -eq 1 ] \
@@ -783,6 +784,67 @@ EOF
     run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
     [ "$status" -eq 1 ] \
         && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
+}
+
+@test "inline code spans cannot cross CommonMark block boundaries" {
+    local id="COMM-0010"
+    local variant
+    local root
+    local file
+    for variant in blank heading fence item; do
+        root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+        file="$root/datarim/tasks/${id}-expectations.md"
+        case "$variant" in
+            blank)
+                cat >> "$file" <<'EOF'
+Paragraph `opens
+
+and closes` after a blank block boundary.
+EOF
+                ;;
+            heading)
+                cat >> "$file" <<'EOF'
+Paragraph `opens
+## A new block
+and closes` after a heading boundary.
+EOF
+                ;;
+            fence)
+                cat >> "$file" <<'EOF'
+Paragraph `opens
+~~~text
+and closes` after a fence boundary.
+~~~
+EOF
+                ;;
+            item)
+                cat >> "$file" <<'EOF'
+Paragraph `opens
+- **2. Hidden unbound wish.**
+  - wish_id: hidden-unbound-wish
+  - evidence_type: static
+  - #### История статусов
+    - 2026-08-24T00:00:00Z / 2026-08-24 00:00 (UTC) · pending → pending · /dr-prd · reason: item created
+  - #### Текущий статус
+    - pending
+and closes` after an item boundary.
+EOF
+                ;;
+        esac
+
+        run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"unclosed inline code span before block boundary"* ]]; then
+            echo "code span crossed ${variant} boundary in task mode: ${output}" >&2
+            return 1
+        fi
+
+        run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"BLOCKED: expectations file fails structural validation"* ]]; then
+            echo "code span crossed ${variant} boundary in verify mode: ${output}" >&2
+            return 1
+        fi
+        rm -rf "$root"
+    done
 }
 
 @test "schema validation rejects duplicate frontmatter keys in task and verify modes" {

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -18,6 +18,7 @@ assert_contains() {
     [[ -f "$DELIVERY_SKILL" ]]
     assert_contains "$DELIVERY_SKILL" 'name: customer-delivery'
     assert_contains "$DELIVERY_SKILL" 'description:'
+    [[ "$(grep -cE '^## U[1-8]\.' "$DELIVERY_SKILL")" -eq 8 ]]
     ! grep -Eq '[A-Z]{2,10}-[0-9]{4}' "$DELIVERY_SKILL"
 }
 
@@ -75,11 +76,11 @@ assert_contains() {
 }
 
 @test "expectations contract makes customer binding mandatory without invalidating legacy files" {
+    assert_contains "$EXPECTATIONS_SKILL" 'Every new wish derived from a customer remark MUST carry these four fields:'
     assert_contains "$EXPECTATIONS_SKILL" 'requirement_id'
     assert_contains "$EXPECTATIONS_SKILL" 'surface_class'
     assert_contains "$EXPECTATIONS_SKILL" 'visitor_visible'
     assert_contains "$EXPECTATIONS_SKILL" 'delivery_receipt'
-    assert_contains "$EXPECTATIONS_SKILL" 'MUST'
     assert_contains "$EXPECTATIONS_SKILL" 'Legacy expectations files'
     assert_contains "$EXPECTATIONS_SKILL" 'remain valid without these fields'
 }

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -36,7 +36,7 @@ assert_no_direct_in_place_sed() {
     local file="$1"
     local violations
 
-    if ! violations="$(awk '
+    if ! violations="$(LC_ALL=C awk '
         function inspect(line, line_number, line_len, pos, char, quote, value,
                          count, i, expect_command, sed_command, wrapper,
                          skip_wrapper_arg, skip_redirection_arg, values, kinds) {
@@ -1646,6 +1646,20 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     run assert_no_direct_in_place_sed "$mutant_suite"
     if [ "$status" -ne 0 ]; then
         echo "inert sed prose was treated as executable (status=${status}): ${output}" >&2
+        return 1
+    fi
+
+    cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
+    printf '\377\n' >> "$mutant_suite"
+    run assert_no_direct_in_place_sed "$mutant_suite"
+    if [ "$status" -ne 0 ]; then
+        echo "byte-oriented scan rejected inert non-UTF-8 input (status=${status}): ${output}" >&2
+        return 1
+    fi
+    printf '%s\n' "sed --in-place -E 's/x/y/' mutant" >> "$mutant_suite"
+    run assert_no_direct_in_place_sed "$mutant_suite"
+    if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
+        echo "byte-oriented scan missed executable sed (status=${status}): ${output}" >&2
         return 1
     fi
 

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+    DELIVERY_SKILL="${REPO_ROOT}/skills/customer-delivery/SKILL.md"
+    EXPECTATIONS_SKILL="${REPO_ROOT}/skills/expectations-checklist/SKILL.md"
+    EXPECTATIONS_TEMPLATE="${REPO_ROOT}/templates/expectations-template.md"
+}
+
+assert_contains() {
+    local file="$1"
+    local literal="$2"
+
+    grep -Fq -- "$literal" "$file"
+}
+
+@test "customer delivery skill is a valid history-agnostic skill entrypoint" {
+    [[ -f "$DELIVERY_SKILL" ]]
+    assert_contains "$DELIVERY_SKILL" 'name: customer-delivery'
+    assert_contains "$DELIVERY_SKILL" 'description:'
+    ! grep -Eq '[A-Z]{2,10}-[0-9]{4}' "$DELIVERY_SKILL"
+}
+
+@test "customer delivery skill preserves verbatim remarks under atomic stable requirement IDs" {
+    assert_contains "$DELIVERY_SKILL" 'verbatim'
+    assert_contains "$DELIVERY_SKILL" 'atomic'
+    assert_contains "$DELIVERY_SKILL" 'stable Requirement ID'
+    assert_contains "$DELIVERY_SKILL" 'paraphrase'
+}
+
+@test "customer delivery skill defines the complete acceptance and pre-work contracts" {
+    for literal in \
+        'before-state' 'after-state' 'evidence method' 'responsible owner' \
+        'role' 'skill' 'blueprint' 'constraint' 'policy' 'success criterion' \
+        'selected before implementation starts' 'post-hoc attribution' \
+        'Gap' 'Unbound'; do
+        assert_contains "$DELIVERY_SKILL" "$literal"
+    done
+}
+
+@test "customer delivery skill defines coverage closure and review evolution semantics" {
+    for literal in \
+        'red/green evidence' 'merged revision' 'deployed revision' \
+        'live evidence' 'customer disposition' 'NOT MET' \
+        'green CI != deployed' 'deployed != visually accepted' \
+        'enabling work != customer outcome' 'derived from the Requirement graph' \
+        'ABSENT' 'WEAK' 'STALE' 'MIS_SCOPED' 'NOT_BOUND' 'NO_CANON_CHANGE'; do
+        assert_contains "$DELIVERY_SKILL" "$literal"
+    done
+}
+
+@test "customer delivery skill separates enabling and visitor-visible output" {
+    assert_contains "$DELIVERY_SKILL" 'enabling changes'
+    assert_contains "$DELIVERY_SKILL" 'visitor-visible changes'
+    assert_contains "$DELIVERY_SKILL" 'zero visitor-visible changes'
+    assert_contains "$DELIVERY_SKILL" 'cannot satisfy'
+}
+
+@test "customer delivery skill requires the complete painted visual matrix" {
+    for literal in 'RU' 'EN' 'mobile' 'desktop' 'light' 'dark' 'operator'; do
+        assert_contains "$DELIVERY_SKILL" "$literal"
+    done
+    assert_contains "$DELIVERY_SKILL" 'cannot replace'
+}
+
+@test "new customer expectation examples bind requirement surface visibility and receipt" {
+    for literal in \
+        'requirement_id: {req-NNNN}' \
+        'surface_class: {VISITOR_VISIBLE | ENABLING}' \
+        'visitor_visible: {true | false}' \
+        'delivery_receipt: {datarim/receipts/{TASK-ID}-customer-delivery.yaml}'; do
+        count="$(grep -Fc -- "$literal" "$EXPECTATIONS_TEMPLATE")"
+        [[ "$count" -eq 2 ]]
+    done
+}
+
+@test "expectations contract makes customer binding mandatory without invalidating legacy files" {
+    assert_contains "$EXPECTATIONS_SKILL" 'requirement_id'
+    assert_contains "$EXPECTATIONS_SKILL" 'surface_class'
+    assert_contains "$EXPECTATIONS_SKILL" 'visitor_visible'
+    assert_contains "$EXPECTATIONS_SKILL" 'delivery_receipt'
+    assert_contains "$EXPECTATIONS_SKILL" 'MUST'
+    assert_contains "$EXPECTATIONS_SKILL" 'Legacy expectations files'
+    assert_contains "$EXPECTATIONS_SKILL" 'remain valid without these fields'
+}

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -9,6 +9,22 @@ setup() {
     SKILLS_REFERENCE="${REPO_ROOT}/documentation/reference/skills.md"
 }
 
+portable_sed_in_place() {
+    local last_index=$(( $# - 1 ))
+    local args=("$@")
+    local file="${args[$last_index]}"
+    local temp_file
+
+    [ "$last_index" -gt 0 ] || return 2
+    unset 'args[$last_index]'
+    temp_file="$(mktemp "${file}.sed.XXXXXX")" || return 1
+    if ! sed "${args[@]}" "$file" > "$temp_file"; then
+        rm -f "$temp_file"
+        return 1
+    fi
+    mv "$temp_file" "$file"
+}
+
 assert_contains() {
     local file="$1"
     local literal="$2"
@@ -187,7 +203,7 @@ EOF
 @test "commented customer binding bullets do not satisfy the template contract" {
     local mutant="${BATS_TEST_TMPDIR}/commented-bindings.md"
     cp "$EXPECTATIONS_TEMPLATE" "$mutant"
-    sed -E -i 's/^(  - (requirement_id|surface_class|visitor_visible|delivery_receipt):.*)$/<!-- \1 -->/' "$mutant"
+    portable_sed_in_place -E 's/^(  - (requirement_id|surface_class|visitor_visible|delivery_receipt):.*)$/<!-- \1 -->/' "$mutant"
 
     run template_has_exact_binding_bullets "$mutant"
     [ "$status" -ne 0 ]
@@ -290,7 +306,7 @@ EOF
     local file
     root="$(write_migrated_expectations "$id")"
     file="$root/datarim/tasks/${id}-expectations.md"
-    sed -E -i.bak '/^- \*\*1\./,/^- \*\*2\./ { /^  - customer_derived:/d; }' "$file"
+    portable_sed_in_place -E '/^- \*\*1\./,/^- \*\*2\./ { /^  - customer_derived:/d; }' "$file"
     rm -f "${file}.bak"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
@@ -304,10 +320,10 @@ EOF
     local file
     root="$(write_migrated_expectations "$id")"
     file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i.bak '/^schema_version: 4$/a\
+    portable_sed_in_place '/^schema_version: 4$/a\
 customer_binding_from: appended-internal-wish' "$file"
     rm -f "${file}.bak"
-    sed -E -i.bak '/^- \*\*2\./,/^- \*\*3\./ { /^  - (customer_derived|requirement_id|surface_class|visitor_visible|delivery_receipt):/d; }' "$file"
+    portable_sed_in_place -E '/^- \*\*2\./,/^- \*\*3\./ { /^  - (customer_derived|requirement_id|surface_class|visitor_visible|delivery_receipt):/d; }' "$file"
     rm -f "${file}.bak"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
@@ -321,10 +337,10 @@ customer_binding_from: appended-internal-wish' "$file"
     local file
     root="$(write_migrated_expectations "$id")"
     file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i.bak '/^schema_version: 4$/a\
+    portable_sed_in_place '/^schema_version: 4$/a\
 customer_binding_from: appended-internal-wish' "$file"
     rm -f "${file}.bak"
-    sed -E -i.bak '/^- \*\*2\./,/^- \*\*3\./ { /^  - (customer_derived|requirement_id|surface_class|visitor_visible|delivery_receipt):/d; }' "$file"
+    portable_sed_in_place -E '/^- \*\*2\./,/^- \*\*3\./ { /^  - (customer_derived|requirement_id|surface_class|visitor_visible|delivery_receipt):/d; }' "$file"
     rm -f "${file}.bak"
 
     run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
@@ -344,7 +360,8 @@ customer_binding_from: appended-internal-wish' "$file"
         [ "$schema" -eq 4 ] && binding="$(valid_customer_binding "$id")"
         root="$(write_expectations "$id" "$schema" "$binding")"
         file="$root/datarim/tasks/${id}-expectations.md"
-        sed -i "/^schema_version: ${schema}$/a customer_binding_from: customer-outcome" "$file"
+        portable_sed_in_place "/^schema_version: ${schema}$/a\\
+customer_binding_from: customer-outcome" "$file"
 
         run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
         if [ "$status" -ne 1 ] || [[ "$output" != *"customer_binding_from is obsolete"* ]]; then
@@ -407,7 +424,7 @@ EOF
     local file
     root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
     file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i 's/status: canonical/status: canonica1/' "$file"
+    portable_sed_in_place 's/status: canonical/status: canonica1/' "$file"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 1 ] \
@@ -420,7 +437,7 @@ EOF
     local file
     root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
     file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i 's/status: canonical/status: canonica1/' "$file"
+    portable_sed_in_place 's/status: canonical/status: canonica1/' "$file"
 
     run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
     [ "$status" -eq 1 ] \
@@ -449,34 +466,34 @@ EOF
         if [ "$variant" = "duplicate_value" ]; then
             root="$(write_migrated_expectations "$id")"
             file="$root/datarim/tasks/${id}-expectations.md"
-            sed -i 's/wish_id: appended-internal-wish/wish_id: preserved-legacy-wish/' "$file"
+            portable_sed_in_place 's/wish_id: appended-internal-wish/wish_id: preserved-legacy-wish/' "$file"
             expected="duplicate wish_id value 'preserved-legacy-wish'"
         else
             root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
             file="$root/datarim/tasks/${id}-expectations.md"
             case "$variant" in
                 invalid_space)
-                    sed -i 's/wish_id: customer-outcome/wish_id: not a kebab slug/' "$file"
+                    portable_sed_in_place 's/wish_id: customer-outcome/wish_id: not a kebab slug/' "$file"
                     expected="wish_id must be a kebab slug"
                     ;;
                 invalid_underscore)
-                    sed -i 's/wish_id: customer-outcome/wish_id: not_a_kebab_slug/' "$file"
+                    portable_sed_in_place 's/wish_id: customer-outcome/wish_id: not_a_kebab_slug/' "$file"
                     expected="wish_id must be a kebab slug"
                     ;;
                 invalid_empty_segment)
-                    sed -i 's/wish_id: customer-outcome/wish_id: empty--segment/' "$file"
+                    portable_sed_in_place 's/wish_id: customer-outcome/wish_id: empty--segment/' "$file"
                     expected="wish_id must be a kebab slug"
                     ;;
                 invalid_separator)
-                    sed -i 's@wish_id: customer-outcome@wish_id: path/segment@' "$file"
+                    portable_sed_in_place 's@wish_id: customer-outcome@wish_id: path/segment@' "$file"
                     expected="wish_id must be a kebab slug"
                     ;;
                 invalid_other_script)
-                    sed -i 's/wish_id: customer-outcome/wish_id: δοκιμή/' "$file"
+                    portable_sed_in_place 's/wish_id: customer-outcome/wish_id: δοκιμή/' "$file"
                     expected="wish_id must be a kebab slug"
                     ;;
                 duplicate_field)
-                    sed -i '/wish_id: customer-outcome/a\
+                    portable_sed_in_place '/wish_id: customer-outcome/a\
   - wish_id: second-focus-key' "$file"
                     expected="duplicate wish_id field"
                     ;;
@@ -506,7 +523,7 @@ EOF
     for slug in 'Outcome-2' 'сохранение-исходного-промпта'; do
         root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
         file="$root/datarim/tasks/${id}-expectations.md"
-        sed -i "s/wish_id: customer-outcome/wish_id: ${slug}/" "$file"
+        portable_sed_in_place "s/wish_id: customer-outcome/wish_id: ${slug}/" "$file"
         run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
         if [ "$status" -ne 0 ]; then
             echo "valid wish_id rejected (${slug}): ${output}" >&2
@@ -571,7 +588,7 @@ EOF
     local id="BIND-0014"
     local root
     root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
-    sed -E -i 's/^(- \*\*1\. Customer outcome\.\*\*)$/<!-- \1 -->/' \
+    portable_sed_in_place -E 's/^(- \*\*1\. Customer outcome\.\*\*)$/<!-- \1 -->/' \
         "$root/datarim/tasks/${id}-expectations.md"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
@@ -585,8 +602,8 @@ EOF
     local file
     root="$(write_migrated_expectations "$id")"
     file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i 's/^- \*\*2\. Appended customer wish\.\*\*$/& <!-- active header trailing comment -->/' "$file"
-    sed -i '/^  - customer_derived: true$/,/^  - delivery_receipt:/d' "$file"
+    portable_sed_in_place 's/^- \*\*2\. Appended customer wish\.\*\*$/& <!-- active header trailing comment -->/' "$file"
+    portable_sed_in_place '/^  - customer_derived: true$/,/^  - delivery_receipt:/d' "$file"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 1 ] \
@@ -607,13 +624,13 @@ EOF
         file="$root/datarim/tasks/${id}-expectations.md"
         case "$variant" in
             single_tick)
-                sed -i '/success criterion/s/$/ `<!--` literal/' "$file"
+                portable_sed_in_place '/success criterion/s/$/ `<!--` literal/' "$file"
                 ;;
             delimiter_run)
-                sed -i '/success criterion/s/$/ ``short ` then <!-- `` literal/' "$file"
+                portable_sed_in_place '/success criterion/s/$/ ``short ` then <!-- `` literal/' "$file"
                 ;;
             escaped)
-                sed -i '/success criterion/s/$/ \\<!-- literal/' "$file"
+                portable_sed_in_place '/success criterion/s/$/ \\<!-- literal/' "$file"
                 grep -Fq '\<!-- literal' "$file" || return 1
                 ;;
         esac
@@ -639,7 +656,7 @@ EOF
     local file
     root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
     file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i '/success criterion/c\
+    portable_sed_in_place '/success criterion/c\
   - Как проверить (success criterion): A ``span opens\
 <!-- remains literal before ` shorter delimiter\
 `` span closes before active bindings.' "$file"
@@ -663,7 +680,7 @@ EOF
     local file
     root="$(write_expectations "$id" 4 '  - customer_derived: true')"
     file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i '/success criterion/c\
+    portable_sed_in_place '/success criterion/c\
   - Как проверить (success criterion): These ``fields are examples:\
   - requirement_id: req-0001\
   - surface_class: VISITOR_VISIBLE\
@@ -686,7 +703,7 @@ EOF
     local file
     root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
     file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i '/success criterion/s/$/ \\`<!--`/' "$file"
+    portable_sed_in_place '/success criterion/s/$/ \\`<!--`/' "$file"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 1 ] && [[ "$output" == *"missing customer_derived"* ]] || return 1
@@ -702,7 +719,7 @@ EOF
     local file
     root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
     file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i 's/wish_id: customer-outcome/wish_id: `not a kebab slug`/' "$file"
+    portable_sed_in_place 's/wish_id: customer-outcome/wish_id: `not a kebab slug`/' "$file"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 1 ] && [[ "$output" == *"wish_id must be a kebab slug"* ]] || return 1
@@ -718,7 +735,7 @@ EOF
     local file
     root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
     file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i '/evidence_type: static/i\
+    portable_sed_in_place '/evidence_type: static/i\
   - verification_mode: reproducible\
   - evidence_artifact: `not-real`' "$file"
     printf '%s\n' 'structured-value collision `not-real`' > "$root/sentinel.sh"
@@ -737,10 +754,10 @@ EOF
     local file
     root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
     file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i '/evidence_type: static/i\
+    portable_sed_in_place '/evidence_type: static/i\
   - override: See `FOLLOW-1234`\
   - override_by: operator' "$file"
-    sed -i '/^    - pending$/s/pending/partial/' "$file"
+    portable_sed_in_place '/^    - pending$/s/pending/partial/' "$file"
 
     run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
     [ "$status" -eq 0 ] && [[ "$output" == *"CONDITIONAL_PASS"* ]]
@@ -752,8 +769,8 @@ EOF
     local file
     root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
     file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i 's/A deterministic signal passes./The `https:\/\/prod.example.test\/status` endpoint passes./' "$file"
-    sed -i 's/evidence_type: static/evidence_type: empirical/' "$file"
+    portable_sed_in_place 's/A deterministic signal passes./The `https:\/\/prod.example.test\/status` endpoint passes./' "$file"
+    portable_sed_in_place 's/evidence_type: static/evidence_type: empirical/' "$file"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 0 ] \
@@ -861,7 +878,8 @@ EOF
             schema_version) duplicate='schema_version: 4' ;;
             status) duplicate='status: canonica1' ;;
         esac
-        sed -i "/^${key}:/a ${duplicate}" "$file"
+        portable_sed_in_place "/^${key}:/a\\
+${duplicate}" "$file"
 
         run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
         if [ "$status" -ne 1 ] || [[ "$output" != *"duplicate frontmatter field '${key}'"* ]]; then
@@ -884,7 +902,8 @@ EOF
     local file
     root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
     file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i '/^status: canonical$/a surprise_key: must-not-pass' "$file"
+    portable_sed_in_place '/^status: canonical$/a\
+surprise_key: must-not-pass' "$file"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 1 ] \
@@ -904,10 +923,11 @@ EOF
         root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
         file="$root/datarim/tasks/${id}-expectations.md"
         if [ "$construct" = "__NESTED__" ]; then
-            sed -i '/^status: canonical$/a\
+            portable_sed_in_place '/^status: canonical$/a\
   nested: must-not-pass' "$file"
         else
-            sed -i "/^status: canonical$/a ${construct}" "$file"
+            portable_sed_in_place "/^status: canonical$/a\\
+${construct}" "$file"
         fi
 
         run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
@@ -937,7 +957,8 @@ EOF
     local file
     root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
     file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i '/^status: canonical$/a agent: planner\
+    portable_sed_in_place '/^status: canonical$/a\
+agent: planner\
 parent_init_task: ALWD-0001-init-task.md\
 parent_prd: ../prd/PRD-ALWD-0001.md' "$file"
 
@@ -957,11 +978,12 @@ parent_prd: ../prd/PRD-ALWD-0001.md' "$file"
         file="$root/datarim/tasks/${id}-expectations.md"
         case "$variant" in
             preamble)
-                sed -i '1i arbitrary preamble' "$file"
+                portable_sed_in_place '1i\
+arbitrary preamble' "$file"
                 expected="frontmatter opener must be the first line"
                 ;;
             missing_close)
-                sed -i '8d' "$file"
+                portable_sed_in_place '8d' "$file"
                 expected="frontmatter missing closing delimiter"
                 ;;
         esac
@@ -991,7 +1013,7 @@ parent_prd: ../prd/PRD-ALWD-0001.md' "$file"
     while IFS='|' read -r field replacement expected; do
         root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
         file="$root/datarim/tasks/${id}-expectations.md"
-        sed -i "s@^${field}:.*@${field}: ${replacement}@" "$file"
+        portable_sed_in_place "s@^${field}:.*@${field}: ${replacement}@" "$file"
 
         run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
         if [ "$status" -ne 1 ] || [[ "$output" != *"${expected}"* ]]; then
@@ -1020,7 +1042,8 @@ EOF
             parent_init_task) replacement="../tasks/OTHR-0001-init-task.md"; expected="parent_init_task must equal DOMN-0001-init-task.md" ;;
             parent_prd) replacement="../../other/PRD-OTHR-0001.md"; expected="parent_prd must equal ../prd/PRD-DOMN-0001.md" ;;
         esac
-        sed -i "/^status: canonical$/a ${field}: ${replacement}" "$file"
+        portable_sed_in_place "/^status: canonical$/a\\
+${field}: ${replacement}" "$file"
 
         run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
         if [ "$status" -ne 1 ] || [[ "$output" != *"${expected}"* ]]; then
@@ -1040,8 +1063,9 @@ EOF
     local file
     root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
     file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i 's/^captured_at:.*/captured_at: 2024-02-29/' "$file"
-    sed -i '/^status: canonical$/a agent: architect\
+    portable_sed_in_place 's/^captured_at:.*/captured_at: 2024-02-29/' "$file"
+    portable_sed_in_place '/^status: canonical$/a\
+agent: architect\
 parent_init_task: LEAP-0001-init-task.md\
 parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
 
@@ -1057,7 +1081,7 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     local file
     root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
     file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i 's/^## Ожидания$/& <!-- active heading trailing comment -->/' "$file"
+    portable_sed_in_place 's/^## Ожидания$/& <!-- active heading trailing comment -->/' "$file"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 0 ] || return 1
@@ -1073,7 +1097,8 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     local file
     root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
     file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i '/^  - customer_derived:/i ## Ожидания' "$file"
+    portable_sed_in_place '/^  - customer_derived:/i\
+## Ожидания' "$file"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 1 ] \
@@ -1092,8 +1117,9 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     for suffix in '##' '## <!-- trailing heading comment -->'; do
         root="$(write_migrated_expectations "$id")"
         file="$root/datarim/tasks/${id}-expectations.md"
-        sed -i "/^- \*\*2\. Appended customer wish\.\*\*$/i ## Ожидания ${suffix}" "$file"
-        sed -i '/^  - customer_derived: true$/,/^  - delivery_receipt:/d' "$file"
+        portable_sed_in_place "/^- \*\*2\. Appended customer wish\.\*\*$/i\\
+## Ожидания ${suffix}" "$file"
+        portable_sed_in_place '/^  - customer_derived: true$/,/^  - delivery_receipt:/d' "$file"
 
         run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
         if [ "$status" -ne 1 ] || [[ "$output" != *"duplicate active ## Ожидания heading"* ]]; then
@@ -1118,7 +1144,7 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     for heading in '## Ожидания ##' $'   ##\tОжидания ###'; do
         root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
         file="$root/datarim/tasks/${id}-expectations.md"
-        sed -i "s/^## Ожидания$/${heading}/" "$file"
+        portable_sed_in_place "s/^## Ожидания$/${heading}/" "$file"
 
         run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
         if [ "$status" -ne 0 ]; then
@@ -1141,7 +1167,8 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     local file
     root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
     file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i '/^## Ожидания$/i ```markdown' "$file"
+    portable_sed_in_place '/^## Ожидания$/i\
+```markdown' "$file"
     printf '\n```\n' >> "$file"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
@@ -1159,7 +1186,8 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     local file
     root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
     file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i '/^## Ожидания$/i ~~~markdown\
+    portable_sed_in_place '/^## Ожидания$/i\
+~~~markdown\
 ## Ожидания\
 \
 - **99. Fenced decoy wish.**\
@@ -1209,7 +1237,7 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
         id="STAT-000${schema}"
         root="$(write_expectations "$id" "$schema")"
         file="$root/datarim/tasks/${id}-expectations.md"
-        sed -i 's/status: canonical/status: canonica1/' "$file"
+        portable_sed_in_place 's/status: canonical/status: canonica1/' "$file"
         run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
         if [ "$status" -ne 1 ] || [[ "$output" != *"frontmatter status must be 'canonical' or 'amended'"* ]]; then
             echo "legacy schema v${schema} accepted invalid status: ${output}" >&2
@@ -1240,4 +1268,15 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     disk_count="$(find "${REPO_ROOT}/skills" -mindepth 2 -maxdepth 2 -name SKILL.md | wc -l | tr -d '[:space:]')"
     documented_count="$(sed -nE 's/^Datarim includes ([0-9]+) reusable skill modules\..*/\1/p' "$SKILLS_REFERENCE")"
     [[ "$documented_count" -eq "$disk_count" ]]
+}
+
+@test "focused customer binding tests are BSD-portable and run in macOS CI" {
+    local focused_suite="${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats"
+    local workflow="${REPO_ROOT}/.github/workflows/bats.yml"
+
+    if grep -Eq 'sed (-E )?-i([^A-Za-z]|$)' "$focused_suite"; then
+        echo "focused suite contains GNU-only sed in-place syntax" >&2
+        return 1
+    fi
+    grep -Fq 'tests/customer-requirement-expectations-binding.bats' "$workflow"
 }

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -2,6 +2,7 @@
 
 setup() {
     REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+    CHECK_EXPECTATIONS="${REPO_ROOT}/dev-tools/check-expectations-checklist.sh"
     DELIVERY_SKILL="${REPO_ROOT}/skills/customer-delivery/SKILL.md"
     EXPECTATIONS_SKILL="${REPO_ROOT}/skills/expectations-checklist/SKILL.md"
     EXPECTATIONS_TEMPLATE="${REPO_ROOT}/templates/expectations-template.md"
@@ -13,6 +14,69 @@ assert_contains() {
     local literal="$2"
 
     grep -Fq -- "$literal" "$file"
+}
+
+template_has_exact_binding_bullets() {
+    local file="$1"
+    local item_count
+    local field
+
+    item_count="$(grep -cE '^- \*\*[0-9]+\. ' "$file")"
+    [ "$item_count" -gt 0 ] || return 1
+    for field in customer_requirement requirement_id surface_class visitor_visible delivery_receipt; do
+        [ "$(grep -cE "^  - ${field}:" "$file")" -eq "$item_count" ] || return 1
+    done
+}
+
+write_expectations() {
+    local id="$1"
+    local schema="$2"
+    local binding="${3:-}"
+    local evidence=""
+    local file="${BATS_TEST_TMPDIR}/${id}/datarim/tasks/${id}-expectations.md"
+
+    mkdir -p "$(dirname "$file")"
+    if [ "$schema" -ge 2 ]; then
+        evidence="  - evidence_type: static"
+    fi
+    cat > "$file" <<EOF
+---
+task_id: $id
+artifact: expectations
+schema_version: $schema
+captured_at: 2026-08-24
+captured_by: /dr-prd
+status: canonical
+---
+
+# $id expectations
+
+## Ожидания
+
+- **1. Customer outcome.**
+  - wish_id: customer-outcome
+  - Что хочу проверить: The requested outcome is delivered.
+  - Как проверить (success criterion): A deterministic signal passes.
+  - Связанный AC из PRD: V-AC-1
+$binding
+$evidence
+  - #### История статусов
+    - 2026-08-24T00:00:00Z / 2026-08-24 00:00 (UTC) · pending → pending · /dr-prd · reason: item created
+  - #### Текущий статус
+    - pending
+EOF
+    printf '%s\n' "${BATS_TEST_TMPDIR}/${id}"
+}
+
+valid_customer_binding() {
+    local id="$1"
+    cat <<EOF
+  - customer_requirement: customer-derived
+  - requirement_id: req-0001
+  - surface_class: VISITOR_VISIBLE
+  - visitor_visible: true
+  - delivery_receipt: datarim/receipts/${id}-customer-delivery.yaml
+EOF
 }
 
 @test "customer delivery skill is a valid history-agnostic skill entrypoint" {
@@ -68,18 +132,118 @@ assert_contains() {
 }
 
 @test "new customer expectation examples bind requirement surface visibility and receipt" {
-    for literal in \
-        'requirement_id: {req-NNNN}' \
-        'surface_class: {VISITOR_VISIBLE | ENABLING}' \
-        'visitor_visible: {true | false}' \
-        'delivery_receipt: {datarim/receipts/{TASK-ID}-customer-delivery.yaml}'; do
-        count="$(grep -Fc -- "$literal" "$EXPECTATIONS_TEMPLATE")"
-        [[ "$count" -eq 2 ]]
+    template_has_exact_binding_bullets "$EXPECTATIONS_TEMPLATE"
+}
+
+@test "commented customer binding bullets do not satisfy the template contract" {
+    local mutant="${BATS_TEST_TMPDIR}/commented-bindings.md"
+    cp "$EXPECTATIONS_TEMPLATE" "$mutant"
+    sed -E -i 's/^(  - (requirement_id|surface_class|visitor_visible|delivery_receipt):.*)$/<!-- \1 -->/' "$mutant"
+
+    run template_has_exact_binding_bullets "$mutant"
+    [ "$status" -ne 0 ]
+}
+
+@test "schema v4 customer-derived wish with complete binding passes" {
+    local id="BIND-0001"
+    local root
+    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 0 ]
+}
+
+@test "schema v4 new artifact with zero binding fields fails closed" {
+    local id="BIND-0002"
+    local root
+    root="$(write_expectations "$id" 4)"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"missing customer_requirement"* ]] \
+        && [[ "$output" != *"schema_version must"* ]]
+}
+
+@test "schema v4 HTML-commented binding fields fail closed" {
+    local id="BIND-0003"
+    local binding
+    local root
+    binding="$(valid_customer_binding "$id" | sed -E 's/^(  - (requirement_id|surface_class|visitor_visible|delivery_receipt):.*)$/<!-- \1 -->/')"
+    root="$(write_expectations "$id" 4 "$binding")"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"missing requirement_id"* ]] \
+        && [[ "$output" != *"schema_version must"* ]]
+}
+
+@test "schema v4 rejects removal of every customer-derived binding field" {
+    local field
+    local id
+    local binding
+    local root
+    for field in customer_requirement requirement_id surface_class visitor_visible delivery_receipt; do
+        id="BIND-0004"
+        binding="$(valid_customer_binding "$id" | sed -E "/^  - ${field}:/d")"
+        root="$(write_expectations "$id" 4 "$binding")"
+        run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"missing ${field}"* ]]; then
+            echo "field-removal mutant survived: ${field}" >&2
+            return 1
+        fi
+        rm -rf "$root"
+    done
+}
+
+@test "schema v4 not-applicable wish requires a reason and passes without binding fields" {
+    local id="BIND-0005"
+    local root
+    root="$(write_expectations "$id" 4 $'  - customer_requirement: not-applicable\n  - customer_requirement_reason: Internal framework-only wish')"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 0 ]
+}
+
+@test "schema v4 not-applicable wish without a reason fails closed" {
+    local id="BIND-0006"
+    local root
+    root="$(write_expectations "$id" 4 '  - customer_requirement: not-applicable')"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"missing customer_requirement_reason"* ]]
+}
+
+@test "schema v4 rejects inconsistent visitor visibility" {
+    local id="BIND-0007"
+    local binding
+    local root
+    binding="$(valid_customer_binding "$id" | sed 's/visitor_visible: true/visitor_visible: false/')"
+    root="$(write_expectations "$id" 4 "$binding")"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"surface_class and visitor_visible disagree"* ]]
+}
+
+@test "legacy schema versions v1 through v3 remain valid without customer binding" {
+    local schema
+    local id
+    local root
+    for schema in 1 2 3; do
+        id="LEGA-000${schema}"
+        root="$(write_expectations "$id" "$schema")"
+        run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+        if [ "$status" -ne 0 ]; then
+            echo "legacy schema v${schema} rejected: ${output}" >&2
+            return 1
+        fi
     done
 }
 
 @test "expectations contract makes customer binding mandatory without invalidating legacy files" {
-    assert_contains "$EXPECTATIONS_SKILL" 'Every new wish derived from a customer remark MUST carry these four fields:'
+    assert_contains "$EXPECTATIONS_SKILL" 'schema_version: 4'
+    assert_contains "$EXPECTATIONS_SKILL" 'customer_requirement'
     assert_contains "$EXPECTATIONS_SKILL" 'requirement_id'
     assert_contains "$EXPECTATIONS_SKILL" 'surface_class'
     assert_contains "$EXPECTATIONS_SKILL" 'visitor_visible'

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -5,6 +5,7 @@ setup() {
     DELIVERY_SKILL="${REPO_ROOT}/skills/customer-delivery/SKILL.md"
     EXPECTATIONS_SKILL="${REPO_ROOT}/skills/expectations-checklist/SKILL.md"
     EXPECTATIONS_TEMPLATE="${REPO_ROOT}/templates/expectations-template.md"
+    SKILLS_REFERENCE="${REPO_ROOT}/documentation/reference/skills.md"
 }
 
 assert_contains() {
@@ -83,4 +84,12 @@ assert_contains() {
     assert_contains "$EXPECTATIONS_SKILL" 'delivery_receipt'
     assert_contains "$EXPECTATIONS_SKILL" 'Legacy expectations files'
     assert_contains "$EXPECTATIONS_SKILL" 'remain valid without these fields'
+}
+
+@test "customer delivery skill is registered in the canonical skills inventory" {
+    assert_contains "$SKILLS_REFERENCE" '| customer-delivery | Reference |'
+
+    disk_count="$(find "${REPO_ROOT}/skills" -mindepth 2 -maxdepth 2 -name SKILL.md | wc -l | tr -d '[:space:]')"
+    documented_count="$(sed -nE 's/^Datarim includes ([0-9]+) reusable skill modules\..*/\1/p' "$SKILLS_REFERENCE")"
+    [[ "$documented_count" -eq "$disk_count" ]]
 }

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -312,7 +312,7 @@ customer_binding_from: appended-internal-wish' "$file"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 1 ] \
-        && [[ "$output" == *"customer_binding_from is obsolete in schema_version=4"* ]]
+        && [[ "$output" == *"customer_binding_from is obsolete"* ]]
 }
 
 @test "verify blocks coordinated binding strip and cutover advance" {
@@ -332,19 +332,33 @@ customer_binding_from: appended-internal-wish' "$file"
         && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
 }
 
-@test "schema v4 rejects the obsolete customer binding marker" {
-    local id="BIND-0009"
+@test "all schema versions reject the obsolete customer binding marker" {
+    local schema
+    local id
     local root
     local file
-    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
-    file="$root/datarim/tasks/${id}-expectations.md"
-    sed -i.bak '/^schema_version: 4$/a\
-customer_binding_from: customer-outcome' "$file"
-    rm -f "${file}.bak"
+    local binding
+    for schema in 1 2 3 4; do
+        id="MARK-000${schema}"
+        binding=""
+        [ "$schema" -eq 4 ] && binding="$(valid_customer_binding "$id")"
+        root="$(write_expectations "$id" "$schema" "$binding")"
+        file="$root/datarim/tasks/${id}-expectations.md"
+        sed -i "/^schema_version: ${schema}$/a customer_binding_from: customer-outcome" "$file"
 
-    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
-    [ "$status" -eq 1 ] \
-        && [[ "$output" == *"customer_binding_from is obsolete in schema_version=4"* ]]
+        run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"customer_binding_from is obsolete"* ]]; then
+            echo "schema v${schema} accepted obsolete marker: ${output}" >&2
+            return 1
+        fi
+
+        run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+        if [ "$status" -ne 1 ] || [[ "$output" != *"BLOCKED: expectations file fails structural validation"* ]]; then
+            echo "schema v${schema} verify accepted obsolete marker: ${output}" >&2
+            return 1
+        fi
+        rm -rf "$root"
+    done
 }
 
 @test "schema v4 canonical file governs its first wish" {
@@ -529,6 +543,37 @@ EOF
         fi
         rm -rf "$root"
     done
+}
+
+@test "closed expectations schema rejects an unknown frontmatter key in both modes" {
+    local id="UNKN-0001"
+    local root
+    local file
+    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i '/^status: canonical$/a surprise_key: must-not-pass' "$file"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"unknown frontmatter field 'surprise_key'"* ]] || return 1
+
+    run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
+}
+
+@test "closed expectations schema accepts every documented optional frontmatter key" {
+    local id="ALWD-0001"
+    local root
+    local file
+    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i '/^status: canonical$/a agent: planner\
+parent_init_task: datarim/tasks/ALWD-0001-init-task.md\
+parent_prd: datarim/prd/PRD-ALWD-0001.md' "$file"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 0 ]
 }
 
 @test "active expectations heading with a trailing HTML comment passes both modes" {

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -1444,7 +1444,7 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
         mode="$(stat -f '%Lp' "$fixture")"
     fi
     [ "$mode" = "640" ] || return 1
-    [ "$(find "$fixture_dir" -mindepth 1 -maxdepth 1 -type f | wc -l | tr -d '[:space:]')" -eq 1 ]
+    [ "$(find "$fixture_dir" -type f | wc -l | tr -d '[:space:]')" -eq 1 ]
 }
 
 @test "focused customer binding tests are BSD-portable and run in macOS CI" {

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -547,6 +547,46 @@ EOF
         && [[ "$output" == *"PASS"* ]]
 }
 
+@test "schema v4 ignores an expectations section inside a backtick fence" {
+    local id="FENC-0001"
+    local root
+    local file
+    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i '/^## Ожидания$/i ```markdown' "$file"
+    printf '\n```\n' >> "$file"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"no items found under ## Ожидания"* ]] || return 1
+
+    run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
+}
+
+@test "schema v4 ignores a tilde-fenced decoy beside active content" {
+    local id="FENC-0002"
+    local root
+    local file
+    root="$(write_expectations "$id" 4 "$(valid_customer_binding "$id")")"
+    file="$root/datarim/tasks/${id}-expectations.md"
+    sed -i '/^## Ожидания$/i ~~~markdown\
+## Ожидания\
+\
+- **99. Fenced decoy wish.**\
+  - wish_id: fenced-decoy\
+~~~\
+' "$file"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 0 ] || return 1
+
+    run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+    [ "$status" -eq 0 ] \
+        && [[ "$output" == *"PASS"* ]]
+}
+
 @test "verify mode blocks a structurally invalid schema v4 artifact" {
     local id="BIND-0016"
     local root

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -39,7 +39,9 @@ assert_no_direct_in_place_sed() {
     if ! violations="$(LC_ALL=C awk '
         function inspect(line, line_number, line_len, pos, char, quote, value,
                          count, i, expect_command, sed_command, wrapper,
-                         skip_wrapper_arg, skip_redirection_arg, values, kinds) {
+                         skip_wrapper_arg, skip_redirection_arg, in_backtick,
+                         pending_outer_quote, backtick_outer_quote, resume_quote,
+                         values, kinds) {
             line_len = length(line)
             pos = 1
             count = 0
@@ -52,7 +54,23 @@ assert_no_direct_in_place_sed() {
                 if (char == "#") {
                     break
                 }
-                if (char ~ /[;&|(){}]/ || char == "`") {
+                if (char == "`") {
+                    values[++count] = char
+                    if (in_backtick) {
+                        kinds[count] = "substitution_close"
+                        in_backtick = 0
+                        resume_quote = backtick_outer_quote
+                        backtick_outer_quote = ""
+                    } else {
+                        kinds[count] = "separator"
+                        in_backtick = 1
+                        backtick_outer_quote = pending_outer_quote
+                    }
+                    pending_outer_quote = ""
+                    pos++
+                    continue
+                }
+                if (char ~ /[;&|(){}]/) {
                     values[++count] = char
                     kinds[count] = "separator"
                     pos++
@@ -60,11 +78,15 @@ assert_no_direct_in_place_sed() {
                 }
 
                 value = ""
-                quote = ""
+                quote = resume_quote
+                resume_quote = ""
                 while (pos <= line_len) {
                     char = substr(line, pos, 1)
                     if ((quote == "" && (char ~ /[[:space:]]/ || char ~ /[;&|(){}]/ || char == "`")) ||
                         (quote == "\"" && char == "`")) {
+                        if (quote == "\"" && char == "`") {
+                            pending_outer_quote = quote
+                        }
                         break
                     }
                     if (quote == "" && (char == "\"" || char == "\047")) {
@@ -96,6 +118,14 @@ assert_no_direct_in_place_sed() {
             skip_wrapper_arg = 0
             skip_redirection_arg = 0
             for (i = 1; i <= count; i++) {
+                if (kinds[i] == "substitution_close") {
+                    expect_command = 0
+                    sed_command = 0
+                    wrapper = ""
+                    skip_wrapper_arg = 0
+                    skip_redirection_arg = 0
+                    continue
+                }
                 if (kinds[i] == "separator") {
                     expect_command = 1
                     sed_command = 0
@@ -1650,6 +1680,7 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
     printf 'ignored=\140sed --in-place -e "s/x/y/" mutant\140\n' >> "$mutant_suite"
     printf 'quoted="\140sed -i.bak s/x/y/ mutant\140"\n' >> "$mutant_suite"
+    printf 'sequential="before \140printf ok\140 middle \140sed -i.bak s/x/y/ mutant\140 after"\n' >> "$mutant_suite"
     run assert_no_direct_in_place_sed "$mutant_suite"
     if [ "$status" -ne 1 ] || [[ "$output" != *"direct in-place sed syntax"* ]]; then
         echo "legacy backtick sed mutants were not rejected (status=${status}): ${output}" >&2
@@ -1673,6 +1704,8 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     printf '%s\n' 'exec -cla sed echo allowed' >> "$mutant_suite"
     printf "literal='\\140sed --in-place -e s/x/y/ mutant\\140'\n" >> "$mutant_suite"
     printf 'escaped=\134\140sed --in-place -e s/x/y/ mutant\134\140\n' >> "$mutant_suite"
+    printf 'message="before \140printf ok\140 sed -i.bak is literal prose"\n' >> "$mutant_suite"
+    printf 'escaped_message="before \134\140sed -i.bak\134\140 after"\n' >> "$mutant_suite"
     run assert_no_direct_in_place_sed "$mutant_suite"
     if [ "$status" -ne 0 ]; then
         echo "inert sed prose was treated as executable (status=${status}): ${output}" >&2

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -1428,13 +1428,57 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
 @test "portable sed helper preserves bytes mode and sibling cleanliness" {
     local fixture_dir="${BATS_TEST_TMPDIR}/portable-editor"
     local fixture="${fixture_dir}/sample.txt"
+    local shim_dir="${BATS_TEST_TMPDIR}/portable-editor-bin"
+    local shim_log="${BATS_TEST_TMPDIR}/portable-editor-shim.log"
+    local real_editor
+    local shim
+    local long_option="--in""-place"
     local mode
+    local original_path="$PATH"
 
-    mkdir -p "$fixture_dir"
+    real_editor="$(command -v "$(portable_editor_word)")"
+    shim="${shim_dir}/$(portable_editor_word)"
+    mkdir -p "$fixture_dir" "$shim_dir"
     printf 'alpha\n' > "$fixture"
     chmod 640 "$fixture"
+    : > "$shim_log"
+    printf '%s\n' \
+        '#!/usr/bin/env bash' \
+        'set -euo pipefail' \
+        'for argument in "$@"; do' \
+        '    case "$argument" in' \
+        '        --in-place|--in-place=*|-i*|-[A-Za-z]*i*)' \
+        '            printf '\''%s\n'\'' "$argument" >> "$SED_SHIM_LOG"' \
+        '            exit 97' \
+        '            ;;' \
+        '    esac' \
+        'done' \
+        'exec "$REAL_SED" "$@"' > "$shim"
+    chmod +x "$shim"
 
+    run env \
+        REAL_SED="$real_editor" \
+        SED_SHIM_LOG="$shim_log" \
+        PATH="${shim_dir}:${PATH}" \
+        "$(portable_editor_word)" "$long_option" 's/x/y/' "$fixture"
+    [ "$status" -eq 97 ] || return 1
+    [ -s "$shim_log" ] || return 1
+
+    : > "$shim_log"
+    run env \
+        REAL_SED="$real_editor" \
+        SED_SHIM_LOG="$shim_log" \
+        PATH="${shim_dir}:${PATH}" \
+        "$(portable_editor_word)" -n 's/^alpha$/alpha/p' "$fixture"
+    [ "$status" -eq 0 ] && [ "$output" = "alpha" ] || return 1
+    [ ! -s "$shim_log" ] || return 1
+
+    export REAL_SED="$real_editor" SED_SHIM_LOG="$shim_log"
+    PATH="${shim_dir}:${PATH}"
+    export PATH
     portable_sed_in_place 's/alpha/beta/' "$fixture"
+    PATH="$original_path"
+    export PATH
 
     [ "$(cat "$fixture")" = "beta" ] || return 1
     [ "$(wc -c < "$fixture" | tr -d '[:space:]')" -eq 5 ] || return 1
@@ -1444,6 +1488,7 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
         mode="$(stat -f '%Lp' "$fixture")"
     fi
     [ "$mode" = "640" ] || return 1
+    [ ! -s "$shim_log" ] || return 1
     [ "$(find "$fixture_dir" -type f | wc -l | tr -d '[:space:]')" -eq 1 ]
 }
 
@@ -1599,13 +1644,18 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     done
 
     cp "${REPO_ROOT}/tests/customer-requirement-expectations-binding.bats" "$mutant_suite"
-    portable_sed_in_place "/^[[:space:]]*if ! sed /i\\
-    local editor
-    editor=\"\$(portable_editor_word)\"
-" "$mutant_suite"
     portable_sed_in_place \
-        "s/if ! sed /if ! \"\\\$editor\" ${short_option} /" \
+        's/^[[:space:]]*local temp_file$/    local temp_file editor/' \
         "$mutant_suite"
+    portable_sed_in_place '/^[[:space:]]*if ! sed "${args\[@\]}" "$file" > "$temp_file"; then$/i\
+    editor="$(portable_editor_word)"
+' "$mutant_suite"
+    portable_sed_in_place \
+        's|^[[:space:]]*if ! sed "${args\[@\]}" "$file" > "$temp_file"; then$|    if ! "$editor" '"${short_option}"' "${args[@]}" "$temp_file"; then|' \
+        "$mutant_suite"
+    portable_sed_in_place '/^[[:space:]]*mv "$temp_file" "$file"$/i\
+    rm -f "${temp_file}.bak"
+' "$mutant_suite"
     run bats --filter \
         'portable sed helper preserves bytes mode and sibling cleanliness' \
         "$mutant_suite"

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -1230,6 +1230,71 @@ parent_prd: ../prd/PRD-LEAP-0001.md' "$file"
     [ "$status" -eq 0 ] && [[ "$output" == *"PASS"* ]]
 }
 
+@test "tracked schema v2 repo-root parent paths remain read-compatible" {
+    run "$CHECK_EXPECTATIONS" --task TUNE-0574 --root "$REPO_ROOT"
+    [ "$status" -eq 0 ] || return 1
+
+    run "$CHECK_EXPECTATIONS" --verify TUNE-0574 --root "$REPO_ROOT"
+    [ "$status" -eq 0 ] && [[ "$output" == *"PASS"* ]]
+}
+
+@test "legacy schemas accept task-bound repo-root parent paths" {
+    local id
+    local schema
+    local root
+    local file
+
+    for schema in 1 2 3; do
+        id="LPTH-000${schema}"
+        root="$(write_expectations "$id" "$schema")"
+        file="$root/datarim/tasks/${id}-expectations.md"
+        portable_sed_in_place "/^status: canonical$/a\\
+parent_init_task: datarim/tasks/${id}-init-task.md\\
+parent_prd: datarim/prd/PRD-${id}.md" "$file"
+
+        run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+        if [ "$status" -ne 0 ]; then
+            echo "schema v${schema} rejected task-bound repo-root parents: ${output}" >&2
+            return 1
+        fi
+
+        run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+        if [ "$status" -ne 0 ] || [[ "$output" != *"PASS"* ]]; then
+            echo "schema v${schema} verify rejected task-bound repo-root parents: ${output}" >&2
+            return 1
+        fi
+        rm -rf "$root"
+    done
+}
+
+@test "legacy repo-root parent paths stay task-bound and traversal-free" {
+    local id="LPTH-0004"
+    local field
+    local replacement
+    local root
+    local file
+
+    while IFS='|' read -r field replacement; do
+        root="$(write_expectations "$id" 2)"
+        file="$root/datarim/tasks/${id}-expectations.md"
+        portable_sed_in_place "/^status: canonical$/a\\
+${field}: ${replacement}" "$file"
+
+        run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+        [ "$status" -eq 1 ] || return 1
+        run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+        [ "$status" -eq 1 ] \
+            && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]] \
+            || return 1
+        rm -rf "$root"
+    done <<EOF
+parent_init_task|../../other/${id}-init-task.md
+parent_init_task|datarim/tasks/OTHR-0001-init-task.md
+parent_prd|../../other/PRD-${id}.md
+parent_prd|datarim/prd/PRD-OTHR-0001.md
+EOF
+}
+
 @test "active expectations heading with a trailing HTML comment passes both modes" {
     local id="HEAD-0001"
     local root

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -81,6 +81,54 @@ valid_customer_binding() {
 EOF
 }
 
+write_cutover_expectations() {
+    local id="$1"
+    local marker="${2:-appended-customer-wish}"
+    local root="${BATS_TEST_TMPDIR}/${id}"
+    local file="${root}/datarim/tasks/${id}-expectations.md"
+    mkdir -p "$(dirname "$file")"
+    cat > "$file" <<EOF
+---
+task_id: $id
+artifact: expectations
+schema_version: 4
+customer_binding_from: $marker
+captured_at: 2026-05-14
+captured_by: /dr-prd
+status: amended
+---
+
+## Ожидания
+
+- **1. Preserved legacy wish.**
+  - wish_id: preserved-legacy-wish
+  - evidence_type: static
+  - #### История статусов
+    - 2026-05-14T00:00:00Z / 2026-05-14 00:00 (UTC) · pending → pending · /dr-prd · reason: item created
+  - #### Текущий статус
+    - pending
+
+- **2. Appended customer wish.**
+  - wish_id: appended-customer-wish
+$(valid_customer_binding "$id")
+  - evidence_type: static
+  - #### История статусов
+    - 2026-08-24T00:00:00Z / 2026-08-24 00:00 (UTC) · pending → pending · /dr-prd · reason: item appended
+  - #### Текущий статус
+    - pending
+
+- **3. Appended non-customer wish.**
+  - wish_id: appended-internal-wish
+  - customer_derived: false
+  - evidence_type: static
+  - #### История статусов
+    - 2026-08-24T00:00:00Z / 2026-08-24 00:00 (UTC) · pending → pending · /dr-prd · reason: item appended
+  - #### Текущий статус
+    - pending
+EOF
+    printf '%s\n' "$root"
+}
+
 @test "customer delivery skill is a valid history-agnostic skill entrypoint" {
     [[ -f "$DELIVERY_SKILL" ]] || return 1
     assert_contains "$DELIVERY_SKILL" 'name: customer-delivery' || return 1
@@ -230,51 +278,41 @@ EOF
 
 @test "schema v4 legacy cutover preserves old wishes and governs mixed appended wishes" {
     local id="BIND-0008"
-    local root="${BATS_TEST_TMPDIR}/${id}"
-    local file="${root}/datarim/tasks/${id}-expectations.md"
-    mkdir -p "$(dirname "$file")"
-    cat > "$file" <<EOF
----
-task_id: $id
-artifact: expectations
-schema_version: 4
-customer_binding_from: appended-customer-wish
-captured_at: 2026-05-14
-captured_by: /dr-prd
-status: amended
----
-
-## Ожидания
-
-- **1. Preserved legacy wish.**
-  - wish_id: preserved-legacy-wish
-  - evidence_type: static
-  - #### История статусов
-    - 2026-05-14T00:00:00Z / 2026-05-14 00:00 (UTC) · pending → pending · /dr-prd · reason: item created
-  - #### Текущий статус
-    - pending
-
-- **2. Appended customer wish.**
-  - wish_id: appended-customer-wish
-$(valid_customer_binding "$id")
-  - evidence_type: static
-  - #### История статусов
-    - 2026-08-24T00:00:00Z / 2026-08-24 00:00 (UTC) · pending → pending · /dr-prd · reason: item appended
-  - #### Текущий статус
-    - pending
-
-- **3. Appended non-customer wish.**
-  - wish_id: appended-internal-wish
-  - customer_derived: false
-  - evidence_type: static
-  - #### История статусов
-    - 2026-08-24T00:00:00Z / 2026-08-24 00:00 (UTC) · pending → pending · /dr-prd · reason: item appended
-  - #### Текущий статус
-    - pending
-EOF
+    local root
+    root="$(write_cutover_expectations "$id")"
 
     run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
     [ "$status" -eq 0 ]
+}
+
+@test "schema v4 amended file rejects moving cutover forward past a bound wish" {
+    local id="BIND-0017"
+    local root
+    root="$(write_cutover_expectations "$id" appended-internal-wish)"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"customer binding field appears before customer_binding_from"* ]]
+}
+
+@test "verify mode blocks a schema v4 cutover moved past a bound wish" {
+    local id="BIND-0019"
+    local root
+    root="$(write_cutover_expectations "$id" appended-internal-wish)"
+
+    run "$CHECK_EXPECTATIONS" --verify "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"BLOCKED: expectations file fails structural validation"* ]]
+}
+
+@test "schema v4 amended file rejects moving cutover backward into a legacy wish" {
+    local id="BIND-0018"
+    local root
+    root="$(write_cutover_expectations "$id" preserved-legacy-wish)"
+
+    run "$CHECK_EXPECTATIONS" --task "$id" --root "$root"
+    [ "$status" -eq 1 ] \
+        && [[ "$output" == *"missing customer_derived"* ]]
 }
 
 @test "schema v4 rejects a cutover marker that names no wish" {


### PR DESCRIPTION
## Summary
- add the history-agnostic customer-delivery runtime skill implementing U1-U8
- bind new customer-derived expectations to stable requirement, surface, visibility, and receipt fields
- preserve compatibility for legacy expectation files

## Verification
- RED baseline: 0/8 before implementation
- GREEN: 40/40 focused and regression expectation tests
- exact English gate: PASS (211 files)
- skill frontmatter/layout/sibling, template path, doc refs, frontmatter-English, and quick validation: PASS
- four binding-removal mutants killed: requirement_id, surface_class, visitor_visible, delivery_receipt