### PR TITLE
feat: wire customer delivery through datarim lifecycle

### DIFF
--- a/commands/dr-archive.md
+++ b/commands/dr-archive.md
@@ -517,9 +517,29 @@ Enforcing this binding mechanically is **site policy, and the framework ships no
    - A legitimate deferral (time-dependent or hard external blocker) clears the
      gate ONLY by citing a follow-up ID / `blocked_by` reference that exists in
      `backlog.md` / `tasks.md`. Both scanners are fail-open on their own
-     git-probe failure (warn, do not block) — an infrastructure hiccup never
-     hard-blocks an otherwise-clean archive. Archive is idempotent; a fixed gap
-     re-enters cleanly on the next `/dr-archive` run.
+   git-probe failure (warn, do not block) — an infrastructure hiccup never
+   hard-blocks an otherwise-clean archive. Archive is idempotent; a fixed gap
+   re-enters cleanly on the next `/dr-archive` run.
+
+0.46. **CUSTOMER DELIVERY + REVIEW EVOLUTION CLOSURE GATE (HARD)**
+   (mandatory when a schema-v4 expectations wish declares
+   `customer_derived: true`):
+   - Re-run both validators against the exact revision being archived:
+     ```bash
+     "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-customer-delivery.sh" \
+         --root <repo-root> --task {TASK-ID} --stage archive --format json
+     "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-review-evolution.sh" \
+         --root <repo-root> --task {TASK-ID} --format json
+     ```
+   - Exit `1` from either validator means `NOT_MET`: STOP the archive and route
+     to the earliest stage named by the finding. Exit `2` is fail-closed:
+     STOP the archive until the configuration or required artifact is fixed.
+   - Preserve the customer requirement set, delivery receipt, review-evolution
+     record, validator output, deployed SHA evidence, and live painted-surface
+     matrix in the archive evidence inventory. Never rewrite or discard prior
+     receipt evidence.
+   - Tools, documentation, tests, CI, and ledger output cannot satisfy a visitor-visible requirement. Canon evolution cannot replace the product
+     fix; a clean spec-graph inventory cannot replace this closure gate.
 
 0.48. **STALE-RUNTIME REMINDER** (advisory, non-blocking):
    - Invoke the shared detector (single source of truth for this advisory):

--- a/commands/dr-compliance.md
+++ b/commands/dr-compliance.md
@@ -80,6 +80,24 @@ Enforcing this binding mechanically is **site policy, and the framework ships no
     -   Include graph completeness, evaluated artifacts, trace buckets, and the report-only grade in the compliance audit addendum.
     -   Exit `2` makes the verdict **NON-COMPLIANT**. In explicit hard mode, exit `1` also makes the verdict **NON-COMPLIANT**. The grade letter never changes routing.
 
+5e. **CUSTOMER DELIVERY + REVIEW EVOLUTION GATE (HARD)** (mandatory when a
+    schema-v4 expectations wish declares `customer_derived: true`):
+    - Invoke both validators independently:
+      ```bash
+      "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-customer-delivery.sh" \
+          --root <repo-root> --task {TASK-ID} --stage compliance --format json
+      "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-review-evolution.sh" \
+          --root <repo-root> --task {TASK-ID} --format json
+      ```
+    - Either validator exit `1` makes the verdict **NON-COMPLIANT**. Exit `2`
+      is a fail-closed configuration/required-artifact error and also makes the
+      verdict **NON-COMPLIANT**. Preserve both JSON results and exact findings
+      in the compliance addendum.
+    - Tools, documentation, tests, CI, and ledger output cannot satisfy a visitor-visible requirement. Canon evolution supports the associated
+      product fix and never replaces it.
+    - `spec-graph-gate.sh` only inventories the expanded edges;
+      `check-customer-delivery.sh` retains semantic closure responsibility.
+
 6.  **APPLY CHECKLIST**: Execute the appropriate checklist(s) from the compliance skill:
     - **Code** → 7-step software checklist (lint, tests, coverage, CI/CD)
     - **Documentation** → completeness, accuracy, consistency, cross-references, audience

--- a/commands/dr-do.md
+++ b/commands/dr-do.md
@@ -54,6 +54,21 @@ Note: the machine-local PreToolUse guard remains the hard floor; this Step-0 che
     ```
     If any check fails — fix before implementing. Do not start coding on a broken foundation.
 
+6.1. **CUSTOMER DELIVERY RECEIPT PRE-WORK GATE** (mandatory before writing
+    code or content when any schema-v4 expectation is customer-derived):
+    - Invoke `spec-graph-gate.sh --task {TASK-ID} --stage do --root
+      <repo-root> --format json` before the first implementation edit and read
+      its `customer_delivery_prework` object.
+    - Do not write code or content until `prework_ready` is `true`. Exit `1`
+      means the Requirement-to-V-AC binding, customer requirements artifact,
+      receipt `requirement` edge, receipt `selected_knowledge` edge, or one of
+      the six pinned knowledge kinds is missing; return to `/dr-plan`. Exit `2`
+      is fail-closed configuration failure. Non-customer work receives
+      `applicable: false` and proceeds normally.
+    - This gate proves only the pre-work prefix. It does not claim customer
+      delivery, and it does not replace `check-customer-delivery.sh` at QA,
+      compliance, or archive.
+
 6.5. **STAGING-NOT-STALE PRE-CHECK** (MANDATORY before executing any Acceptance Criterion whose E2E verification requires a non-prod / staging environment):
     -   Identify whether the AC under execution needs a live non-prod target (staging host, compose project, or equivalent environment defined by the task/plan). If the AC's evidence can be produced with a unit/integration test or a semantic assertion against data already available, skip this step.
     -   When a non-prod target is required, verify it is live and current — stack-agnostic, no hardcoded service names:
@@ -129,7 +144,9 @@ Note: the machine-local PreToolUse guard remains the hard floor; this Step-0 che
         "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/spec-graph-gate.sh" \
             --task {TASK-ID} --stage do --root <repo-root> --format json
         ```
-    -   The do-stage gate is advisory even when hard mode is active because evidence is still accruing. Exit `2` remains fail-closed.
+    -   The do-stage evidence findings remain advisory even when hard mode is
+        active because evidence is still accruing. Customer pre-work exit `1`
+        from Step 6.1 is hard; exit `2` remains fail-closed.
 
 8.  **REVIEW-FEEDBACK HANDLING** (when an automated code review or human review returns findings):
     Classify each finding, then act:

--- a/commands/dr-init.md
+++ b/commands/dr-init.md
@@ -225,6 +225,24 @@ Note: the machine-local PreToolUse guard remains the hard floor; this Step-0 che
     - Exit 1 or exit 2 is a hard INIT failure for a framework task. Do not
       continue to PRD/plan and do not recapture later from `/dr-do`.
 
+4.68. **Customer remarks (verbatim requirement intake)** (mandatory when the
+    brief or append-log contains customer/client review language or requests a
+    visitor-facing product outcome):
+    - Leave `## Operator brief (verbatim)` byte-for-byte unchanged. Duplicate
+      every customer remark byte-for-byte under a separate
+      `## Customer remarks (verbatim requirement intake)` heading; never
+      replace it with the extracted wish or an agent paraphrase. Preserve
+      source order and the source reference.
+    - Assign one stable intake Requirement ID (`req-NNNN`) to each atomic
+      outcome. When one remark contains multiple independently acceptable
+      outcomes, repeat the exact quotation for each atomic ID. A later
+      correction is append-only and records the superseding ID; it never
+      rewrites the original quotation.
+    - Mark the matching expectations wishes `customer_derived: true`; mark all
+      other wishes `customer_derived: false`. Do not infer a customer origin
+      from a similar internal acceptance criterion. `/dr-prd` Step 5.5a turns
+      this intake into the full customer-requirements artifact.
+
 4.7. **WRITE EXPECTATIONS SKELETON** (mandatory for all complexity levels L1-L4 — see `$HOME/.claude/skills/expectations-checklist/SKILL.md` § When the file is created):
     - Compute `EXPECTATIONS_FILE="datarim/tasks/{TASK-ID}-expectations.md"`.
     - Skip silently when `EXPECTATIONS_FILE` already exists (re-run `/dr-init` on backlog ID, or operator-amended skeleton from a prior cycle) — preserve operator edits.
@@ -234,11 +252,11 @@ Note: the machine-local PreToolUse guard remains the hard floor; this Step-0 che
       - Extraction approach: LLM extraction via the agent's own model context (consistent with `/dr-prd` Step 5.5b pattern). Quote operator wording where possible; default `evidence_type: empirical` per wish (operator corrects via amendment if `static` or `measurement` is more appropriate).
       - Hallucination mitigation: wish title MUST trace back to a phrase or paraphrasable concept in the brief; do NOT invent goals the operator did not state. Vague brief → use the fallback skeleton below.
     - Write the file from `${DATARIM_RUNTIME:-$HOME/.claude}/templates/expectations-template.md` with:
-      - **Frontmatter (canonical):** `task_id`, `artifact: expectations`, `schema_version: 2`, `captured_at`, `captured_by: /dr-init`, `agent: planner`, `status: canonical`, `parent_init_task: {TASK-ID}-init-task.md`.
-      - **Per-wish item:** title (plain Russian, ending with «.»), `wish_id` (kebab-slug, cyrillic allowed), `Что хочу проверить:` (1-2 sentences), `Как проверить (success criterion):` (concrete signal — file path, command, visible behaviour), `Связанный AC из PRD: «—»` (no PRD yet), `evidence_type: empirical` (default), `#### История статусов` one initial line `<ISO> / <local> · /dr-init · pending → pending · reason: пункт создан при инициализации задачи`, `#### Текущий статус` followed by a single bullet line carrying the value (`pending` on first write). <!-- allow-non-ascii: russian-expectations-field-names-and-status-history-cited-from-canonical-schema -->
+      - **Frontmatter (canonical):** `task_id`, `artifact: expectations`, `schema_version: 4`, `captured_at`, `captured_by: /dr-init`, `agent: planner`, `status: canonical`, `parent_init_task: {TASK-ID}-init-task.md`.
+      - **Per-wish item:** title (plain Russian, ending with «.»), `wish_id` (kebab-slug, cyrillic allowed), `Что хочу проверить:` (1-2 sentences), `Как проверить (success criterion):` (concrete signal — file path, command, visible behaviour), `Связанный AC из PRD: «—»` (no PRD yet), exactly one `customer_derived: true | false`, `evidence_type: empirical` (default), `#### История статусов` one initial line `<ISO> / <local> · /dr-init · pending → pending · reason: пункт создан при инициализации задачи`, `#### Текущий статус` followed by a single bullet line carrying the value (`pending` on first write). A `true` wish also carries `requirement_id`, `surface_class`, `visitor_visible`, and `delivery_receipt`; a `false` wish carries none of those four fields. <!-- allow-non-ascii: russian-expectations-field-names-and-status-history-cited-from-canonical-schema -->
       - **Schema (mandatory).** Items MUST use the canonical bullet-list shape from `skills/expectations-checklist/SKILL.md` § Body shape — i.e. one top-level bullet per wish (`- **<N>. <Title>**`) with **nested bullets** (`  - wish_id:`, `  - Что хочу проверить:`, …) and a two-line `Текущий статус` block (`  - #### Текущий статус` followed by `    - <value>`). Do **NOT** use heading-style items (`### N. Title`) or single-line «inline» status (`#### Текущий статус: pending`) — the validator parses only the bullet-list shape, and heading-style files are rejected on the very next pipeline step (see `"${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-expectations-checklist.sh" --task {TASK-ID} --report` for the exact errors emitted on schema drift). <!-- allow-non-ascii: russian-expectations-field-names-cited-from-canonical-schema -->
     - Probe: `bash "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-expectations-checklist.sh" --task {TASK-ID} --root "$DATARIM_ROOT"`. Exit 0 = OK; non-zero = print warning + continue (fail-soft — operator may amend manually).
-    - **Fallback (empty / diffuse brief or LLM extraction failure):** write 1-wish skeleton with title «Цель задачи — TBD (оператор уточняет).», `wish_id: tsel-zadachi-tbd`, `evidence_type: empirical`, and an inline HTML comment `<!-- TODO: operator fills concrete wish at next /dr-prd or /dr-plan amendment -->`. This satisfies the L1+ mandate floor and surfaces the gap to the operator at the next pipeline step. <!-- allow-non-ascii: russian-fallback-skeleton-title-cited-from-template -->
+    - **Fallback (empty / diffuse brief or LLM extraction failure):** write 1-wish skeleton with title «Цель задачи — TBD (оператор уточняет).», `wish_id: tsel-zadachi-tbd`, `customer_derived: false`, `evidence_type: empirical`, and an inline HTML comment `<!-- TODO: operator fills concrete wish at next /dr-prd or /dr-plan amendment -->`. This satisfies the L1+ mandate floor and surfaces the gap to the operator at the next pipeline step. <!-- allow-non-ascii: russian-fallback-skeleton-title-cited-from-template -->
     - This step applies to **all complexity levels L1-L4** (mandate scope — the operator set this as a hard requirement with no exceptions).
 
 5.  **SUBTASK BACKLOG** (Level 3-4 only):

--- a/commands/dr-plan.md
+++ b/commands/dr-plan.md
@@ -138,6 +138,22 @@ Note: the machine-local PreToolUse guard remains the hard floor; this Step-0 che
 
 4.5. **Plan ↔ Creative Deploy-Dependency Cross-Reference** (MANDATORY when this task has a companion `datarim/creative/creative-{TASK-ID}-*.md` design doc that marks any Decision as deploy-gated — i.e. the decision only takes observable effect after a deploy/cutover, not merely after the code merges): for every Implementation Step whose completion depends on such a decision, annotate the step inline with `[deploy-gated — see creative-{TASK-ID}.md § Decision]`. This makes the deploy dependency visible to `/dr-qa` Layer 3 (Plan Completeness) and to the operator reading the plan, instead of surfacing only when a step marked "done" turns out to still be waiting on a deploy. Cost: one grep of the creative doc's § Decision sections for a deploy-gated marker. Saving: avoids a `/dr-qa` false-positive on a step that is code-complete but not yet effective.
 
+4.8. **CUSTOMER PRE-WORK KNOWLEDGE AND RECEIPT** (mandatory when any
+    schema-v4 expectation declares `customer_derived: true`):
+    - Before implementation starts, select and pin the applicable role, skill, blueprint, constraint, policy, and success criterion. Every selection
+      carries an immutable revision, digest, and selection timestamp earlier
+      than `implementation_started_at`. Record the issued selection in
+      `datarim/tasks/{TASK-ID}-customer-requirements.yaml` and in the plan.
+      `Gap` or `Unbound` may authorize a separate capability-creation task but
+      cannot stand in for a delivery-bound selection. Selection after implementation starts is post-hoc attribution and fails.
+    - Create `datarim/receipts/{TASK-ID}-customer-delivery.yaml` before implementation starts. Its per-requirement record begins with
+      `coverage_status: NOT_MET`, complete requirement and selected_knowledge edges,
+      and `missing_edges` naming every downstream edge not yet earned.
+      Never invent merge, deploy, live, or customer-disposition evidence.
+    - The receipt prefix is deliberately incomplete delivery evidence. It
+      authorizes work only; `check-customer-delivery.sh` remains the sole
+      semantic closure authority at QA, compliance, and archive.
+
 5.  **Create Implementation Plan (Phase 5)** — thin-index schema:
     -   **`datarim/tasks.md`** carries ONLY the one-liner pointer (canonical regex per `skills/datarim-system/SKILL.md` § Operational File Schema):
         ```
@@ -165,6 +181,12 @@ Note: the machine-local PreToolUse guard remains the hard floor; this Step-0 che
             - `#### История статусов` with one initial line `<ISO> / <local> · /dr-plan · pending → pending · reason: пункт добавлен из плана § Validation Checklist`; <!-- allow-non-ascii: literal-russian-field-name-from-expectations-template -->
             - `#### Текущий статус: pending`. <!-- allow-non-ascii: literal-russian-field-name-from-expectations-template -->
     -   **Do not rewrite, reorder, or delete existing items.** Operator controls pruning via explicit `Текущий статус: deleted`. <!-- allow-non-ascii: literal-russian-field-name-from-expectations-template -->
+    -   **Legacy freeze before append.** An expectations file at v1-v3 MUST NOT
+        receive a new wish or an in-place wish mutation. Complete the full
+        full metadata-only migration to schema v4 first, preserving every legacy
+        body, title, history, order, and `wish_id`; classify every wish with
+        `customer_derived`; add the conditional binding quartet for `true`
+        wishes; record the migration; then append.
     -   **Post-write validation gate.** Invoke:
         ```bash
         "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-expectations-checklist.sh" --task {TASK-ID}
@@ -179,7 +201,9 @@ Note: the machine-local PreToolUse guard remains the hard floor; this Step-0 che
         "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/spec-graph-gate.sh" \
             --task {TASK-ID} --stage plan --root <repo-root> --format json
         ```
-    -   Exit `2` blocks the stage. In explicit hard mode, exit `1` blocks transition to `/dr-do`; otherwise findings are advisory and must be summarized in the plan response.
+    -   Exit `2` blocks the stage. Exit `1` always blocks transition to `/dr-do`
+        when `customer_delivery_prework.prework_ready` is false; other graph
+        findings block only in explicit hard mode and otherwise remain advisory.
 
 6.  **Technology Validation**:
     -   **Stack Proposal (mandatory for new project/service, cross-domain, stack-migration — skip for routine same-domain):** Load `$HOME/.claude/skills/tech-stack/SKILL.md` and run the Trigger Classifier. On `Trigger: FULL`, generate a Stack Proposal with 2-3 candidates using the mandatory template (Context, Candidate Stacks with 10-factor assessment including Security posture and Escape velocity, Trade-off Summary, Recommendation, Operator Decision). The operator chooses; record the choice as a decision note in the plan's § Decisions section (not a standalone ADR). On `Trigger: SKIP`, document the incumbent or Default Recommendation in one line. If an architecture-driving stack choice was flagged at `/dr-prd`, the proposal at this step is the formal decision point. The chosen stack is bound by the immutability contract — revisable via Return-to-Plan amendment; a CVSS 9+ or KEV CVE suspends the binding (see `skills/tech-stack/SKILL.md` § Security-Emergency Fast-Track).

--- a/commands/dr-prd.md
+++ b/commands/dr-prd.md
@@ -97,6 +97,22 @@ Enforcing this binding mechanically is **site policy, and the framework ships no
         - **V-AC spec-graph evidence-edge seed.** For every V-AC-N in § Success Criteria, author it so its spec-graph Evidence edge is seedable: pair the `Covers:` binding with the intended verification (planned command / test / measurement) for that criterion. `/dr-do` step 7.6 turns that intent into the concrete `Evidence: V-AC-N — <artifact>` edge as tests are produced, and `spec-graph-gate.sh` verifies the resulting evidence coverage before `/dr-qa`. A V-AC with no seedable evidence path is under-specified — make it verifiable or fold it into a `D-REQ`.
     -   Save to `datarim/prd/PRD-{slug}.md`.
 
+5.5a. **CUSTOMER ACCEPTANCE TUPLE** (mandatory when any schema-v4 expectations
+    wish declares `customer_derived: true`):
+    - Create or update
+      `datarim/tasks/{TASK-ID}-customer-requirements.yaml` from
+      `${DATARIM_RUNTIME:-$HOME/.claude}/templates/customer-requirements-template.yaml`.
+      Preserve each source remark verbatim and bind every atomic `req-NNNN` to
+      one or more V-ACs through its expectations wish. A paraphrase is metadata,
+      never the source quotation.
+    - Every Requirement ID carries the full acceptance tuple: originating source and exact quotation; affected product and surface or route; locale, viewport, and theme dimensions when applicable; observable before-state and required after-state; evidence method and responsible owner; applicable role, skill, blueprint, constraint, policy, and success criterion; delivery task, code/content paths, and target environment; and customer disposition (`pending`, `accepted`, `rejected`, or `superseded`).
+    - For every user-facing Requirement, author at least one acceptance
+      criterion asserting an observable visitor-facing change on the live production product. Test-environment rendering is supporting evidence;
+      documentation, knowledge, tests, CI, and ledgers cannot satisfy it.
+    - `/dr-plan` pins the exact admissible knowledge revisions before work. Do
+      not fabricate a future selection timestamp or an implementation start
+      time in this stage.
+
 5.5b. **Append-merge expectations checklist (L3-L4, mandatory)** per `$HOME/.claude/skills/expectations-checklist/SKILL.md`:
     -   The checklist file `datarim/tasks/{TASK-ID}-expectations.md` is created by `/dr-init` at Step 4.7. At `/dr-prd`, the architect MUST append-merge any new wishes derived from the PRD § Success Criteria block — never create the file from scratch, and never replace existing operator-derived wishes.
     -   **Source of items.** Each operator wish becomes one item. Derive items from:
@@ -111,6 +127,17 @@ Enforcing this binding mechanically is **site policy, and the framework ships no
         - `#### История статусов` with one initial line `<ISO> / <local> · /dr-prd · pending → pending · reason: пункт создан при формировании PRD`; <!-- allow-non-ascii: russian-status-history-section-name-cited-from-canonical-schema -->
         - `#### Текущий статус` set to `pending`. <!-- allow-non-ascii: russian-current-status-section-name-cited-from-canonical-schema -->
     -   **Append-merge if the file already exists.** Load existing items by `wish_id`. New PRD-derived wishes whose slug does not match any existing item are appended at the bottom; existing items are not rewritten. If a previously-linked AC was renamed, append one `stage: append-merge` History line to the affected item.
+    -   **Legacy freeze before append.** If the file declares schema v1-v3,
+        do not append, reorder, or mutate any wish. First perform the full
+        full metadata-only migration to schema v4 required by
+        `skills/expectations-checklist/SKILL.md`: preserve bodies, titles,
+        history, order, and `wish_id`; add all missing versioned metadata and
+        `customer_derived` classifications; add the conditional binding quartet
+        to every `true` wish; record the migration; only then append.
+    -   Every appended schema-v4 item declares `customer_derived: true | false`.
+        A `true` item additionally carries `requirement_id`, `surface_class`,
+        `visitor_visible`, and the canonical `delivery_receipt` pointer; a
+        `false` item carries none of those four fields.
     -   **Post-write validation gate.** Invoke:
         ```bash
         "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-expectations-checklist.sh" --task {TASK-ID}

--- a/commands/dr-qa.md
+++ b/commands/dr-qa.md
@@ -288,9 +288,9 @@ Invoke both deterministic validators:
 
 ```bash
 "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-customer-delivery.sh" \
-    --root <repo-root> --task {TASK-ID} --stage qa --format json
+    --root <repo-root> --task "{TASK-ID}" --stage qa --format json
 "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-review-evolution.sh" \
-    --root <repo-root> --task {TASK-ID} --format json
+    --root <repo-root> --task "{TASK-ID}" --format json
 ```
 
 - Delivery exit `0` and review-evolution exit `0` are required. Delivery exit

--- a/commands/dr-qa.md
+++ b/commands/dr-qa.md
@@ -279,6 +279,35 @@ Invoke:
 
 ---
 
+## Layer 3d: Customer Delivery and Review Evolution (HARD)
+
+**Condition:** execute when the schema-v4 expectations file contains at least
+one `customer_derived: true` wish. Otherwise record `NOT_APPLICABLE`.
+
+Invoke both deterministic validators:
+
+```bash
+"${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-customer-delivery.sh" \
+    --root <repo-root> --task {TASK-ID} --stage qa --format json
+"${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-review-evolution.sh" \
+    --root <repo-root> --task {TASK-ID} --format json
+```
+
+- Delivery exit `0` and review-evolution exit `0` are required. Delivery exit
+  `1` is semantic NOT_MET and makes QA **FAIL**; exit `2` is a QA **BLOCKED**
+  configuration or required-artifact failure. Review-evolution exit `1` makes
+  QA **FAIL**; exit `2` is **BLOCKED**.
+- Include both JSON verdicts and exact findings in the QA report. Evolution
+  cannot replace the product fix, and `NO_CANON_CHANGE` is valid only with its
+  required evidence and reviewer approval.
+- Tools, documentation, tests, CI, and ledger output cannot satisfy a visitor-visible requirement. Green CI is not deployment, and deployment is
+  not customer visual acceptance.
+- The spec graph inventories Requirement-to-V-AC and downstream edges. These
+  validators retain semantic closure responsibility; do not treat a clean
+  graph inventory as delivery.
+
+---
+
 ## Layer 4: Code Quality
 
 **Condition:** Always executed.

--- a/dev-tools/spec-graph-gate.sh
+++ b/dev-tools/spec-graph-gate.sh
@@ -11,6 +11,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 LINT="${SCRIPT_DIR}/dr-lint.sh"
 TRACE="${SCRIPT_DIR}/dr-trace.sh"
 GRADE="${SCRIPT_DIR}/dr-spec-grade.sh"
+LIB="${SCRIPT_DIR}/../scripts/lib/spec-graph.sh"
 
 TASK=""
 STAGE=""
@@ -42,8 +43,10 @@ case "$STAGE" in
 esac
 case "$FORMAT" in json|text) ;; *) usage_die "--format must be json|text" ;; esac
 [ -d "$ROOT" ] || usage_die "root not found: $ROOT"
-[ -f "$LINT" ] && [ -f "$TRACE" ] && [ -f "$GRADE" ] \
+[ -f "$LINT" ] && [ -f "$TRACE" ] && [ -f "$GRADE" ] && [ -f "$LIB" ] \
     || usage_die "spec-graph helper missing under $SCRIPT_DIR"
+# shellcheck source=scripts/lib/spec-graph.sh
+. "$LIB"
 
 DATARIM_ROOT=""
 search="$ROOT"
@@ -57,6 +60,10 @@ PRD="$DATARIM_ROOT/prd/PRD-${TASK}.md"
 PLAN="$DATARIM_ROOT/plans/${TASK}-plan.md"
 EXPECTATIONS="$DATARIM_ROOT/tasks/${TASK}-expectations.md"
 TASK_DESC="$DATARIM_ROOT/tasks/${TASK}-task-description.md"
+CUSTOMER_REQUIREMENTS="$DATARIM_ROOT/tasks/${TASK}-customer-requirements.yaml"
+CUSTOMER_RECEIPT="$DATARIM_ROOT/receipts/${TASK}-customer-delivery.yaml"
+QA_REPORT="$DATARIM_ROOT/qa/qa-report-${TASK}.md"
+COMPLIANCE_REPORT="$DATARIM_ROOT/reports/compliance-report-${TASK}.md"
 
 # _match_complexity <file> <level-label>
 # Single helper shared by the PRD and task-description branches so the two
@@ -194,6 +201,92 @@ for artifact in "${required[@]}"; do
     [ -f "$artifact" ] || usage_die "required artifact missing for stage $STAGE: $artifact"
 done
 
+# Customer delivery extends the graph inventory, but does not become a second
+# closure validator. A schema-v4 customer-derived wish makes the extension
+# applicable. Plan/do fail hard only on the U3 pre-work prefix: stable
+# Requirement -> V-AC binding plus requirement and selected-knowledge receipt
+# edges with all six knowledge kinds. Downstream delivery edges may be absent
+# while implementation is in progress and remain owned by
+# check-customer-delivery.sh at QA/compliance/archive.
+customer_applicable=0
+customer_prework_ready=1
+customer_prework_findings=""
+customer_links_tmp=""
+customer_receipt_tmp=""
+customer_knowledge_tmp=""
+customer_requirement_knowledge_tmp=""
+lint_tmp=""
+trace_tmp=""
+grade_tmp=""
+customer_links_tmp="$(mktemp)" || usage_die "cannot allocate customer link inventory"
+trap 'rm -f -- "$lint_tmp" "$trace_tmp" "$grade_tmp" "$customer_links_tmp" "$customer_receipt_tmp" "$customer_knowledge_tmp" "$customer_requirement_knowledge_tmp"' EXIT
+customer_receipt_tmp="$(mktemp)" || usage_die "cannot allocate customer receipt inventory"
+customer_knowledge_tmp="$(mktemp)" || usage_die "cannot allocate customer knowledge inventory"
+customer_requirement_knowledge_tmp="$(mktemp)" \
+    || usage_die "cannot allocate customer requirement knowledge inventory"
+
+collect_customer_requirement_vac_edges "$EXPECTATIONS" include-incomplete >"$customer_links_tmp" \
+    || usage_die "customer requirement/V-AC collector failed"
+if [ -s "$customer_links_tmp" ]; then
+    customer_applicable=1
+    collect_customer_receipt_edges "$CUSTOMER_RECEIPT" >"$customer_receipt_tmp" \
+        || usage_die "customer receipt edge collector failed"
+    collect_customer_selected_knowledge_kinds "$CUSTOMER_RECEIPT" >"$customer_knowledge_tmp" \
+        || usage_die "customer selected-knowledge collector failed"
+    collect_customer_selected_knowledge_kinds "$CUSTOMER_REQUIREMENTS" \
+        >"$customer_requirement_knowledge_tmp" \
+        || usage_die "customer requirement knowledge collector failed"
+
+    if [ ! -f "$CUSTOMER_REQUIREMENTS" ]; then
+        customer_prework_ready=0
+        customer_prework_findings="${customer_prework_findings}missing_customer_requirements\n"
+    fi
+    if [ ! -f "$CUSTOMER_RECEIPT" ]; then
+        customer_prework_ready=0
+        customer_prework_findings="${customer_prework_findings}missing_customer_delivery_receipt\n"
+    fi
+
+    while IFS=$'\t' read -r requirement_id _vac _source; do
+        [ -n "$requirement_id" ] || continue
+        if [ "$requirement_id" = "__MISSING_REQUIREMENT__" ]; then
+            customer_prework_ready=0
+            customer_prework_findings="${customer_prework_findings}missing_customer_binding:requirement_id\n"
+            continue
+        fi
+        if [ "$_vac" = "__MISSING_VAC__" ]; then
+            customer_prework_ready=0
+            customer_prework_findings="${customer_prework_findings}missing_customer_binding:v_ac:${requirement_id}\n"
+            continue
+        fi
+        if ! collect_customer_requirement_ids "$CUSTOMER_REQUIREMENTS" | grep -qx "$requirement_id"; then
+            customer_prework_ready=0
+            customer_prework_findings="${customer_prework_findings}missing_requirement:${requirement_id}\n"
+        fi
+        for edge in requirement selected_knowledge; do
+            if ! awk -F'\t' -v req="$requirement_id" -v edge="$edge" \
+                '$1 == req && $2 == edge {found=1} END {exit(found ? 0 : 1)}' \
+                "$customer_receipt_tmp"; then
+                customer_prework_ready=0
+                customer_prework_findings="${customer_prework_findings}missing_prework_edge:${requirement_id}:${edge}\n"
+            fi
+        done
+        for kind in roles skills blueprints constraints policies success_criteria; do
+            if ! awk -F'\t' -v req="$requirement_id" -v kind="$kind" \
+                '$1 == req && $2 == kind {found=1} END {exit(found ? 0 : 1)}' \
+                "$customer_knowledge_tmp"; then
+                customer_prework_ready=0
+                customer_prework_findings="${customer_prework_findings}missing_knowledge_kind:${requirement_id}:${kind}\n"
+            fi
+            if ! awk -F'\t' -v req="$requirement_id" -v kind="$kind" \
+                '$1 == req && $2 == kind {found=1} END {exit(found ? 0 : 1)}' \
+                "$customer_requirement_knowledge_tmp"; then
+                customer_prework_ready=0
+                customer_prework_findings="${customer_prework_findings}missing_requirement_knowledge_kind:${requirement_id}:${kind}\n"
+            fi
+        done
+    done <"$customer_links_tmp"
+fi
+
 rules=""
 case "$STAGE" in
     prd)
@@ -207,10 +300,9 @@ case "$STAGE" in
         ;;
 esac
 
-lint_tmp="$(mktemp)"
-trace_tmp="$(mktemp)"
-grade_tmp="$(mktemp)"
-trap 'rm -f "$lint_tmp" "$trace_tmp" "$grade_tmp"' EXIT
+lint_tmp="$(mktemp)" || usage_die "cannot allocate lint output"
+trace_tmp="$(mktemp)" || usage_die "cannot allocate trace output"
+grade_tmp="$(mktemp)" || usage_die "cannot allocate grade output"
 
 bash "$LINT" --task "$TASK" --root "$ROOT" --stage "$STAGE" \
     --rules "$rules" --format json --advisory >"$lint_tmp"
@@ -262,21 +354,38 @@ if [ "$STAGE" = "do" ] && [ -s "$lint_tmp" ]; then
     exit_code=0
 fi
 
+if [ "$customer_applicable" -eq 1 ] \
+    && { [ "$STAGE" = "plan" ] || [ "$STAGE" = "do" ]; } \
+    && [ "$customer_prework_ready" -ne 1 ]; then
+    decision="blocked"
+    exit_code=1
+fi
+
 if [ "$FORMAT" = "json" ]; then
     python3 - "$TASK" "$STAGE" "$LEVEL" "$MODE" "$decision" \
         "$lint_tmp" "$trace_tmp" "$grade_tmp" "$ROOT" \
-        "$PRD" "$PLAN" "$EXPECTATIONS" "$TASK_DESC" <<'PYEOF'
+        "$PRD" "$PLAN" "$EXPECTATIONS" "$TASK_DESC" \
+        "$CUSTOMER_REQUIREMENTS" "$CUSTOMER_RECEIPT" \
+        "$customer_applicable" "$customer_prework_ready" \
+        "$customer_prework_findings" "$customer_links_tmp" \
+        "$customer_receipt_tmp" "$QA_REPORT" "$COMPLIANCE_REPORT" <<'PYEOF'
 import json
 import os
 import sys
 
-task, stage, level, mode, decision, lint_path, trace_path, grade_path, root, *canonical = sys.argv[1:]
+(
+    task, stage, level, mode, decision, lint_path, trace_path, grade_path, root,
+    prd, plan, expectations, task_desc, customer_requirements, customer_receipt,
+    customer_applicable, customer_prework_ready, customer_prework_findings,
+    customer_links_path, customer_receipt_path, qa_report, compliance_report,
+) = sys.argv[1:]
 with open(lint_path, encoding="utf-8") as fh:
     findings = [json.loads(line) for line in fh if line.strip()]
 with open(trace_path, encoding="utf-8") as fh:
     trace = json.load(fh)
 with open(grade_path, encoding="utf-8") as fh:
     grade = json.load(fh)
+canonical = (prd, plan, expectations, task_desc, customer_requirements, customer_receipt)
 included = [
     {"path": os.path.relpath(path, root), "reason": "canonical current-task artifact"}
     for path in canonical if os.path.isfile(path)
@@ -285,6 +394,82 @@ excluded = [
     {"path": os.path.relpath(path, root), "reason": "artifact absent and optional for this stage"}
     for path in canonical if not os.path.isfile(path)
 ]
+
+links = []
+with open(customer_links_path, encoding="utf-8") as fh:
+    for line in fh:
+        parts = line.rstrip("\n").split("\t")
+        if len(parts) >= 2:
+            links.append((parts[0], parts[1]))
+receipt_edges = {}
+with open(customer_receipt_path, encoding="utf-8") as fh:
+    for line in fh:
+        parts = line.rstrip("\n").split("\t")
+        if len(parts) >= 2:
+            receipt_edges.setdefault(parts[0], set()).add(parts[1])
+
+evidence_vacs = set()
+evidence_pattern = __import__("re").compile(r"Evidence:\s*(V-AC-[A-Z]?\d+(?:\.\d+)?)\s+—")
+for path in (task_desc, qa_report, compliance_report):
+    if not os.path.isfile(path):
+        continue
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            match = evidence_pattern.search(line)
+            if match:
+                evidence_vacs.add(match.group(1))
+
+edges = []
+missing = []
+for requirement, vac in links:
+    if requirement.startswith("__MISSING_") or vac.startswith("__MISSING_"):
+        missing.append("customer_binding")
+        continue
+    edges.append({"from": f"requirement:{requirement}", "to": f"vac:{vac}"})
+    present = receipt_edges.get(requirement, set())
+    if "selected_knowledge" in present:
+        edges.append({
+            "from": f"requirement:{requirement}",
+            "to": f"knowledge:{requirement}:selected_knowledge",
+        })
+    else:
+        missing.append(f"{requirement}:selected_knowledge")
+    if "red_green" in present and vac in evidence_vacs:
+        edges.append({"from": f"vac:{vac}", "to": f"evidence:{requirement}:red_green"})
+    else:
+        missing.append(f"{requirement}:evidence")
+    if "implementation_delta" in present:
+        edges.append({
+            "from": f"evidence:{requirement}:red_green",
+            "to": f"implementation:{requirement}:implementation_delta",
+        })
+    else:
+        missing.append(f"{requirement}:implementation")
+    if "live_evidence" in present:
+        edges.append({
+            "from": f"implementation:{requirement}:implementation_delta",
+            "to": f"live:{requirement}:live_evidence",
+        })
+    else:
+        missing.append(f"{requirement}:live")
+    if "customer_disposition" in present:
+        edges.append({
+            "from": f"live:{requirement}:live_evidence",
+            "to": f"customer:{requirement}:customer_disposition",
+        })
+    else:
+        missing.append(f"{requirement}:customer_disposition")
+
+customer_graph = {
+    "applicable": customer_applicable == "1",
+    "prework_ready": customer_prework_ready == "1",
+    "prework_findings": [
+        item for item in customer_prework_findings.split("\\n") if item
+    ],
+    "edges": edges,
+    "missing_edges": sorted(set(missing)),
+    "closure_authority": "check-customer-delivery.sh",
+}
 print(json.dumps({
     "task": task,
     "stage": stage,
@@ -296,6 +481,7 @@ print(json.dumps({
     "findings": findings,
     "trace": trace,
     "grade": grade,
+    "customer_delivery_prework": customer_graph,
 }, separators=(",", ":")))
 PYEOF
 else

--- a/dev-tools/tests/spec-graph-gate.bats
+++ b/dev-tools/tests/spec-graph-gate.bats
@@ -38,6 +38,94 @@ EOF
 EOF
 }
 
+write_customer_prework_fixture() {
+    write_fixture
+    cat >>"$WORK/datarim/tasks/GT-0001-expectations.md" <<'EOF'
+  - customer_derived: true
+  - requirement_id: req-0001
+  - surface_class: VISITOR_VISIBLE
+  - visitor_visible: true
+  - delivery_receipt: datarim/receipts/GT-0001-customer-delivery.yaml
+EOF
+    sed -i.bak '1i\---\nschema_version: 4\n---' \
+        "$WORK/datarim/tasks/GT-0001-expectations.md"
+    cat >"$WORK/datarim/tasks/GT-0001-customer-requirements.yaml" <<'EOF'
+requirements:
+  req-0001:
+    acceptance:
+      knowledge_selection:
+        roles: [{id: reviewer}]
+        skills: [{id: customer-delivery}]
+        blueprints: [{id: delivery-blueprint}]
+        constraints: [{id: prework}]
+        policies: [{id: delivery-policy}]
+        success_criteria: [{id: live-result}]
+EOF
+    mkdir -p "$WORK/datarim/receipts"
+    cat >"$WORK/datarim/receipts/GT-0001-customer-delivery.yaml" <<'EOF'
+requirements:
+  req-0001:
+    coverage_status: NOT_MET
+    missing_edges:
+      - implementation_delta
+      - red_green
+      - merged_revision
+      - deployed_revision
+      - live_evidence
+      - customer_disposition
+    coverage_chain:
+      requirement:
+        requirement_id: req-0001
+      selected_knowledge:
+        roles:
+          - id: reviewer
+            revision: "1"
+            digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+            selected_at: "2026-01-02T09:10:00Z"
+            selected_before_implementation: true
+            immutable: true
+        skills:
+          - id: customer-delivery
+            revision: "1"
+            digest: sha256:2222222222222222222222222222222222222222222222222222222222222222
+            selected_at: "2026-01-02T09:11:00Z"
+            selected_before_implementation: true
+            immutable: true
+        blueprints:
+          - id: delivery-blueprint
+            revision: "1"
+            digest: sha256:3333333333333333333333333333333333333333333333333333333333333333
+            selected_at: "2026-01-02T09:12:00Z"
+            selected_before_implementation: true
+            immutable: true
+        constraints:
+          - id: prework
+            revision: "1"
+            digest: sha256:4444444444444444444444444444444444444444444444444444444444444444
+            selected_at: "2026-01-02T09:13:00Z"
+            selected_before_implementation: true
+            immutable: true
+        policies:
+          - id: delivery-policy
+            revision: "1"
+            digest: sha256:5555555555555555555555555555555555555555555555555555555555555555
+            selected_at: "2026-01-02T09:14:00Z"
+            selected_before_implementation: true
+            immutable: true
+        success_criteria:
+          - id: live-result
+            revision: "1"
+            digest: sha256:6666666666666666666666666666666666666666666666666666666666666666
+            selected_at: "2026-01-02T09:15:00Z"
+            selected_before_implementation: true
+            immutable: true
+EOF
+    cp "$WORK/datarim/receipts/GT-0001-customer-delivery.yaml" \
+        "$WORK/datarim/tasks/GT-0001-customer-requirements.yaml"
+    sed -i.bak 's/^      selected_knowledge:/      knowledge_selection:/' \
+        "$WORK/datarim/tasks/GT-0001-customer-requirements.yaml"
+}
+
 @test "L3 defaults to advisory and emits evaluated artifact manifest" {
     write_fixture
     run "$SCRIPT" --task GT-0001 --stage qa --root "$WORK" --format json
@@ -127,6 +215,61 @@ EOF
         --task GT-0001 --stage verify --root "$WORK" --format json
     [ "$status" -eq 0 ] \
       && printf '%s\n' "$output" | grep -qF '"decision":"clean"'
+}
+
+@test "customer do stage emits a ready pre-work graph without claiming closure" {
+    write_customer_prework_fixture
+    run "$SCRIPT" --task GT-0001 --stage do --root "$WORK" --format json
+    [ "$status" -eq 0 ] \
+      && printf '%s\n' "$output" | grep -qF '"prework_ready":true' \
+      && printf '%s\n' "$output" | grep -qF '"closure_authority":"check-customer-delivery.sh"' \
+      && printf '%s\n' "$output" | grep -qF '"from":"requirement:req-0001"' \
+      && printf '%s\n' "$output" | grep -qF '"to":"vac:V-AC-1"'
+}
+
+@test "customer do stage blocks when the receipt lacks selected knowledge" {
+    write_customer_prework_fixture
+    sed -i.bak '/^      selected_knowledge:/,$d' \
+        "$WORK/datarim/receipts/GT-0001-customer-delivery.yaml"
+    run "$SCRIPT" --task GT-0001 --stage do --root "$WORK" --format json
+    [ "$status" -eq 1 ] \
+      && printf '%s\n' "$output" | grep -qF '"prework_ready":false'
+}
+
+@test "customer do stage cannot fail-open on an incomplete customer binding" {
+    write_customer_prework_fixture
+    sed -i.bak '/^  - requirement_id: req-0001$/d' \
+        "$WORK/datarim/tasks/GT-0001-expectations.md"
+    run "$SCRIPT" --task GT-0001 --stage do --root "$WORK" --format json
+    [ "$status" -eq 1 ] \
+      && printf '%s\n' "$output" | grep -qF 'missing_customer_binding:requirement_id'
+}
+
+@test "customer do stage blocks incomplete selected-knowledge pin metadata" {
+    write_customer_prework_fixture
+    sed -i.bak '/^            immutable: true$/d' \
+        "$WORK/datarim/receipts/GT-0001-customer-delivery.yaml"
+    run "$SCRIPT" --task GT-0001 --stage do --root "$WORK" --format json
+    [ "$status" -eq 1 ] \
+      && printf '%s\n' "$output" | grep -qF 'missing_knowledge_kind:req-0001:roles'
+}
+
+@test "customer do stage blocks incomplete issued-contract knowledge metadata" {
+    write_customer_prework_fixture
+    sed -i.bak '/^            revision: /d' \
+        "$WORK/datarim/tasks/GT-0001-customer-requirements.yaml"
+    run "$SCRIPT" --task GT-0001 --stage do --root "$WORK" --format json
+    [ "$status" -eq 1 ] \
+      && printf '%s\n' "$output" | grep -qF 'missing_requirement_knowledge_kind:req-0001:roles'
+}
+
+@test "spec graph inventory does not assume customer delivery closure authority" {
+    write_customer_prework_fixture
+    run env DATARIM_SPEC_GRAPH_MODE=hard "$SCRIPT" \
+        --task GT-0001 --stage qa --root "$WORK" --format json
+    [ "$status" -eq 0 ] \
+      && printf '%s\n' "$output" | grep -qF '"closure_authority":"check-customer-delivery.sh"' \
+      && printf '%s\n' "$output" | grep -qF '"missing_edges"'
 }
 
 # ===========================================================================

--- a/dev-tools/tests/spec-graph-lib.bats
+++ b/dev-tools/tests/spec-graph-lib.bats
@@ -107,3 +107,91 @@ assert "finding_id" in f, f
     [ "$status" -eq 0 ]
     [[ "$output" == "error" ]]
 }
+
+@test "customer requirement links become Requirement to V-AC edges" {
+    cat >"$WORK/expectations.md" <<'EOF'
+---
+schema_version: 4
+---
+- **1. Visitor result.**
+  - wish_id: visitor-result
+  - customer_derived: true
+  - requirement_id: req-0001
+  - Связанный AC из PRD: V-AC-7
+  - #### Текущий статус
+    - pending
+EOF
+    run bash -c "source '$LIB'; collect_customer_requirement_vac_edges '$WORK/expectations.md'"
+    [ "$status" -eq 0 ] \
+      && [ "$output" = $'req-0001\tV-AC-7\texpectations.md' ]
+}
+
+@test "legacy or commented customer metadata does not create graph edges" {
+    cat >"$WORK/expectations.md" <<'EOF'
+---
+schema_version: 3
+---
+- **1. Legacy wish.**
+  - wish_id: legacy-wish
+  - customer_derived: true
+  - requirement_id: req-0001
+  - Связанный AC из PRD: V-AC-7
+<!--
+  - wish_id: commented-wish
+  - customer_derived: true
+  - requirement_id: req-0002
+  - Связанный AC из PRD: V-AC-8
+-->
+EOF
+    run bash -c "source '$LIB'; collect_customer_requirement_vac_edges '$WORK/expectations.md'"
+    [ "$status" -eq 0 ] && [ -z "$output" ]
+}
+
+@test "customer receipt becomes evidence implementation live and customer edges" {
+    cat >"$WORK/receipt.yaml" <<'EOF'
+requirements:
+  req-0001:
+    coverage_status: MET
+    coverage_chain:
+      requirement:
+        requirement_id: req-0001
+      selected_knowledge:
+        roles: []
+      implementation_delta:
+        task_id: task:web:0001
+      red_green:
+        red: {}
+        green: {}
+      live_evidence:
+        evidence_ref: artifacts/live.json
+      customer_disposition:
+        status: accepted
+EOF
+    run bash -c "source '$LIB'; collect_customer_receipt_edges '$WORK/receipt.yaml'"
+    [ "$status" -eq 0 ] \
+      && printf '%s\n' "$output" | grep -qF $'req-0001\tselected_knowledge' \
+      && printf '%s\n' "$output" | grep -qF $'req-0001\tred_green' \
+      && printf '%s\n' "$output" | grep -qF $'req-0001\timplementation_delta' \
+      && printf '%s\n' "$output" | grep -qF $'req-0001\tlive_evidence' \
+      && printf '%s\n' "$output" | grep -qF $'req-0001\tcustomer_disposition'
+}
+
+@test "selected knowledge collector requires immutable revision digest and timestamp" {
+    cat >"$WORK/receipt.yaml" <<'EOF'
+requirements:
+  req-0001:
+    coverage_chain:
+      selected_knowledge:
+        roles:
+          - id: reviewer
+            revision: "1"
+            digest: sha256:1111111111111111111111111111111111111111111111111111111111111111
+            selected_at: "2026-01-02T09:10:00Z"
+            selected_before_implementation: true
+            immutable: true
+        skills: [{id: incomplete-inline-entry}]
+EOF
+    run bash -c "source '$LIB'; collect_customer_selected_knowledge_kinds '$WORK/receipt.yaml'"
+    [ "$status" -eq 0 ] \
+      && [ "$output" = $'req-0001\troles' ]
+}

--- a/dev-tools/tests/spec-graph-wiring.bats
+++ b/dev-tools/tests/spec-graph-wiring.bats
@@ -10,6 +10,27 @@ setup() {
     done
 }
 
+@test "customer hard stages invoke the delivery and review-evolution validators" {
+    for pair in 'dr-qa qa' 'dr-compliance compliance' 'dr-archive archive'; do
+        read -r command stage <<<"$pair"
+        grep -qF 'check-customer-delivery.sh' "$REPO_ROOT/commands/$command.md" \
+          && grep -qF -- "--stage $stage" "$REPO_ROOT/commands/$command.md" \
+          && grep -qF 'check-review-evolution.sh' "$REPO_ROOT/commands/$command.md" \
+          || return 1
+    done
+}
+
+@test "do command consumes the spec-graph customer pre-work verdict" {
+    grep -qF 'customer_delivery_prework' "$REPO_ROOT/commands/dr-do.md" \
+      && grep -qF 'prework_ready' "$REPO_ROOT/commands/dr-do.md"
+}
+
+@test "spec graph declares customer edge collectors and external closure authority" {
+    grep -qF 'collect_customer_requirement_vac_edges' "$REPO_ROOT/scripts/lib/spec-graph.sh" \
+      && grep -qF 'collect_customer_receipt_edges' "$REPO_ROOT/scripts/lib/spec-graph.sh" \
+      && grep -qF 'check-customer-delivery.sh' "$REPO_ROOT/dev-tools/spec-graph-gate.sh"
+}
+
 @test "pipeline agents carry graph authoring and verification responsibilities" {
     grep -qF 'Covers:' "$REPO_ROOT/agents/architect.md" \
       && grep -qF 'Verifies:' "$REPO_ROOT/agents/planner.md" \

--- a/scripts/lib/spec-graph.sh
+++ b/scripts/lib/spec-graph.sh
@@ -470,3 +470,264 @@ with open(path, encoding="utf-8") as fh:
 flush()
 PYEOF
 }
+
+# collect_customer_requirement_vac_edges <expectations-file>
+# Prints: requirement_id<TAB>linked_vac<TAB>source-basename
+#
+# This is an inventory edge only. The expectations validator remains the
+# authority for schema-v4 classification and binding validity.
+collect_customer_requirement_vac_edges() {
+    local file="$1"
+    local mode="${2:-complete-only}"
+    case "$mode" in
+        complete-only|include-incomplete) ;;
+        *) return 2 ;;
+    esac
+    [ -f "$file" ] || return 0
+    python3 - "$file" "$mode" <<'PYEOF'
+import os
+import re
+import sys
+
+path = sys.argv[1]
+include_incomplete = sys.argv[2] == "include-incomplete"
+current = None
+schema_version = None
+frontmatter_seen = False
+in_frontmatter = False
+in_comment = False
+fence = None
+
+
+def emit(item):
+    if schema_version != 4 or not item or item["customer_derived"] != "true":
+        return
+    if include_incomplete or (item["requirement_id"] and item["vac"]):
+        print("\t".join((
+            item["requirement_id"] or "__MISSING_REQUIREMENT__",
+            item["vac"] or "__MISSING_VAC__",
+            os.path.basename(path),
+        )))
+
+
+with open(path, encoding="utf-8") as handle:
+    for raw in handle:
+        line = raw.rstrip("\n")
+        if line == "---" and not frontmatter_seen:
+            frontmatter_seen = True
+            in_frontmatter = True
+            continue
+        if line == "---" and in_frontmatter:
+            in_frontmatter = False
+            continue
+        if in_frontmatter:
+            match = re.match(r"^schema_version:\s*([0-9]+)\s*$", line)
+            if match:
+                schema_version = int(match.group(1))
+            continue
+        stripped = line.lstrip(" ")
+        fence_match = re.match(r"^(`{3,}|~{3,})", stripped)
+        if fence_match:
+            marker = fence_match.group(1)
+            if fence is None:
+                fence = (marker[0], len(marker))
+            elif marker[0] == fence[0] and len(marker) >= fence[1]:
+                fence = None
+            continue
+        if fence is not None:
+            continue
+        if in_comment:
+            if "-->" in line:
+                in_comment = False
+            continue
+        if "<!--" in line:
+            if "-->" not in line.split("<!--", 1)[1]:
+                in_comment = True
+            continue
+        match = re.match(r"^  - wish_id:\s*(\S+)\s*$", line)
+        if match:
+            emit(current)
+            current = {
+                "customer_derived": "",
+                "requirement_id": "",
+                "vac": "",
+            }
+            continue
+        if current is None:
+            continue
+        match = re.match(r"^  - customer_derived:\s*(true|false)\s*$", line)
+        if match:
+            current["customer_derived"] = match.group(1)
+            continue
+        match = re.match(r"^  - requirement_id:\s*(req-[0-9]{4})\s*$", line)
+        if match:
+            current["requirement_id"] = match.group(1)
+            continue
+        if "Связанный AC из PRD:" in line:
+            match = re.search(r"V-AC-[A-Z]?\d+(?:\.\d+)?", line)
+            current["vac"] = match.group(0) if match else ""
+if schema_version == 4:
+    emit(current)
+PYEOF
+}
+
+# collect_customer_requirement_ids <requirements-file>
+# Prints one schema-shaped requirement id per line. This is deliberately a
+# structural collector; check-customer-delivery.sh owns semantic closure.
+collect_customer_requirement_ids() {
+    local file="$1"
+    [ -f "$file" ] || return 0
+    sed -nE 's/^  (req-[0-9]{4}):[[:space:]]*$/\1/p' "$file"
+}
+
+# collect_customer_receipt_edges <receipt-file>
+# Prints: requirement_id<TAB>coverage_chain_edge<TAB>source-basename
+# Only canonical coverage-chain keys are emitted. Absence stays observable to
+# the stage adapter as a missing edge; this function never supplies a verdict.
+collect_customer_receipt_edges() {
+    local file="$1"
+    [ -f "$file" ] || return 0
+    python3 - "$file" <<'PYEOF'
+import os
+import re
+import sys
+
+path = sys.argv[1]
+allowed = {
+    "requirement",
+    "selected_knowledge",
+    "implementation_delta",
+    "red_green",
+    "merged_revision",
+    "deployed_revision",
+    "live_evidence",
+    "customer_disposition",
+}
+requirement = ""
+in_chain = False
+with open(path, encoding="utf-8") as handle:
+    for raw in handle:
+        line = raw.rstrip("\n")
+        match = re.match(r"^  (req-[0-9]{4}):\s*$", line)
+        if match:
+            requirement = match.group(1)
+            in_chain = False
+            continue
+        if requirement and re.match(r"^    coverage_chain:\s*$", line):
+            in_chain = True
+            continue
+        match = re.match(r"^      ([a-z_]+):\s*$", line)
+        if requirement and in_chain and match:
+            edge = match.group(1)
+            if edge in allowed:
+                print("\t".join((requirement, edge, os.path.basename(path))))
+            continue
+        if requirement and in_chain and re.match(r"^    [a-z_]+:", line):
+            in_chain = False
+PYEOF
+}
+
+# collect_customer_selected_knowledge_kinds <receipt-file>
+# Prints: requirement_id<TAB>knowledge-kind. Used by the pre-work gate to
+# distinguish a selected_knowledge label from the complete six-kind U3 pin.
+collect_customer_selected_knowledge_kinds() {
+    local file="$1"
+    [ -f "$file" ] || return 0
+    python3 - "$file" <<'PYEOF'
+import re
+import sys
+
+path = sys.argv[1]
+kind_order = (
+    "roles",
+    "skills",
+    "blueprints",
+    "constraints",
+    "policies",
+    "success_criteria",
+)
+allowed = set(kind_order)
+requirement = ""
+in_selected = False
+current_kind = ""
+current_item = None
+kind_items = {}
+
+
+def unquote(value):
+    value = value.strip()
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in "\"'":
+        return value[1:-1]
+    return value
+
+
+def flush_item():
+    global current_item
+    if not requirement or not current_kind or current_item is None:
+        current_item = None
+        return
+    values = {key: unquote(value) for key, value in current_item.items()}
+    valid = (
+        bool(values.get("id"))
+        and values.get("id") not in {"Gap", "Unbound"}
+        and bool(values.get("revision"))
+        and re.fullmatch(r"sha256:[0-9a-f]{64}", values.get("digest", "")) is not None
+        and re.fullmatch(
+            r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})",
+            values.get("selected_at", ""),
+        ) is not None
+        and values.get("selected_before_implementation") == "true"
+        and values.get("immutable") == "true"
+    )
+    kind_items.setdefault((requirement, current_kind), []).append(valid)
+    current_item = None
+
+
+def flush_kind():
+    global current_kind
+    flush_item()
+    current_kind = ""
+
+
+with open(path, encoding="utf-8") as handle:
+    for raw in handle:
+        line = raw.rstrip("\n")
+        match = re.match(r"^  (req-[0-9]{4}):\s*$", line)
+        if match:
+            flush_kind()
+            requirement = match.group(1)
+            in_selected = False
+            continue
+        if requirement and re.match(r"^      (?:selected_knowledge|knowledge_selection):\s*$", line):
+            flush_kind()
+            in_selected = True
+            continue
+        if requirement and in_selected:
+            match = re.match(r"^        ([a-z_]+):\s*$", line)
+            if match and match.group(1) in allowed:
+                flush_kind()
+                current_kind = match.group(1)
+                continue
+            match = re.match(r"^          - id:\s*(\S.*?)\s*$", line)
+            if current_kind and match:
+                flush_item()
+                current_item = {"id": match.group(1)}
+                continue
+            match = re.match(
+                r"^            (revision|digest|selected_at|selected_before_implementation|immutable):\s*(\S.*?)\s*$",
+                line,
+            )
+            if current_item is not None and match:
+                current_item[match.group(1)] = match.group(2)
+                continue
+            if re.match(r"^      [a-z_]+:", line) or re.match(r"^    [a-z_]+:", line):
+                flush_kind()
+                in_selected = False
+flush_kind()
+for req in sorted({req for req, _kind in kind_items}):
+    for kind in kind_order:
+        items = kind_items.get((req, kind), [])
+        if items and all(items):
+            print("\t".join((req, kind)))
+PYEOF
+}

--- a/tests/customer-delivery-command-wiring.bats
+++ b/tests/customer-delivery-command-wiring.bats
@@ -1,0 +1,98 @@
+#!/usr/bin/env bats
+
+setup() {
+    REPO_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+}
+
+assert_contains() {
+    local file="$1" literal="$2"
+    grep -qF -- "$literal" "$file"
+}
+
+@test "init preserves every customer remark verbatim for atomic Requirement IDs" {
+    assert_contains "$REPO_ROOT/commands/dr-init.md" \
+        'Customer remarks (verbatim requirement intake)'
+}
+
+@test "init creates new expectations with current schema v4 customer classification" {
+    assert_contains "$REPO_ROOT/commands/dr-init.md" 'schema_version: 4' \
+      && assert_contains "$REPO_ROOT/commands/dr-init.md" 'customer_derived: true | false'
+}
+
+@test "PRD authors the complete customer acceptance tuple and live visitor AC" {
+    local spec="$REPO_ROOT/commands/dr-prd.md"
+    for literal in \
+        'originating source and exact quotation' \
+        'affected product and surface or route' \
+        'locale, viewport, and theme dimensions' \
+        'observable before-state and required after-state' \
+        'evidence method and responsible owner' \
+        'role, skill, blueprint, constraint, policy, and success criterion' \
+        'delivery task, code/content paths, and target environment' \
+        'customer disposition' \
+        'observable visitor-facing change on the live production product'; do
+        assert_contains "$spec" "$literal" || return 1
+    done
+}
+
+@test "plan pins all six knowledge kinds before implementation and forbids post-hoc attribution" {
+    local spec="$REPO_ROOT/commands/dr-plan.md"
+    assert_contains "$spec" 'role, skill, blueprint, constraint, policy, and success criterion' \
+      && assert_contains "$spec" 'immutable revision, digest, and selection timestamp' \
+      && assert_contains "$spec" 'Selection after implementation starts is post-hoc attribution and fails'
+}
+
+@test "plan creates a NOT_MET receipt prefix before implementation" {
+    local spec="$REPO_ROOT/commands/dr-plan.md"
+    assert_contains "$spec" 'coverage_status: NOT_MET' \
+      && assert_contains "$spec" 'requirement and selected_knowledge edges' \
+      && assert_contains "$spec" 'before implementation starts'
+}
+
+@test "do blocks implementation until the customer receipt pre-work prefix is ready" {
+    local spec="$REPO_ROOT/commands/dr-do.md"
+    assert_contains "$spec" 'CUSTOMER DELIVERY RECEIPT PRE-WORK GATE' \
+      && assert_contains "$spec" 'customer_delivery_prework' \
+      && assert_contains "$spec" 'Do not write code or content until `prework_ready` is `true`'
+}
+
+@test "PRD and plan forbid appending to legacy expectations before full v4 migration" {
+    for command in dr-prd dr-plan; do
+        local spec="$REPO_ROOT/commands/${command}.md"
+        assert_contains "$spec" 'v1-v3' \
+          && assert_contains "$spec" 'full metadata-only migration to schema v4' \
+          || return 1
+    done
+}
+
+@test "QA hard-gates customer delivery and review evolution" {
+    local spec="$REPO_ROOT/commands/dr-qa.md"
+    assert_contains "$spec" 'check-customer-delivery.sh' \
+      && assert_contains "$spec" '--stage qa' \
+      && assert_contains "$spec" 'check-review-evolution.sh' \
+      && assert_contains "$spec" 'semantic NOT_MET'
+}
+
+@test "compliance hard-gates customer delivery and review evolution" {
+    local spec="$REPO_ROOT/commands/dr-compliance.md"
+    assert_contains "$spec" 'check-customer-delivery.sh' \
+      && assert_contains "$spec" '--stage compliance' \
+      && assert_contains "$spec" 'check-review-evolution.sh' \
+      && assert_contains "$spec" 'NON-COMPLIANT'
+}
+
+@test "archive hard-gates customer delivery and review evolution" {
+    local spec="$REPO_ROOT/commands/dr-archive.md"
+    assert_contains "$spec" 'check-customer-delivery.sh' \
+      && assert_contains "$spec" '--stage archive' \
+      && assert_contains "$spec" 'check-review-evolution.sh' \
+      && assert_contains "$spec" 'STOP the archive'
+}
+
+@test "hard stage commands distinguish enabling evidence from visitor delivery" {
+    for command in dr-qa dr-compliance dr-archive; do
+        assert_contains "$REPO_ROOT/commands/${command}.md" \
+            'Tools, documentation, tests, CI, and ledger output cannot satisfy a visitor-visible requirement' \
+          || return 1
+    done
+}

--- a/tests/test-tune-0266-init-step-4-7.bats
+++ b/tests/test-tune-0266-init-step-4-7.bats
@@ -35,9 +35,9 @@ CMDS_DIR="$BATS_TEST_DIRNAME/../commands"
         | grep -q "L1-L4"
 }
 
-@test "dr-init.md Step 4.7 references schema_version 2" {
+@test "dr-init.md Step 4.7 references current schema_version 4" {
     awk '/^4\.7\./{flag=1} /^5\.  /{flag=0} flag' "$CMDS_DIR/dr-init.md" \
-        | grep -q "schema_version: 2"
+        | grep -q "schema_version: 4"
 }
 
 @test "dr-init.md Step 4.7 references evidence_type default empirical" {


### PR DESCRIPTION
## Summary
- wire verbatim customer intake, full acceptance tuples, immutable pre-work knowledge pins, and receipt prefixes through init/PRD/plan/do
- add Requirement-to-V-AC and receipt-edge inventory while retaining `check-customer-delivery.sh` as semantic closure authority
- hard-gate customer delivery plus review evolution at QA, compliance, and archive, with legacy v1-v3 expectations frozen until metadata-only v4 migration

## Test Plan
- [x] 96 focused and adjacent spec-graph/command Bats cases
- [x] ShellCheck at warning severity for changed shell sources
- [x] Bats registry, doc-reference, template/dev-tools path, English-body, and whitespace gates
- [x] signed commit verified