### PR TITLE
Fix framework accountability and embedded L1/L2 plans

### DIFF
--- a/commands/dr-do.md
+++ b/commands/dr-do.md
@@ -111,7 +111,7 @@ Note: the machine-local PreToolUse guard remains the hard floor; this Step-0 che
     applicability; task prose or the parent command must not pre-classify it.
     ```bash
     "${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-framework-version-accountability.sh" \
-      --task {TASK-ID} --workspace <workspace-root> --repo <framework-repo>
+      --task {TASK-ID} --workspace <workspace-root> --repo <implementation-repo>
     ```
     - Exit 0 with `not_applicable`, `satisfied_by_version`, or
       `satisfied_by_deferral` permits the remaining `/dr-do` gates.

--- a/dev-tools/check-framework-version-accountability.sh
+++ b/dev-tools/check-framework-version-accountability.sh
@@ -90,6 +90,42 @@ is_accountability_path() {
   esac
 }
 
+is_datarim_identity_commit() {
+  local oid="$1" entries
+  entries="$(git -C "$repo" ls-tree "$oid" -- VERSION commands skills 2>/dev/null)" \
+    || return 2
+  printf '%s\n' "$entries" | awk '
+    $2 == "blob" && $4 == "VERSION" { version = 1 }
+    $2 == "tree" && $4 == "commands" { commands = 1 }
+    $2 == "tree" && $4 == "skills" { skills = 1 }
+    END { exit(version && commands && skills ? 0 : 1) }
+  '
+}
+
+has_committed_datarim_identity() {
+  local oid identity_status history
+  identity_status=0
+  is_datarim_identity_commit "$head_oid" || identity_status=$?
+  case "$identity_status" in
+    0) return 0 ;;
+    1) ;;
+    *) return 2 ;;
+  esac
+  history="$(git -C "$repo" rev-list --all -- VERSION commands skills 2>/dev/null)" \
+    || return 2
+  while IFS= read -r oid; do
+    [ -n "$oid" ] || continue
+    identity_status=0
+    is_datarim_identity_commit "$oid" || identity_status=$?
+    case "$identity_status" in
+      0) return 0 ;;
+      1) ;;
+      *) return 2 ;;
+    esac
+  done <<< "$history"
+  return 1
+}
+
 emit() {
   local disposition="$1" code="$2"
   printf 'framework-version-accountability: disposition=%s base=%s head=%s scope_digest=%s\n' \
@@ -128,6 +164,15 @@ git -C "$repo" rev-parse --git-dir >/dev/null 2>&1 || fail_untrusted not_git_rep
 head_oid="$(git -C "$repo" rev-parse 'HEAD^{commit}' 2>/dev/null)" || fail_untrusted invalid_head
 
 record="$workspace/datarim/.auto/version-accountability/$task/baseline.record"
+if [ ! -e "$record" ] && [ ! -L "$record" ]; then
+  identity_status=0
+  has_committed_datarim_identity || identity_status=$?
+  case "$identity_status" in
+    0) fail_untrusted missing_baseline ;;
+    1) emit not_applicable 0 ;;
+    *) fail_untrusted identity_history_unreadable ;;
+  esac
+fi
 if [ ! -f "$record" ] || [ -L "$record" ]; then fail_untrusted missing_baseline; fi
 [ "$(stat_owner "$record")" = "$(id -u)" ] || fail_untrusted baseline_owner
 [ "$(stat_mode "$record")" = 600 ] || fail_untrusted baseline_mode

--- a/dev-tools/dr-spec-lint.sh
+++ b/dev-tools/dr-spec-lint.sh
@@ -77,33 +77,68 @@ done
 [ -n "$DATARIM_ROOT" ] || usage_die "datarim/ not found from $ROOT"
 
 PRD_FILE="$DATARIM_ROOT/prd/PRD-${SPEC_TASK}.md"
-PLAN_FILE="$DATARIM_ROOT/plans/${SPEC_TASK}-plan.md"
+DEDICATED_PLAN_FILE="$DATARIM_ROOT/plans/${SPEC_TASK}-plan.md"
 EXP_FILE="$DATARIM_ROOT/tasks/${SPEC_TASK}-expectations.md"
 TASK_FILE="$DATARIM_ROOT/tasks/${SPEC_TASK}-task-description.md"
 QA_FILE="$DATARIM_ROOT/qa/qa-report-${SPEC_TASK}.md"
 COMPLIANCE_FILE="$DATARIM_ROOT/reports/compliance-report-${SPEC_TASK}.md"
 
-# The graph needs at least one source artefact (PRD or plan) to exist.
+# Determine complexity from the canonical field, with task-description and
+# index-row fallbacks matching spec-graph-gate.sh.
+LEVEL="L3"
+_resolved=0
+if [ -f "$PRD_FILE" ]; then
+    if grep -qiE '^[[:space:]]*(\*\*)?complexity[^:]*:[^[:alnum:]]*(Level[[:space:]]+4|L4)\b' "$PRD_FILE"; then LEVEL="L4"; _resolved=1
+    elif grep -qiE '^[[:space:]]*(\*\*)?complexity[^:]*:[^[:alnum:]]*(Level[[:space:]]+3|L3)\b' "$PRD_FILE"; then LEVEL="L3"; _resolved=1
+    elif grep -qiE '^[[:space:]]*(\*\*)?complexity[^:]*:[^[:alnum:]]*(Level[[:space:]]+2|L2)\b' "$PRD_FILE"; then LEVEL="L2"; _resolved=1
+    elif grep -qiE '^[[:space:]]*(\*\*)?complexity[^:]*:[^[:alnum:]]*(Level[[:space:]]+1|L1)\b' "$PRD_FILE"; then LEVEL="L1"; _resolved=1
+    fi
+fi
+
+if [ "$_resolved" -eq 0 ] && [ -f "$TASK_FILE" ]; then
+    if grep -qiE '^[[:space:]]*(\*\*)?complexity[^:]*:[^[:alnum:]]*(Level[[:space:]]+4|L4)\b' "$TASK_FILE"; then LEVEL="L4"; _resolved=1
+    elif grep -qiE '^[[:space:]]*(\*\*)?complexity[^:]*:[^[:alnum:]]*(Level[[:space:]]+3|L3)\b' "$TASK_FILE"; then LEVEL="L3"; _resolved=1
+    elif grep -qiE '^[[:space:]]*(\*\*)?complexity[^:]*:[^[:alnum:]]*(Level[[:space:]]+2|L2)\b' "$TASK_FILE"; then LEVEL="L2"; _resolved=1
+    elif grep -qiE '^[[:space:]]*(\*\*)?complexity[^:]*:[^[:alnum:]]*(Level[[:space:]]+1|L1)\b' "$TASK_FILE"; then LEVEL="L1"; _resolved=1
+    fi
+fi
+
+if [ "$_resolved" -eq 0 ]; then
+    for _idx in "$DATARIM_ROOT/backlog.md" "$DATARIM_ROOT/tasks.md"; do
+        [ -f "$_idx" ] || continue
+        _row="$(grep -m1 -E "^- ${SPEC_TASK} ·" "$_idx" || true)"
+        [ -n "$_row" ] || continue
+        if printf '%s' "$_row" | grep -qE '· L1 ·'; then LEVEL="L1"; break
+        elif printf '%s' "$_row" | grep -qE '· L2 ·'; then LEVEL="L2"; break
+        elif printf '%s' "$_row" | grep -qE '· L4 ·'; then LEVEL="L4"; break
+        elif printf '%s' "$_row" | grep -qE '· L3 ·'; then LEVEL="L3"; break
+        fi
+    done
+fi
+
+# Planning storage is complexity-dependent: L1/L2 embed the canonical plan in
+# the task description, while L3/L4 own a dedicated datarim/plans artefact.
+case "$LEVEL" in
+    L1|L2) PLAN_FILE="$TASK_FILE" ;;
+    L3|L4) PLAN_FILE="$DEDICATED_PLAN_FILE" ;;
+esac
+
+case "$SPEC_STAGE" in
+    plan|do|qa|compliance)
+        [ -f "$PLAN_FILE" ] \
+            || usage_die "required canonical plan missing for $LEVEL task: $PLAN_FILE"
+        ;;
+esac
+
+# The graph needs at least one source artefact (PRD or canonical plan) to exist.
 if [ ! -f "$PRD_FILE" ] && [ ! -f "$PLAN_FILE" ]; then
-    usage_die "no PRD or plan artefact for $SPEC_TASK under $DATARIM_ROOT (prd/ plans/)"
+    usage_die "no PRD or canonical plan artefact for $SPEC_TASK under $DATARIM_ROOT"
 fi
 
 # Spec-graph documents to scan (PRD carries D-REQ + V-AC; plan may carry V-AC).
 SPEC_DOCS=()
 [ -f "$PRD_FILE" ] && SPEC_DOCS+=("$PRD_FILE")
 [ -f "$PLAN_FILE" ] && SPEC_DOCS+=("$PLAN_FILE")
-
-# Determine complexity from the canonical field, with task-description fallback.
-LEVEL="L3"
-if [ -f "$PRD_FILE" ] && grep -qiE '^[[:space:]]*(\*\*)?complexity[^:]*:[^[:alnum:]]*(Level[[:space:]]+4|L4)\b' "$PRD_FILE"; then LEVEL="L4"
-elif [ -f "$PRD_FILE" ] && grep -qiE '^[[:space:]]*(\*\*)?complexity[^:]*:[^[:alnum:]]*(Level[[:space:]]+2|L2)\b' "$PRD_FILE"; then LEVEL="L2"
-elif [ -f "$PRD_FILE" ] && grep -qiE '^[[:space:]]*(\*\*)?complexity[^:]*:[^[:alnum:]]*(Level[[:space:]]+1|L1)\b' "$PRD_FILE"; then LEVEL="L1"
-elif [ -f "$TASK_FILE" ]; then
-    if grep -qiE '^[[:space:]]*(\*\*)?complexity[^:]*:[^[:alnum:]]*(Level[[:space:]]+4|L4)\b' "$TASK_FILE"; then LEVEL="L4"
-    elif grep -qiE '^[[:space:]]*(\*\*)?complexity[^:]*:[^[:alnum:]]*(Level[[:space:]]+2|L2)\b' "$TASK_FILE"; then LEVEL="L2"
-    elif grep -qiE '^[[:space:]]*(\*\*)?complexity[^:]*:[^[:alnum:]]*(Level[[:space:]]+1|L1)\b' "$TASK_FILE"; then LEVEL="L1"
-    fi
-fi
 
 # ---------------------------------------------------------------------------
 # Findings bookkeeping. We collect findings into a temp file (JSONL) so we can

--- a/dev-tools/spec-graph-gate.sh
+++ b/dev-tools/spec-graph-gate.sh
@@ -54,7 +54,8 @@ done
 [ -n "$DATARIM_ROOT" ] || usage_die "datarim/ not found from $ROOT"
 
 PRD="$DATARIM_ROOT/prd/PRD-${TASK}.md"
-PLAN="$DATARIM_ROOT/plans/${TASK}-plan.md"
+DEDICATED_PLAN="$DATARIM_ROOT/plans/${TASK}-plan.md"
+PLAN="$DEDICATED_PLAN"
 EXPECTATIONS="$DATARIM_ROOT/tasks/${TASK}-expectations.md"
 TASK_DESC="$DATARIM_ROOT/tasks/${TASK}-task-description.md"
 
@@ -76,6 +77,7 @@ _resolved=0
 
 if [ -f "$PRD" ]; then
     if _match_complexity "$PRD" "L4"; then LEVEL="L4"; _resolved=1
+    elif _match_complexity "$PRD" "L3"; then LEVEL="L3"; _resolved=1
     elif _match_complexity "$PRD" "L2"; then LEVEL="L2"; _resolved=1
     elif _match_complexity "$PRD" "L1"; then LEVEL="L1"; _resolved=1
     fi
@@ -83,6 +85,7 @@ fi
 
 if [ "$_resolved" -eq 0 ] && [ -f "$TASK_DESC" ]; then
     if _match_complexity "$TASK_DESC" "L4"; then LEVEL="L4"; _resolved=1
+    elif _match_complexity "$TASK_DESC" "L3"; then LEVEL="L3"; _resolved=1
     elif _match_complexity "$TASK_DESC" "L2"; then LEVEL="L2"; _resolved=1
     elif _match_complexity "$TASK_DESC" "L1"; then LEVEL="L1"; _resolved=1
     fi
@@ -109,6 +112,13 @@ if [ "$_resolved" -eq 0 ]; then
         fi
     done
 fi
+
+# Planning storage is complexity-dependent: L1/L2 embed the canonical plan in
+# the task description, while L3/L4 own a dedicated datarim/plans artefact.
+case "$LEVEL" in
+    L1|L2) PLAN="$TASK_DESC" ;;
+    L3|L4) PLAN="$DEDICATED_PLAN" ;;
+esac
 
 MODE="${DATARIM_SPEC_GRAPH_MODE:-advisory}"
 case "$MODE" in advisory|hard) ;; *) usage_die "DATARIM_SPEC_GRAPH_MODE must be advisory|hard" ;; esac
@@ -174,7 +184,9 @@ case "$STAGE" in
     plan|do|qa|compliance) required+=("$PLAN") ;;
 esac
 case "$STAGE" in
-    do|qa|compliance) required+=("$TASK_DESC") ;;
+    do|qa|compliance)
+        [ "$TASK_DESC" = "$PLAN" ] || required+=("$TASK_DESC")
+        ;;
 esac
 if { [ "$LEVEL" = "L3" ] || [ "$LEVEL" = "L4" ]; } && [ "$STAGE" != "verify" ]; then
     required+=("$EXPECTATIONS")
@@ -279,11 +291,13 @@ with open(grade_path, encoding="utf-8") as fh:
     grade = json.load(fh)
 included = [
     {"path": os.path.relpath(path, root), "reason": "canonical current-task artifact"}
-    for path in canonical if os.path.isfile(path)
+    for index, path in enumerate(canonical)
+    if path not in canonical[:index] and os.path.isfile(path)
 ]
 excluded = [
     {"path": os.path.relpath(path, root), "reason": "artifact absent and optional for this stage"}
-    for path in canonical if not os.path.isfile(path)
+    for index, path in enumerate(canonical)
+    if path not in canonical[:index] and not os.path.isfile(path)
 ]
 print(json.dumps({
     "task": task,

--- a/dev-tools/tests/dr-spec-lint.bats
+++ b/dev-tools/tests/dr-spec-lint.bats
@@ -66,6 +66,79 @@ EOF
     [ "$status" -eq 0 ]
 }
 
+@test "L2 resolves the embedded task-description as its canonical plan" {
+    cat >"$WORK/datarim/tasks/EX-0003-task-description.md" <<'EOF'
+---
+task_id: EX-0003
+complexity: L2
+plan: null
+---
+
+## Requirements (D-REQ)
+
+#### D-REQ-01: embedded plans are linted
+
+## Success Criteria
+
+- V-AC-1: embedded plan validation succeeds
+  Covers: D-REQ-01
+
+## Implementation Plan
+
+- Step 1: lint the embedded plan
+  Verifies: V-AC-1
+EOF
+    run "$SCRIPT" --task EX-0003 --root "$WORK" --stage plan --format json
+    [ "$status" -eq 0 ] && [ -z "$output" ]
+}
+
+@test "L3 plan stage requires its dedicated canonical plan" {
+    write_clean_fixture
+    rm "$WORK/datarim/plans/EX-0001-plan.md"
+    run "$SCRIPT" --task EX-0001 --root "$WORK" --stage plan --format json
+    [ "$status" -eq 2 ] \
+      && [[ "$output" == *"required canonical plan missing for L3 task"* ]] \
+      && [[ "$output" == *"datarim/plans/EX-0001-plan.md"* ]]
+}
+
+@test "explicit PRD L3 takes precedence over stale L2 task metadata" {
+    write_clean_fixture
+    sed -i.bak 's/Level 3/Level 2/' \
+      "$WORK/datarim/tasks/EX-0001-task-description.md"
+    printf '%s\n' 'complexity: L2' \
+      > "$WORK/datarim/tasks/EX-0001-task-description.md"
+    rm "$WORK/datarim/plans/EX-0001-plan.md"
+    run "$SCRIPT" --task EX-0001 --root "$WORK" --stage plan --format json
+    [ "$status" -eq 2 ] \
+      && [[ "$output" == *"required canonical plan missing for L3 task"* ]]
+}
+
+@test "L2 index fallback resolves the embedded canonical plan" {
+    cat >"$WORK/datarim/prd/PRD-EX-0004.md" <<'EOF'
+# PRD: Index fallback
+
+#### D-REQ-01: fallback remains consistent
+
+- V-AC-1: embedded validation succeeds
+  Covers: D-REQ-01
+EOF
+    cat >"$WORK/datarim/tasks/EX-0004-task-description.md" <<'EOF'
+---
+task_id: EX-0004
+plan: null
+---
+
+## Implementation Plan
+
+- Step 1: lint the embedded plan
+  Verifies: V-AC-1
+EOF
+    printf '%s\n' '- EX-0004 · in_progress · P2 · L2 · Index fallback fixture' \
+      > "$WORK/datarim/tasks.md"
+    run "$SCRIPT" --task EX-0004 --root "$WORK" --stage plan --format json
+    [ "$status" -eq 0 ] && [ -z "$output" ]
+}
+
 @test "dreq-id-format — bad slug flagged" {
     write_clean_fixture
     # corrupt one D-REQ to a single-digit id

--- a/dev-tools/tests/spec-graph-gate.bats
+++ b/dev-tools/tests/spec-graph-gate.bats
@@ -63,11 +63,100 @@ EOF
       && printf '%s\n' "$output" | grep -qF '"decision":"advisory"'
 }
 
-@test "missing plan at plan stage is fail-closed exit 2" {
+@test "L3 plan stage still requires a dedicated plan file" {
     write_fixture
     rm "$WORK/datarim/plans/GT-0001-plan.md"
     run "$SCRIPT" --task GT-0001 --stage plan --root "$WORK" --format json
-    [ "$status" -eq 2 ]
+    [ "$status" -eq 2 ] \
+      && [[ "$output" == *"required artifact missing"* ]] \
+      && [[ "$output" == *"datarim/plans/GT-0001-plan.md"* ]]
+}
+
+@test "L2 plan stage validates the canonical embedded task-description plan" {
+    cat >"$WORK/datarim/prd/PRD-GT-0004.md" <<'EOF'
+# PRD: Embedded plan
+**Complexity:** Level 2
+
+## Requirements (D-REQ)
+
+#### D-REQ-01: embedded plans are validated
+
+## Success Criteria
+
+- V-AC-1: embedded validation succeeds
+  Covers: D-REQ-01
+EOF
+    cat >"$WORK/datarim/tasks/GT-0004-task-description.md" <<'EOF'
+---
+task_id: GT-0004
+complexity: L2
+plan: null
+---
+
+## Implementation Plan
+
+- Step 1: validate the embedded plan
+  Verifies: V-AC-1
+EOF
+    run "$SCRIPT" --task GT-0004 --stage plan --root "$WORK" --format json
+    [ "$status" -eq 0 ] \
+      && [[ "$output" == *'"decision":"clean"'* ]] \
+      && [[ "$output" == *'datarim/tasks/GT-0004-task-description.md'* ]] \
+      && [[ "$output" != *'datarim/plans/GT-0004-plan.md'* ]]
+}
+
+@test "explicit PRD L3 cannot be downgraded by stale L2 task metadata" {
+    cat >"$WORK/datarim/prd/PRD-GT-0005.md" <<'EOF'
+# PRD: L3 precedence
+**Complexity:** Level 3
+
+#### D-REQ-01: L3 storage remains dedicated
+
+- V-AC-1: dedicated plan is required
+  Covers: D-REQ-01
+EOF
+    cat >"$WORK/datarim/tasks/GT-0005-task-description.md" <<'EOF'
+---
+task_id: GT-0005
+complexity: L2
+---
+
+## Implementation Plan
+
+- Step 1: stale embedded plan
+  Verifies: V-AC-1
+EOF
+    run "$SCRIPT" --task GT-0005 --stage plan --root "$WORK" --format json
+    [ "$status" -eq 2 ] \
+      && [[ "$output" == *"datarim/plans/GT-0005-plan.md"* ]]
+}
+
+@test "gate and linter share the L2 index fallback for embedded plans" {
+    cat >"$WORK/datarim/prd/PRD-GT-0006.md" <<'EOF'
+# PRD: Index fallback
+
+#### D-REQ-01: fallback remains consistent
+
+- V-AC-1: embedded validation succeeds
+  Covers: D-REQ-01
+EOF
+    cat >"$WORK/datarim/tasks/GT-0006-task-description.md" <<'EOF'
+---
+task_id: GT-0006
+plan: null
+---
+
+## Implementation Plan
+
+- Step 1: validate the embedded plan
+  Verifies: V-AC-1
+EOF
+    printf '%s\n' '- GT-0006 · in_progress · P2 · L2 · Index fallback fixture' \
+      > "$WORK/datarim/tasks.md"
+    run "$SCRIPT" --task GT-0006 --stage plan --root "$WORK" --format json
+    [ "$status" -eq 0 ] \
+      && [[ "$output" == *'"complexity":"L2"'* ]] \
+      && [[ "$output" == *'"decision":"clean"'* ]]
 }
 
 @test "L1 task without PRD skips from task-description complexity" {

--- a/tests/framework-version-accountability-wiring.bats
+++ b/tests/framework-version-accountability-wiring.bats
@@ -12,6 +12,11 @@ ROOT="$BATS_TEST_DIRNAME/.."
     && grep -qF 'route to `/dr-do`' "$ROOT/commands/dr-do.md"
 }
 
+@test "/dr-do passes the resolved implementation repository to the checker" {
+  grep -qF -- '--repo <implementation-repo>' "$ROOT/commands/dr-do.md" \
+    && ! grep -qF -- '--repo <framework-repo>' "$ROOT/commands/dr-do.md"
+}
+
 @test "/dr-qa independently runs the same checker and blocks PASS routes" {
   grep -qF '${DATARIM_RUNTIME:-$HOME/.claude}/dev-tools/check-framework-version-accountability.sh' "$ROOT/commands/dr-qa.md" \
     && grep -qF 'overall QA result is **FAIL**' "$ROOT/commands/dr-qa.md" \

--- a/tests/framework-version-accountability.bats
+++ b/tests/framework-version-accountability.bats
@@ -112,8 +112,57 @@ write_deferral() {
 }
 
 @test "checker fails closed when the INIT baseline is missing" {
+  mkdir -p "$REPO/commands" "$REPO/skills/example"
+  printf '%s\n' '# command' > "$REPO/commands/dr-example.md"
+  printf '%s\n' '# skill' > "$REPO/skills/example/SKILL.md"
+  git -C "$REPO" add commands skills
+  git -C "$REPO" commit -qm 'add current Datarim identity markers'
   run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
   [ "$status" -eq 2 ] && [[ "$output" == *"error=missing_baseline"* ]]
+}
+
+@test "checker returns not_applicable without a baseline for a consumer repository" {
+  run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 0 ] && [[ "$output" == *"disposition=not_applicable"* ]]
+}
+
+@test "checker fails closed without a baseline for a historical Datarim repository" {
+  mkdir -p "$REPO/commands" "$REPO/skills/example"
+  printf '%s\n' '# command' > "$REPO/commands/dr-example.md"
+  printf '%s\n' '# skill' > "$REPO/skills/example/SKILL.md"
+  git -C "$REPO" add commands skills
+  git -C "$REPO" commit -qm 'add historical Datarim identity markers'
+  git -C "$REPO" rm -qr commands skills
+  git -C "$REPO" commit -qm 'remove Datarim identity markers'
+  run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 2 ] && [[ "$output" == *"error=missing_baseline"* ]]
+}
+
+@test "checker fails closed on a malformed baseline for a consumer repository" {
+  capture_baseline
+  printf '%s\n' 'malformed' \
+    > "$WORKSPACE/datarim/.auto/version-accountability/$TASK_ID/baseline.record"
+  run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 2 ] && [[ "$output" == *"error=baseline_schema"* ]]
+}
+
+@test "checker fails closed on a symlink baseline for a consumer repository" {
+  local record real_record
+  capture_baseline
+  record="$WORKSPACE/datarim/.auto/version-accountability/$TASK_ID/baseline.record"
+  real_record="$(dirname "$record")/real.record"
+  mv "$record" "$real_record"
+  ln -s "$(basename "$real_record")" "$record"
+  run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 2 ] && [[ "$output" == *"error=missing_baseline"* ]]
+}
+
+@test "checker fails closed when committed history cannot be classified" {
+  printf '%040d\n' 0 | tr '0' 'f' > "$REPO/.git/refs/heads/unreadable-history"
+  run "$CHECKER" --task "$TASK_ID" --workspace "$WORKSPACE" --repo "$REPO"
+  [ "$status" -eq 2 ] \
+    && [[ "$output" == *"error=identity_history_unreadable"* ]] \
+    && [[ "$output" != *"disposition=not_applicable"* ]]
 }
 
 @test "tests-only diff is not applicable" {


### PR DESCRIPTION
## Summary

- classify non-Datarim implementation repositories before requiring a framework-version baseline, while preserving fail-closed handling for current or historical Datarim repositories and untrusted evidence
- resolve canonical embedded task-description plans for L1/L2 consistently in the spec-graph gate and linter; keep dedicated plans mandatory for L3/L4
- add regression coverage for history failures, complexity precedence, index fallback parity, malformed/symlink baselines, and /dr-do wiring

## Verification

- targeted Bats: 90/90
- repository-wide shellcheck: pass
- ./validate.sh: ALL CHECKS PASSED
- real DEV-1905 accountability consumer: disposition=not_applicable
- real DEV-1906 plan gate: decision=clean, grade A
- independent re-review: PASS, no remaining high/medium findings
