### PR TITLE
fix(context-window): bind pressure to an absolute token ceiling, not a bare percentage

### DIFF
--- a/plugins/dr-orchestrate/scripts/context_window_controller.sh
+++ b/plugins/dr-orchestrate/scripts/context_window_controller.sh
@@ -47,16 +47,59 @@ policy_mode() {
   [ "$rc" -eq 0 ] && printf '%s\n' "$result"; return "$rc"
 }
 
+# Absolute working-set ceiling, in tokens. A percentage alone cannot express
+# pressure: 75 percent of a 200k window is 150k tokens, 75 percent of a 1M
+# window is 750k. Attention degrades with the LENGTH of the history, not with
+# its ratio to a limit, so a large window is headroom for one big read — never
+# a licence to accumulate. These ceilings therefore bind independently of the
+# percentage, and the STRICTER of the two verdicts wins.
+DR_CTX_SOFT_TOKENS="${DR_CTX_SOFT_TOKENS:-200000}"   # prepare handoff
+DR_CTX_HARD_TOKENS="${DR_CTX_HARD_TOKENS:-280000}"   # reset now
+
+absolute_mode() {
+  local used_tokens="$1"
+  if [ "$used_tokens" -ge "$DR_CTX_HARD_TOKENS" ]; then printf 'full_clear\n'
+  elif [ "$used_tokens" -ge "$DR_CTX_SOFT_TOKENS" ]; then printf 'selective_drop\n'
+  else printf 'no_op\n'; fi
+}
+
+mode_rank() {
+  case "$1" in no_op) printf '0\n' ;; selective_drop) printf '1\n' ;;
+    full_clear) printf '2\n' ;; *) printf '0\n' ;; esac
+}
+
 evaluate() {
-  local used mode rc
+  local used mode rc used_tokens window abs
   used="$(arg_value --used-percent "$@")" || die '--used-percent is required'
   [[ "$used" =~ ^[0-9]+$ ]] && [ "$used" -le 100 ] || die 'used percent must be integer 0..100'
   set +e; mode="$(policy_mode "$used")"; rc=$?; set -e
-  if [ "$rc" -eq 0 ]; then printf '%s\n' "$mode"; return 0; fi
-  [ "$rc" -eq 3 ] || [ "$rc" -eq 4 ] || die 'unsafe taught policy'
-  if [ "$used" -ge 90 ]; then printf 'full_clear\n'
-  elif [ "$used" -ge 75 ]; then printf 'selective_drop\n'
-  else printf 'no_op\n'; fi
+  if [ "$rc" -ne 0 ]; then
+    [ "$rc" -eq 3 ] || [ "$rc" -eq 4 ] || die 'unsafe taught policy'
+    if [ "$used" -ge 90 ]; then mode='full_clear'
+    elif [ "$used" -ge 75 ]; then mode='selective_drop'
+    else mode='no_op'; fi
+  fi
+
+  # Absolute arm. Tokens may be supplied directly, or derived from the window
+  # size. Absent both, the percentage verdict stands alone — unchanged
+  # behaviour for every existing caller.
+  used_tokens="$(arg_value --used-tokens "$@")" || used_tokens=''
+  if [ -z "$used_tokens" ]; then
+    window="$(arg_value --window-tokens "$@")" || window=''
+    if [ -n "$window" ]; then
+      [[ "$window" =~ ^[0-9]+$ ]] && [ "$window" -gt 0 ] || die 'window tokens must be a positive integer'
+      used_tokens=$(( window * used / 100 ))
+    fi
+  else
+    [[ "$used_tokens" =~ ^[0-9]+$ ]] || die 'used tokens must be a non-negative integer'
+  fi
+
+  if [ -n "$used_tokens" ]; then
+    abs="$(absolute_mode "$used_tokens")"
+    [ "$(mode_rank "$abs")" -gt "$(mode_rank "$mode")" ] && mode="$abs"
+  fi
+
+  printf '%s\n' "$mode"
 }
 
 instruction() {

--- a/plugins/dr-orchestrate/tests/test_context_window_controller.bats
+++ b/plugins/dr-orchestrate/tests/test_context_window_controller.bats
@@ -42,6 +42,60 @@ evaluate() { run bash "$CONTROLLER" evaluate --used-percent "$1"; }
 @test "pressure above 100 is rejected" { evaluate 101; [ "$status" -ne 0 ]; }
 @test "fractional controller pressure is rejected" { evaluate 74.5; [ "$status" -ne 0 ]; }
 
+# --- absolute token ceiling -------------------------------------------------
+# The percentage arm alone hides its denominator. These cases pin the arm that
+# made the real incident detectable: a large window whose percentage read as
+# calm while the working set was far past any sane ceiling.
+
+abs() { run bash "$CONTROLLER" evaluate --used-percent "$1" --used-tokens "$2"; }
+win() { run bash "$CONTROLLER" evaluate --used-percent "$1" --window-tokens "$2"; }
+
+@test "absolute: below the soft ceiling is no_op" { abs 10 199999; [ "$status" -eq 0 ] && [ "$output" = no_op ]; }
+@test "absolute: at the soft ceiling is selective_drop" { abs 10 200000; [ "$status" -eq 0 ] && [ "$output" = selective_drop ]; }
+@test "absolute: at the hard ceiling is full_clear" { abs 10 280000; [ "$status" -eq 0 ] && [ "$output" = full_clear ]; }
+
+@test "absolute arm overrides a calm percentage" {
+  # 25% of a 1M window = 250k tokens: calm by ratio, past the soft ceiling.
+  abs 25 250000; [ "$status" -eq 0 ] && [ "$output" = selective_drop ]
+}
+
+@test "the stricter arm wins when the percentage is the strict one" {
+  # 95% of a small window is few tokens, but the percentage arm still clears.
+  abs 95 40000; [ "$status" -eq 0 ] && [ "$output" = full_clear ]
+}
+
+@test "window size derives the token count" {
+  win 25 1000000; [ "$status" -eq 0 ] && [ "$output" = selective_drop ]
+}
+
+@test "the same percentage means different modes on different windows" {
+  # The defect this arm exists to kill: one threshold, two meanings.
+  win 25 200000; [ "$status" -eq 0 ] && [ "$output" = no_op ]
+  win 25 1000000; [ "$status" -eq 0 ] && [ "$output" = selective_drop ]
+}
+
+@test "the incident case clears: a large window at high pressure" {
+  win 98 1000000; [ "$status" -eq 0 ] && [ "$output" = full_clear ]
+}
+
+@test "ceilings are overridable per deployment" {
+  run env DR_CTX_SOFT_TOKENS=50000 DR_CTX_HARD_TOKENS=60000 \
+    bash "$CONTROLLER" evaluate --used-percent 5 --used-tokens 55000
+  [ "$status" -eq 0 ] && [ "$output" = selective_drop ]
+}
+
+@test "absent token evidence the percentage arm still decides" {
+  evaluate 90; [ "$status" -eq 0 ] && [ "$output" = full_clear ]
+}
+
+@test "malformed token count is rejected, never treated as calm" {
+  abs 10 not-a-number; [ "$status" -ne 0 ]
+}
+
+@test "zero window is rejected rather than dividing" {
+  win 50 0; [ "$status" -ne 0 ]
+}
+
 @test "taught launch label selects enum above its floor" {
   policy="$BATS_TEST_TMPDIR/policy.tsv"
   printf 'deep\tfull_clear\t60\n' >"$policy"; chmod 600 "$policy"

--- a/skills/context-window-self-clearing/SKILL.md
+++ b/skills/context-window-self-clearing/SKILL.md
@@ -16,9 +16,29 @@ that explicitly enable context-window automation. It is default-off.
 1. Read the active task snapshot first. Bind the active task-description path,
    last completed snapshot stage, snapshot path, and snapshot digest into a
    private transaction before sending a reset instruction.
-2. Treat pressure below 75 percent as `no_op`, 75 through 89 as
-   `selective_drop`, and 90 through 100 as `full_clear`. A private exact-label
+2. Pressure has TWO arms and the stricter verdict wins.
+
+   **Absolute arm (primary).** Below 200000 tokens of working set is `no_op`,
+   200000 through 279999 is `selective_drop`, 280000 and above is `full_clear`.
+   Ceilings are overridable per deployment via `DR_CTX_SOFT_TOKENS` and
+   `DR_CTX_HARD_TOKENS`.
+
+   **Percentage arm (retained).** Below 75 percent is `no_op`, 75 through 89 is
+   `selective_drop`, 90 through 100 is `full_clear`. A private exact-label
    policy may select a mode only at or above its declared floor, never below 50.
+
+   A percentage alone cannot express pressure, because it hides its
+   denominator: 75 percent of a 200k window is 150k tokens, while 75 percent of
+   a 1M window is 750k. Attention degrades with the LENGTH of the accumulated
+   history, not with its ratio to a limit, so a larger window is headroom for
+   one large read — never a licence to accumulate proportionally more. A
+   threshold written only as a percentage silently changes meaning when the
+   runtime's window changes, which is how a session reached 98 percent of a
+   large window while every declared threshold read as satisfied.
+
+   An orchestrator that cannot obtain a token count MUST still apply the
+   percentage arm, and MUST treat the missing count as a gap to close rather
+   than as evidence of low pressure.
 3. Use only these fixed instructions:
    - Codex selective: `/compact`
    - Claude selective: `/compact Preserve active Datarim task pointer last completed phase current plan open verification findings and next action`


### PR DESCRIPTION
fix(context-window): bind pressure to an absolute token ceiling, not a bare percentage

A percentage hides its denominator. 75 percent of a 200k window is 150k tokens;
75 percent of a 1M window is 750k. The thresholds were written for one window
size and silently changed meaning on another, so an orchestrated session
accumulated a very large working set while every declared threshold read as
satisfied — and produced exactly the failures the rule exists to prevent: a
merge reported green on a red main, a failing gate closed by a bare rerun, and
a completion claimed over four unread instructions.

Attention degrades with the LENGTH of accumulated history, not with its ratio
to a limit. A larger window is headroom for one large read, never a licence to
accumulate proportionally more.

evaluate() now carries two arms and the STRICTER verdict wins: the existing
percentage arm, unchanged, plus an absolute arm at 200k (selective_drop) and
280k (full_clear), overridable per deployment via DR_CTX_SOFT_TOKENS /
DR_CTX_HARD_TOKENS. Tokens come from --used-tokens, or are derived from
--window-tokens; with neither, the percentage arm decides alone, so every
existing caller and the event contract are unaffected.

Tests pin the defect rather than the fix: one percentage yielding different
modes on different windows, the absolute arm overriding a calm ratio, the
percentage arm still winning when it is the stricter one, the incident case
itself, and malformed or zero inputs rejected rather than read as calm.
