### PR TITLE
TUNE-0599: reconcile framework catalogue and macOS fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to the Datarim framework are documented here. Format follows
 
 ## [Unreleased]
 
+### Changed
+
+- **Catalogue and macOS test parity.** Reference documentation now accounts for
+  all 78 shipped skills, including the five Fleet tier skills, and the
+  spec-graph regression fixtures use portable insertion logic so the same
+  negative controls run on BSD/macOS and GNU/Linux.
+
 ## [2.67.0] — 2026-08-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ Skills are reusable knowledge modules loaded on demand. They provide rules, patt
 - `session-handoff-replay.md` -- Consumer contract for `/dr-continue`: read session artefact in clean window, re-verify every claim via live probes (STALE SNAPSHOT / CLAIM-UNVERIFIED / FILE-MISSING banners), downgrade provenance tags, route to `/dr-next` or `/dr-auto`. Squash-collision detection via `git merge-base --is-ancestor`. Shares bilingual replay renderer with `/dr-next` via `skills/dr-next-snapshot-replay/SKILL.md § Shared Replay Renderer`. (loaded by: /dr-continue)
 - `context-window-self-clearing.md` — Default-off orchestrator contract for deterministic Claude Code/Codex pressure thresholds, checkpoint-before-reset transactions, fixed compact/clear instructions, and snapshot-first continuation. (loaded by: /dr-orchestrate plugin runtime)
 
-Skill files: `$HOME/.claude/skills/{name}/SKILL.md` (73 skills, 13 with supporting fragment directories — a "supporting fragment directory" is a skill folder that ships at least one sibling `.md` beside its `SKILL.md`)
+Skill files: `$HOME/.claude/skills/{name}/SKILL.md` (78 skills, 13 with supporting fragment directories — a "supporting fragment directory" is a skill folder that ships at least one sibling `.md` beside its `SKILL.md`)
 
 > **Available since v1.16.0:** `cta-format.md` — canonical CTA "Next Step" block specification, loaded by `planner`, `architect`, `developer`, `reviewer`, `compliance` agents. Defines structure, separators, primary marker, multi-task menu (Variant B), and FAIL-Routing variant.
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ reflection. The result is inconsistent quality, skipped steps, and zero institut
 learning. Every task starts from scratch, repeating the same mistakes from yesterday.
 
 Datarim fixes this by providing a complete iterative pipeline for any project type.
-It includes 19 specialized agents, 73 reusable skills, and 28 commands that guide
+It includes 19 specialized agents, 78 reusable skills, and 28 commands that guide
 work through a structured process: requirements gathering, planning, design,
 execution, quality assurance, compliance, reflection, and archival. The pipeline is
 complexity-aware — a quick fix does not go through the same process as a major
@@ -97,7 +97,7 @@ Stages in `[brackets]` are conditional — included when the agent determines th
   cross-Claude-family fallback). Each agent has a defined role, capabilities,
   and the stages where it operates.
 
-- **73 reusable skills** — modular knowledge units that agents load on demand,
+- **78 reusable skills** — modular knowledge units that agents load on demand,
   covering everything from testing methodology to security hardening to content
   creation workflows and structured research.
 
@@ -553,7 +553,7 @@ involve most of the nineteen agents across different stages.
 | **reflecting** | Post-task reflection: lessons learned, evolution proposals, Class A/B gate | /dr-archive (Step 0.5) |
 
 The table above is a representative sample, not the full catalogue — the
-complete list of all 73 skills is in
+complete list of all 78 skills is in
 [`documentation/reference/skills.md`](documentation/reference/skills.md).
 
 Skills are modular. Each one is a directory containing a `SKILL.md` (plus any
@@ -1092,9 +1092,9 @@ and why it exists.
 ```
 datarim/
   agents/            # Agent personas (19 agents)
-  skills/            # Knowledge modules (73 skills)
+  skills/            # Knowledge modules (78 skills)
   commands/          # Slash commands (28 commands)
-  templates/         # Task and document templates (25 templates)
+  templates/         # Task and document templates (29 templates)
   documentation/              # Extended documentation and use cases
   CLAUDE.md          # Framework rules (copy to your project)
   install.sh         # Automated installer

--- a/dev-tools/.doc-fanout.yml
+++ b/dev-tools/.doc-fanout.yml
@@ -78,7 +78,7 @@ counts:
     # Layout is skills/<name>/SKILL.md — `skills/*.md` expanded to 0, so this
     # rule compared 0 against the documented count and could never be
     # meaningful.
-    source_glob: skills/*/SKILL.md
+    source_glob: skills/**/SKILL.md
     consumer_file: documentation/reference/skills.md
     pattern: ([0-9]+) reusable skill
     severity: error
@@ -110,7 +110,7 @@ counts:
     pattern: ([0-9]+) commands
     severity: warning
   - id: site_hero_skill_count
-    source_glob: skills/*/SKILL.md
+    source_glob: skills/**/SKILL.md
     consumer_file: ../../../Websites/datarim.club/content/en.php
     pattern: ([0-9]+) skills
     severity: warning
@@ -125,7 +125,7 @@ counts:
     pattern: ([0-9]+) commands
     severity: warning
   - id: site_about_skill_count
-    source_glob: skills/*/SKILL.md
+    source_glob: skills/**/SKILL.md
     consumer_file: ../../../Websites/datarim.club/pages/about.php
     pattern: ([0-9]+) skills
     severity: warning

--- a/dev-tools/check-component-counts.sh
+++ b/dev-tools/check-component-counts.sh
@@ -21,8 +21,9 @@
 #
 #   commands   find commands  -mindepth 1 -maxdepth 1 -name '*.md' | wc -l
 #   agents     find agents    -mindepth 1 -maxdepth 1 -name '*.md' | wc -l
-#   skills     find skills    -mindepth 1 -maxdepth 1 -type d      | wc -l   (one dir per skill, SKILL.md inside)
-#   templates  find templates -mindepth 1 -maxdepth 1 -name '*.md' | wc -l
+#   skills     find skills    -mindepth 2 -maxdepth 3 -name 'SKILL.md' | wc -l
+#                         (includes nested tiered skill directories)
+#   templates  find templates -mindepth 1 -maxdepth 3 -name '*.md' | wc -l
 #
 # KNOWN GAP (out of scope for this script, tracked as a follow-up): this
 # check does NOT extend to the public site (datarim.club — pages/about.php,
@@ -96,10 +97,11 @@ actual_count() {  # $1=category
     case "$cat" in
         # Hidden directories are runtime scaffolding, not shipped skills: a
         # Codex install drops an untracked `skills/.system/` holding its own
-        # bundled helpers. Counting it inflated the local total to 68 against a
-        # correct documented 67 — a drift report that fired only on a developer
-        # machine and never in CI (where the untracked dir does not exist).
-        skills) find "$dir" -mindepth 1 -maxdepth 1 -type d ! -name '.*' 2>/dev/null | wc -l | tr -d ' ' ;;
+        # bundled helpers. Count the canonical SKILL.md files instead of
+        # directories so nested Fleet tiers are included without counting the
+        # hidden runtime tree.
+        skills) find "$dir" -mindepth 2 -maxdepth 3 -type f -name 'SKILL.md' ! -path "$dir/.*" 2>/dev/null | wc -l | tr -d ' ' ;;
+        templates) find "$dir" -mindepth 1 -maxdepth 3 -type f -name '*.md' 2>/dev/null | wc -l | tr -d ' ' ;;
         *)      find "$dir" -mindepth 1 -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d ' ' ;;
     esac
 }

--- a/dev-tools/check-version-consistency.sh
+++ b/dev-tools/check-version-consistency.sh
@@ -41,8 +41,8 @@
 #   Ground truth (relative to repo root):
 #     agents/*.md          -> category "agents"
 #     commands/*.md        -> category "commands"
-#     skills/*/SKILL.md    -> category "skills"
-#     templates/*.md       -> category "templates"
+#     skills/**/SKILL.md   -> category "skills" (including nested tiers)
+#     templates/**/*.md    -> category "templates" (including nested docs)
 #   Claim surfaces (relative to repo root; skipped when absent):
 #     CLAUDE.md                                    "Agent files: ... (N agents)"
 #     CLAUDE.md                                    "Skill files: ... (N skills, ..."
@@ -180,8 +180,8 @@ done < <(surfaces)
 # count against a missing directory is real drift, not a skip condition.
 count_agents=$(find "$root/agents" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d '[:space:]')
 count_commands=$(find "$root/commands" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d '[:space:]')
-count_skills=$(find "$root/skills" -mindepth 2 -maxdepth 2 -iname 'SKILL.md' 2>/dev/null | wc -l | tr -d '[:space:]')
-count_templates=$(find "$root/templates" -maxdepth 1 -name '*.md' 2>/dev/null | wc -l | tr -d '[:space:]')
+count_skills=$(find "$root/skills" -mindepth 2 -maxdepth 3 -type f -iname 'SKILL.md' ! -path "$root/skills/.*" 2>/dev/null | wc -l | tr -d '[:space:]')
+count_templates=$(find "$root/templates" -mindepth 1 -maxdepth 3 -type f -name '*.md' 2>/dev/null | wc -l | tr -d '[:space:]')
 
 ground_truth_for() {
     case "$1" in

--- a/dev-tools/doc-fanout-lint.sh
+++ b/dev-tools/doc-fanout-lint.sh
@@ -381,12 +381,115 @@ substitute_name() {
 }
 
 # --- Glob expansion (relative to ROOT_ABS) ------------------------------------
+# Bash 3.2 (the system shell on macOS) has no `globstar`. Keep the native
+# expansion where it exists, and use a component-aware matcher otherwise. The
+# fallback deliberately treats `*` as one path component and `**` as zero or
+# more components, matching the intent of the configured repository globs
+# without allowing the ordinary `*` to cross `/`.
+GLOB_PARTS=()
+PATH_PARTS=()
+GLOB_PART_COUNT=0
+PATH_PART_COUNT=0
+
+glob_component_matches() {
+    local value="$1" pattern="$2"
+
+    # Match the pathname-expansion rule that a wildcard does not select a
+    # leading dot unless the pattern component explicitly starts with one.
+    case "$value" in
+        .*)
+            case "$pattern" in
+                .*) ;;
+                *) return 1 ;;
+            esac
+            ;;
+    esac
+
+    # shellcheck disable=SC2053,SC2254
+    case "$value" in
+        $pattern) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+glob_match_parts() {
+    local pi="$1" vi="$2" part value
+
+    if [ "$pi" -eq "$GLOB_PART_COUNT" ]; then
+        [ "$vi" -eq "$PATH_PART_COUNT" ]
+        return
+    fi
+
+    part="${GLOB_PARTS[$pi]}"
+    if [ "$part" = "**" ]; then
+        # `**` may consume no component.
+        if glob_match_parts $((pi + 1)) "$vi"; then
+            return 0
+        fi
+
+        # Or it may consume one or more visible components. With dotglob off,
+        # native Bash globstar does not descend through hidden components.
+        while [ "$vi" -lt "$PATH_PART_COUNT" ]; do
+            value="${PATH_PARTS[$vi]}"
+            case "$value" in
+                .*) return 1 ;;
+            esac
+            vi=$((vi + 1))
+            if glob_match_parts "$pi" "$vi"; then
+                return 0
+            fi
+        done
+        return 1
+    fi
+
+    [ "$vi" -lt "$PATH_PART_COUNT" ] || return 1
+    value="${PATH_PARTS[$vi]}"
+    glob_component_matches "$value" "$part" || return 1
+    glob_match_parts $((pi + 1)) $((vi + 1))
+}
+
+glob_path_matches() {
+    local pattern="$1" path="$2"
+    GLOB_PARTS=()
+    PATH_PARTS=()
+    IFS='/' read -r -a GLOB_PARTS <<< "$pattern"
+    IFS='/' read -r -a PATH_PARTS <<< "$path"
+    GLOB_PART_COUNT="${#GLOB_PARTS[@]}"
+    PATH_PART_COUNT="${#PATH_PARTS[@]}"
+    glob_match_parts 0 0
+}
+
 expand_glob() {
     # expand_glob pattern → newline-separated absolute paths
-    local pat="$1"
-    # shellcheck disable=SC2086
-    (cd "$ROOT_ABS" && shopt -s nullglob && \
-        for f in $pat; do printf '%s\n' "$ROOT_ABS/$f"; done)
+    local pat="$1" f rel find_bin
+
+    # Prefer Bash's native expansion when globstar is available.
+    if (shopt -s globstar) 2>/dev/null; then
+        # shellcheck disable=SC2086
+        (cd "$ROOT_ABS" && shopt -s nullglob globstar && \
+            for f in $pat; do printf '%s\n' "$ROOT_ABS/$f"; done)
+        return
+    fi
+
+    # Portable fallback for the system Bash shipped with macOS. Use an
+    # absolute find path when available so a token-reduction shim cannot
+    # rewrite the compound predicate used by this gate.
+    if [ -x /usr/bin/find ]; then
+        find_bin=/usr/bin/find
+    elif [ -x /bin/find ]; then
+        find_bin=/bin/find
+    else
+        find_bin="$(command -v find 2>/dev/null || :)"
+    fi
+    [ -x "$find_bin" ] || return 1
+
+    "$find_bin" "$ROOT_ABS" -type f -print0 |
+        while IFS= read -r -d '' f; do
+            rel="${f#"$ROOT_ABS"/}"
+            if glob_path_matches "$pat" "$rel"; then
+                printf '%s\n' "$f"
+            fi
+        done
 }
 
 # --- Resolve cross-root path safely -------------------------------------------

--- a/dev-tools/tests/doc-fanout-lint.bats
+++ b/dev-tools/tests/doc-fanout-lint.bats
@@ -17,6 +17,7 @@
 #   T13 --verbose multiline output
 #   T14 SUMMARY line content
 #   T15 --strict promotes warning to exit 1
+#   T16 recursive `**` matches nested paths while `*` remains one component
 
 LINT="$BATS_TEST_DIRNAME/../doc-fanout-lint.sh"
 
@@ -84,6 +85,32 @@ counts:
   - id: c
     source_glob: skills/*.md
     consumer_file: docs/skills.md
+    pattern: ([0-9]+) reusable skill
+    severity: error'
+    run "$LINT" --root "$TMPROOT" --quiet
+    [ "$status" -eq 0 ]
+}
+
+@test "T16: recursive glob counts nested paths without making * recursive" {
+    mk_artefact "skills/root/SKILL.md"
+    mk_artefact "skills/fleet/l1/SKILL.md"
+    mk_consumer "docs/skills.md" "2 reusable skill modules"
+    write_cfg 'version: 1
+counts:
+  - id: recursive_skill_count
+    source_glob: skills/**/SKILL.md
+    consumer_file: docs/skills.md
+    pattern: ([0-9]+) reusable skill
+    severity: error'
+    run "$LINT" --root "$TMPROOT" --quiet
+    [ "$status" -eq 0 ]
+
+    mk_consumer "docs/root-skills.md" "1 reusable skill module"
+    write_cfg 'version: 1
+counts:
+  - id: nonrecursive_skill_count
+    source_glob: skills/*/SKILL.md
+    consumer_file: docs/root-skills.md
     pattern: ([0-9]+) reusable skill
     severity: error'
     run "$LINT" --root "$TMPROOT" --quiet

--- a/dev-tools/tests/spec-graph-gate.bats
+++ b/dev-tools/tests/spec-graph-gate.bats
@@ -187,7 +187,15 @@ EOF
     write_fixture
     sed -i.bak 's/    - pending/    - missed/' \
         "$WORK/datarim/tasks/GT-0001-expectations.md"
-    sed -i.bak '/missed/i\  - override: nope\n  - override_by: operator' \
+    awk '{
+        if ($0 == "    - missed") {
+            print "  - override: nope"
+            print "  - override_by: operator"
+        }
+        print
+    }' "$WORK/datarim/tasks/GT-0001-expectations.md" \
+        > "$WORK/datarim/tasks/GT-0001-expectations.md.tmp"
+    mv "$WORK/datarim/tasks/GT-0001-expectations.md.tmp" \
         "$WORK/datarim/tasks/GT-0001-expectations.md"
     sed -i.bak '/Verifies:/d' "$WORK/datarim/plans/GT-0001-plan.md"
     run env DATARIM_SPEC_GRAPH_MODE=hard "$SCRIPT" \
@@ -200,7 +208,15 @@ EOF
     write_fixture
     sed -i.bak 's/    - pending/    - partial/' \
         "$WORK/datarim/tasks/GT-0001-expectations.md"
-    sed -i.bak '/partial/i\  - override: operator accepted this deferral\n  - override_by: operator' \
+    awk '{
+        if ($0 == "    - partial") {
+            print "  - override: operator accepted this deferral"
+            print "  - override_by: operator"
+        }
+        print
+    }' "$WORK/datarim/tasks/GT-0001-expectations.md" \
+        > "$WORK/datarim/tasks/GT-0001-expectations.md.tmp"
+    mv "$WORK/datarim/tasks/GT-0001-expectations.md.tmp" \
         "$WORK/datarim/tasks/GT-0001-expectations.md"
     sed -i.bak '/Verifies:/d' "$WORK/datarim/plans/GT-0001-plan.md"
     run env DATARIM_SPEC_GRAPH_MODE=hard "$SCRIPT" \

--- a/documentation/reference/skills.md
+++ b/documentation/reference/skills.md
@@ -1,10 +1,10 @@
 # Skills Reference
 
-Datarim includes 73 reusable skill modules. Skills provide rules, patterns, and guidelines loaded on demand by agents and commands. Each skill is a directory under `skills/` containing a `SKILL.md` plus any supporting fragment files.
+Datarim includes 78 reusable skill modules. Skills provide rules, patterns, and guidelines loaded on demand by agents and commands. Each skill is a directory under `skills/` containing a `SKILL.md` plus any supporting fragment files. This count includes the five tier-specific skills under `skills/fleet/`.
 
 Skills are split into two categories:
-- **Reference skills** — rules and patterns the caller applies inline. No `model` field in frontmatter, so they inherit the caller's model. 53 of the 73.
-- **Task skills** — perform an action when invoked. Carry an explicit `model` field per the [Model Assignment Convention](../../skills/datarim-system/SKILL.md). 20 of the 73.
+- **Reference skills** — rules and patterns the caller applies inline. No `model` field in frontmatter, so they inherit the caller's model. 58 of the 78.
+- **Task skills** — perform an action when invoked. Carry an explicit `model` field per the [Model Assignment Convention](../../skills/datarim-system/SKILL.md). 20 of the 78.
 
 Every shipped skill resolves to `inherit` — the operator's session model wins. Pinning a concrete model generation in a skill breaks under runtimes that do not offer it; express capability intent with `metadata.model_tier:` (resolved through `config/model-tiers.yaml`) instead.
 
@@ -41,6 +41,11 @@ Alphabetical. "Loaded by" names the commands, agents, or trigger conditions that
 | file-sync-config | Reference | Pre-flight checklist + ignore patterns for file-sync (Syncthing/rclone) | on demand for sync setup |
 | finishing-a-development-branch | Reference | Decide how to integrate completed work — merge, PR, or cleanup — via structured options, once implementation is done and tests pass | on demand at end of branch work |
 | fleet | Task | Router for the five-tier fleet starter skill (l1-basic..l5-autonomous) — selects the AAL/complexity level and its context budget for a spawned agent | /dr-init, /dr-prd, /dr-orchestrate |
+| fleet/l1-basic | Reference | Fleet starter for a level-1 single-step task with minimal context | fleet router |
+| fleet/l2-structured | Reference | Fleet starter for a level-2 templated task with a compact context | fleet router |
+| fleet/l3-analyst | Reference | Fleet starter for a level-3 analytical task with on-demand retrieval | fleet router |
+| fleet/l4-expert | Reference | Fleet starter for a level-4 multi-subtask task with on-demand retrieval | fleet router |
+| fleet/l5-autonomous | Reference | Fleet starter for a level-5 self-managed task with bounded autonomy | fleet router |
 | frontend-ui | Task | CSS specificity, dark/light themes, visual testing, mobile responsiveness | when editing HTML/CSS |
 | health-controller-stub-detector | Reference | Surface hard-coded stub literals (`pending-integration`, `not-implemented`, `stub`) in health/status controllers at /dr-do, before /dr-qa wish gating | /dr-do, when a health or status controller is touched |
 | human-summary | Reference | Plain-language operator recap — four sub-sections + banlist + whitelist + per-paragraph escape hatch + 150–400 word budget | /dr-qa, /dr-compliance, /dr-archive (Step 8) |
@@ -88,7 +93,7 @@ Alphabetical. "Loaded by" names the commands, agents, or trigger conditions that
 | writing | Task | Content creation and editorial workflow | writer, editor |
 | writing-plans | Reference | Turn a spec or set of requirements for a multi-step task into a written plan, before touching code | on demand, before implementation |
 
-**Distribution:** 53 reference skills (no `model` field — inherit the caller), 20 task skills (explicit `model: inherit`).
+**Distribution:** 58 reference skills (no `model` field — inherit the caller), 20 task skills (explicit `model: inherit`).
 
 ## Loading Hierarchy
 

--- a/tests/check-component-counts.bats
+++ b/tests/check-component-counts.bats
@@ -8,12 +8,13 @@
 setup() {
     DETECTOR="${BATS_TEST_DIRNAME}/../dev-tools/check-component-counts.sh"
     KB="$(mktemp -d)"
-    mkdir -p "$KB/commands" "$KB/agents" "$KB/skills/skill-a" "$KB/skills/skill-b" "$KB/templates"
+    mkdir -p "$KB/commands" "$KB/agents" "$KB/skills/skill-a" "$KB/skills/skill-b" "$KB/skills/fleet/l1" "$KB/templates"
     : > "$KB/commands/a.md"; : > "$KB/commands/b.md"                       # 2 commands
     : > "$KB/agents/x.md"                                                 # 1 agent
-    : > "$KB/skills/skill-a/SKILL.md"; : > "$KB/skills/skill-b/SKILL.md"  # 2 skills (one dir each)
+    : > "$KB/skills/skill-a/SKILL.md"; : > "$KB/skills/skill-b/SKILL.md"  # 2 top-level skills
+    : > "$KB/skills/fleet/l1/SKILL.md"                                      # 1 nested skill
     : > "$KB/templates/t1.md"                                             # 1 template
-    write_docs 2 1 2 1   # default: fully-consistent claims (commands agents skills templates)
+    write_docs 2 1 3 1   # default: fully-consistent claims (commands agents skills templates)
 }
 
 teardown() { rm -rf "$KB"; }
@@ -60,7 +61,7 @@ EOF
 }
 
 @test "corrupted templates claim: --check exits 1, --report names category+claim+actual (V-AC-2)" {
-    write_docs 2 1 2 19   # templates claim corrupted to 19, actual is still 1
+    write_docs 2 1 3 19   # templates claim corrupted to 19, actual is still 1
     run bash "$DETECTOR" --check --root "$KB"
     [ "$status" -eq 1 ]
     run bash "$DETECTOR" --report --root "$KB"
@@ -70,13 +71,13 @@ EOF
 }
 
 @test "corrupted skills claim: --check exits 1 (V-AC-2)" {
-    write_docs 2 1 99 1   # skills claim corrupted, actual dirs still 2
+    write_docs 2 1 99 1   # skills claim corrupted, actual files still 3
     run bash "$DETECTOR" --check --root "$KB"
     [ "$status" -eq 1 ]
     run bash "$DETECTOR" --report --root "$KB"
     [[ "$output" == *skills* ]]
     [[ "$output" == *"claims 99"* ]]
-    [[ "$output" == *"actual 2"* ]]
+    [[ "$output" == *"actual 3"* ]]
 }
 
 @test "corrupted commands claim: --check exits 1 (V-AC-2)" {

--- a/tests/customer-requirement-expectations-binding.bats
+++ b/tests/customer-requirement-expectations-binding.bats
@@ -1549,7 +1549,7 @@ EOF
     assert_contains "$SKILLS_REFERENCE" '| expectations-checklist | Reference | Operator wishlist artefact' || return 1
     assert_contains "$SKILLS_REFERENCE" 'Schema v4 requires explicit customer derivation' || return 1
 
-    disk_count="$(find "${REPO_ROOT}/skills" -mindepth 2 -maxdepth 2 -name SKILL.md | wc -l | tr -d '[:space:]')"
+    disk_count="$(find "${REPO_ROOT}/skills" -mindepth 2 -maxdepth 3 -name SKILL.md ! -path "${REPO_ROOT}/skills/.*" | wc -l | tr -d '[:space:]')"
     documented_count="$(sed -nE 's/^Datarim includes ([0-9]+) reusable skill modules\..*/\1/p' "$SKILLS_REFERENCE")"
     [[ "$documented_count" -eq "$disk_count" ]]
 }


### PR DESCRIPTION
Synchronize the 2.67.0 catalogue counts and make spec-graph regression fixtures portable on BSD/macOS. Local focused suites: 49 passing.