### PR TITLE
docs: record v2.67.0 release audit

### DIFF
--- a/documentation/release-audit/release-2.67.0.md
+++ b/documentation/release-audit/release-2.67.0.md
@@ -1,0 +1,9 @@
+- release: 2.67.0
+  registry: gh
+  bump_level: minor
+  gates_passed: G0,G1,G2,G3,G4,G5,G6
+  rationale: "range v2.66.2..HEAD: highest Conventional-Commits bump=minor, api_diff=unavailable, zero_x=false"
+  merge_commit: 1c45c0d06a0f5bcf1643bd48bdb0bf8eaebfc27b
+  release_workflow_run: 33522793237
+  artifact_verification: sha256,cosign_tarball,cosign_sbom,github_attestation
+  timestamp: 2026-09-01T14:57:56Z


### PR DESCRIPTION
Commit the release-gate audit emitted for v2.67.0. It records G0-G6, resulting-main commit 1c45c0d, release workflow 33522793237, and checksum/cosign/attestation verification. Documentation only; no runtime or version change.