### PR TITLE
fix: complete v2.67.3 diagnostics and public-surface hardening

### DIFF
--- a/.github/workflows/reusable-security-audit.yml
+++ b/.github/workflows/reusable-security-audit.yml
@@ -88,18 +88,18 @@ jobs:
       # `runs-on: [self-hosted, linux]` matches nearly all of them and they are
       # NOT interchangeable. Measured 2026-07-29 across the seven runner hosts:
       #
-      #   host             node corepack pnpm python python3 shellcheck cargo
-      #   arcana-devs       y     y       y     N      y       y          y
-      #   arcana-prod       y     y       y     N      y       y          N
-      #   arcana-dbs        y     y       y     N      y       N          N
-      #   arcana-kb         y     y       y     N      y       y          N
-      #   arcana-www        N     N       N     N      y       N          N
-      #   arcana-trading    y     y       N     N      y       N          N
-      #   arcana-agents     y     y       y     N      y       N          y
+      #   role      node corepack pnpm python python3 shellcheck cargo
+      #   runner-A   y     y       y     N      y       y          y
+      #   runner-B   y     y       y     N      y       y          N
+      #   runner-C   y     y       y     N      y       N          N
+      #   runner-D   y     y       y     N      y       y          N
+      #   runner-E   N     N       N     N      y       N          N
+      #   runner-F   y     y       N     N      y       N          N
+      #   runner-G   y     y       y     N      y       N          y
       #
       # Consequences that were live before this change:
-      #   - typescript_pnpm exited 127 on arcana-www (cubrim-api PR #21) while
-      #     passing on arcana-prod-ci (PR #16) — identical code, different verdict.
+      #   - typescript_pnpm exited 127 on runner-E (cubrim-api PR #21) while
+      #     passing on runner-B (PR #16) — identical code, different verdict.
       #   - `python` is absent on EVERY host, so the python profile could never
       #     have run at all.
       #   - `framework` silently SKIPPED its only check on the 4 hosts without

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,18 @@ All notable changes to the Datarim framework are documented here. Format follows
   so a broken producer can no longer masquerade as a genuine empty result;
   mixed corpora remain usable with an explicit `partial` status.
 
+### Security
+
+- **Public fixture hygiene.** The retired infrastructure-address fixtures now
+  use RFC 5737 documentation space, removing four obsolete personal-ID gate
+  suppressions and keeping those files inside the normal shipped-surface scan.
+- **Fleet-detail minimization.** The reusable security workflow preserves its
+  portability evidence with anonymous runner roles instead of publishing the
+  fleet's real hostnames.
+- **Protected-main completeness.** Version consistency, task-ID and regression
+  checks, and all eight Bats shards are required on `main` in addition to the
+  existing SAST and secret-scanning contexts.
+
 ## [2.67.2] — 2026-09-03
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Datarim — Universal Iterative Workflow Framework
 
-> **Version:** 2.67.2
+> **Version:** 2.67.3
 > **Framework:** Datarim provides structured rules, agents, skills, and commands for iterative project execution via AI coding assistants — software development, research, documentation, legal work, project management, and any task that benefits from a phased workflow.
 > **Multi-runtime:** Datarim is runtime-agnostic. This file is also available as `AGENTS.md` (symlink) for Codex CLI and other agent runtimes that read `AGENTS.md` by convention. See `documentation/tutorials/use-cases.md#runtime-support` for the canonical Claude Code / Codex CLI / Cursor support matrix.
 

--- a/dev-tools/dead-ip-consumer-sweep.sh
+++ b/dev-tools/dead-ip-consumer-sweep.sh
@@ -114,7 +114,7 @@ escape_ip_for_ere() {
 #   - starts with # (comment)
 #   - is in a documentation/archive/ subtree
 #   - is in a *.bak file
-#   - line contains only a comment reference (e.g. "# was 23.88.34.218")
+#   - line contains only a comment reference (e.g. "# was 192.0.2.218")
 line_is_historical() {
     local line="$1"
     # Trim leading whitespace

--- a/dev-tools/tests/check-db-relocation-class.bats
+++ b/dev-tools/tests/check-db-relocation-class.bats
@@ -65,7 +65,7 @@ title: Database migration
 ---
 
 Relocate the database from the old host.
-The application currently points DB_HOST=23.88.34.218 via environment variable.
+The application currently points DB_HOST=192.0.2.218 via environment variable.
 After migration update the connection string to the new host.
 EOF
     run "$SCRIPT" --task-description "$WORK/task.md"
@@ -137,7 +137,7 @@ EOF
 ---
 type: infra
 title: Repoint consumers off the old DB host
-decommissioned_ip: 23.88.34.218
+decommissioned_ip: 192.0.2.218
 ---
 
 Relocate consumers from the old host to the new database server.

--- a/dev-tools/tests/dead-ip-consumer-sweep.bats
+++ b/dev-tools/tests/dead-ip-consumer-sweep.bats
@@ -29,11 +29,11 @@ EOF
     # Create required audit asserting zero live consumers
     cat >"$WORK/audit.md" <<EOF
 # Audit
-dead_ip: 23.88.34.218
+dead_ip: 192.0.2.218
 live_consumers: 0
 assertion: zero live consumers confirmed
 EOF
-    run "$SCRIPT" --dead-ip 23.88.34.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
+    run "$SCRIPT" --dead-ip 192.0.2.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
     [ "$status" -eq 0 ]
 }
 
@@ -43,16 +43,16 @@ EOF
 @test "block-on-a-live-connstring — class-a hit exits 1" {
     mkdir -p "$WORK/Projects/App/code"
     cat >"$WORK/Projects/App/code/.env" <<'EOF'
-DB_HOST=23.88.34.218
+DB_HOST=192.0.2.218
 DB_PORT=5432
 EOF
     cat >"$WORK/audit.md" <<'EOF'
 # Audit
-dead_ip: 23.88.34.218
+dead_ip: 192.0.2.218
 live_consumers: 0
 assertion: zero live consumers confirmed
 EOF
-    run "$SCRIPT" --dead-ip 23.88.34.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
+    run "$SCRIPT" --dead-ip 192.0.2.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
     [ "$status" -eq 1 ]
     [[ "$output" == *"BLOCK"* ]]
 }
@@ -63,16 +63,16 @@ EOF
 @test "block-on-b-live-bind — class-b hit exits 1" {
     mkdir -p "$WORK/Projects/Svc/code"
     cat >"$WORK/Projects/Svc/code/redis.conf" <<'EOF'
-bind 23.88.34.218
+bind 192.0.2.218
 port 6379
 EOF
     cat >"$WORK/audit.md" <<'EOF'
 # Audit
-dead_ip: 23.88.34.218
+dead_ip: 192.0.2.218
 live_consumers: 0
 assertion: zero live consumers confirmed
 EOF
-    run "$SCRIPT" --dead-ip 23.88.34.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
+    run "$SCRIPT" --dead-ip 192.0.2.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
     [ "$status" -eq 1 ]
     [[ "$output" == *"BLOCK"* ]]
 }
@@ -84,20 +84,20 @@ EOF
     mkdir -p "$WORK/documentation/archive"
     cat >"$WORK/documentation/archive/old-infra.md" <<'EOF'
 # Old infra (decommissioned)
-Previously hosted at 23.88.34.218 (now offline, migrated 2026-06-10).
+Previously hosted at 192.0.2.218 (now offline, migrated 2026-06-10).
 EOF
     mkdir -p "$WORK/Projects/App/code"
     cat >"$WORK/Projects/App/code/config.yml" <<'EOF'
-# Old DB was at 23.88.34.218, now using 10.0.0.5
+# Old DB was at 192.0.2.218, now using 10.0.0.5
 db_host: 10.0.0.5
 EOF
     cat >"$WORK/audit.md" <<'EOF'
 # Audit
-dead_ip: 23.88.34.218
+dead_ip: 192.0.2.218
 live_consumers: 0
 assertion: zero live consumers confirmed
 EOF
-    run "$SCRIPT" --dead-ip 23.88.34.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
+    run "$SCRIPT" --dead-ip 192.0.2.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
     [ "$status" -eq 0 ]
 }
 
@@ -121,7 +121,7 @@ EOF
 # 7. fail-closed-unreadable-root — workspace root does not exist
 # ---------------------------------------------------------------------------
 @test "fail-closed-unreadable-root — missing root exits non-zero" {
-    run "$SCRIPT" --dead-ip 23.88.34.218 --workspace-root /no/such/dir/xyz
+    run "$SCRIPT" --dead-ip 192.0.2.218 --workspace-root /no/such/dir/xyz
     [ "$status" -ne 0 ]
 }
 
@@ -133,7 +133,7 @@ EOF
     cat >"$WORK/Projects/App/code/config.yml" <<'EOF'
 db_host: 10.0.0.5
 EOF
-    run "$SCRIPT" --dead-ip 23.88.34.218 --workspace-root "$WORK" --audit "$WORK/nonexistent-audit.md"
+    run "$SCRIPT" --dead-ip 192.0.2.218 --workspace-root "$WORK" --audit "$WORK/nonexistent-audit.md"
     [ "$status" -eq 1 ]
     [[ "$output" == *"BLOCK"* ]]
 }
@@ -148,11 +148,11 @@ db_host: 10.0.0.5
 EOF
     cat >"$WORK/audit.md" <<'EOF'
 # Dead-IP Audit
-dead_ip: 23.88.34.218
+dead_ip: 192.0.2.218
 live_consumers: 0
 assertion: zero live consumers confirmed
 EOF
-    run "$SCRIPT" --dead-ip 23.88.34.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
+    run "$SCRIPT" --dead-ip 192.0.2.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
     [ "$status" -eq 0 ]
 }
 
@@ -166,10 +166,10 @@ db_host: 10.0.0.5
 EOF
     cat >"$WORK/audit.md" <<'EOF'
 # Dead-IP Audit
-dead_ip: 23.88.34.218
+dead_ip: 192.0.2.218
 some_note: investigated
 EOF
-    run "$SCRIPT" --dead-ip 23.88.34.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
+    run "$SCRIPT" --dead-ip 192.0.2.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
     [ "$status" -eq 1 ]
     [[ "$output" == *"BLOCK"* ]]
 }
@@ -180,14 +180,14 @@ EOF
 @test "defensive-invariant — live hit wording matches non-zero exit" {
     mkdir -p "$WORK/Projects/App/code"
     cat >"$WORK/Projects/App/code/.env" <<'EOF'
-DB_HOST=23.88.34.218
+DB_HOST=192.0.2.218
 EOF
     cat >"$WORK/audit.md" <<'EOF'
-dead_ip: 23.88.34.218
+dead_ip: 192.0.2.218
 live_consumers: 0
 assertion: zero live consumers confirmed
 EOF
-    run "$SCRIPT" --dead-ip 23.88.34.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
+    run "$SCRIPT" --dead-ip 192.0.2.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
     [ "$status" -ne 0 ]
     [[ "$output" == *"BLOCK"* ]]
 }
@@ -200,15 +200,15 @@ EOF
     cat >"$WORK/spaces/foreign/space.yml" <<'EOF'
 name: foreign
 servers:
-  - ip: 23.88.34.218
+  - ip: 192.0.2.218
     role: db
 EOF
     cat >"$WORK/audit.md" <<'EOF'
-dead_ip: 23.88.34.218
+dead_ip: 192.0.2.218
 live_consumers: 0
 assertion: zero live consumers confirmed
 EOF
-    run "$SCRIPT" --dead-ip 23.88.34.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
+    run "$SCRIPT" --dead-ip 192.0.2.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
     [ "$status" -eq 1 ]
     [[ "$output" == *"BLOCK"* ]]
 }
@@ -221,15 +221,15 @@ EOF
     cat >"$WORK/spaces/cluster/space.yml" <<'EOF'
 name: cluster
 cluster_hosts:
-  - 23.88.34.218
+  - 192.0.2.218
   - 10.0.0.2
 EOF
     cat >"$WORK/audit.md" <<'EOF'
-dead_ip: 23.88.34.218
+dead_ip: 192.0.2.218
 live_consumers: 0
 assertion: zero live consumers confirmed
 EOF
-    run "$SCRIPT" --dead-ip 23.88.34.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
+    run "$SCRIPT" --dead-ip 192.0.2.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
     [ "$status" -eq 1 ]
     [[ "$output" == *"BLOCK"* ]]
 }

--- a/dev-tools/tests/dead-ip-sweep-wiring.bats
+++ b/dev-tools/tests/dead-ip-sweep-wiring.bats
@@ -23,23 +23,23 @@ teardown() {
 ---
 type: db-relocation
 title: Migrate DB to new host
-decommissioned_ip: 23.88.34.218
+decommissioned_ip: 192.0.2.218
 ---
 
-Relocate DB from 23.88.34.218 to new host.
-DB_HOST=23.88.34.218 currently in environment.
+Relocate DB from 192.0.2.218 to new host.
+DB_HOST=192.0.2.218 currently in environment.
 EOF
 
     # Live consumer in the workspace
     mkdir -p "$WORK/Projects/App/code"
     cat >"$WORK/Projects/App/code/.env" <<'EOF'
-DB_HOST=23.88.34.218
+DB_HOST=192.0.2.218
 DB_PORT=5432
 EOF
 
     # Valid audit (but live hit should still block)
     cat >"$WORK/audit.md" <<'EOF'
-dead_ip: 23.88.34.218
+dead_ip: 192.0.2.218
 live_consumers: 0
 assertion: zero live consumers confirmed
 EOF
@@ -49,7 +49,7 @@ EOF
     [ "$status" -eq 0 ]
 
     # 2. Sweep must block due to live consumer
-    run "$SWEEP" --dead-ip 23.88.34.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
+    run "$SWEEP" --dead-ip 192.0.2.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
     [ "$status" -eq 1 ]
     [[ "$output" == *"BLOCK"* ]]
 }
@@ -62,10 +62,10 @@ EOF
 ---
 type: db-relocation
 title: Migrate DB to new host
-decommissioned_ip: 23.88.34.218
+decommissioned_ip: 192.0.2.218
 ---
 
-Relocate DB from 23.88.34.218 to new host.
+Relocate DB from 192.0.2.218 to new host.
 EOF
 
     # No live consumer — all configs reference new IP
@@ -77,7 +77,7 @@ EOF
 
     # Valid audit
     cat >"$WORK/audit.md" <<'EOF'
-dead_ip: 23.88.34.218
+dead_ip: 192.0.2.218
 live_consumers: 0
 assertion: zero live consumers confirmed
 EOF
@@ -87,7 +87,7 @@ EOF
     [ "$status" -eq 0 ]
 
     # 2. Sweep must pass
-    run "$SWEEP" --dead-ip 23.88.34.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
+    run "$SWEEP" --dead-ip 192.0.2.218 --workspace-root "$WORK" --audit "$WORK/audit.md"
     [ "$status" -eq 0 ]
 }
 

--- a/scripts/personal-id-gate.sh
+++ b/scripts/personal-id-gate.sh
@@ -203,14 +203,7 @@ whitelist_paths=("$regex_file" "$0" "$_regex_basename" "$_self_basename"
     "tests/datarim-doctor-execution-drift.bats"
     # Supreme Directive canonical Source-of-Truth URL — public canon, not a
     # personal data leak. The URL is the published identifier of the spec.
-    "templates/project-claude-md.md"
-    # Dead-IP-sweep tooling embeds the decommissioned public IP it hunts — the
-    # IP is the detector's own needle (same rationale as the regex source file
-    # being exempt from its own scan). Flagging these would break the tool.
-    "dev-tools/dead-ip-consumer-sweep.sh"
-    "dev-tools/tests/dead-ip-consumer-sweep.bats"
-    "dev-tools/tests/dead-ip-sweep-wiring.bats"
-    "dev-tools/tests/check-db-relocation-class.bats")
+    "templates/project-claude-md.md")
 
 # Load additional whitelist paths (one prefix per line, # comments ok).
 if [ -n "$whitelist_file" ] && [ -f "$whitelist_file" ]; then

--- a/tests/personal-id-no-real-values.bats
+++ b/tests/personal-id-no-real-values.bats
@@ -46,18 +46,9 @@ teardown() {
     rm -rf "$TMP_DIR"
 }
 
-# Paths whose match IS the detector's own needle and cannot be synthetic.
-# Keep this list SHORT and justified — every entry is a suppression.
-#
-#   dev-tools/dead-ip-*        post-relocate dead-IP sweep: the decommissioned
-#   dev-tools/tests/dead-ip-*  address is the input the tool and its fixtures
-#   check-db-relocation-class  hunt for. Already exempt in the gate's whitelist.
-#   this file                  describes the mechanism; holds no address.
-EXEMPT_PATHS=':!dev-tools/dead-ip-consumer-sweep.sh
-:!dev-tools/tests/dead-ip-consumer-sweep.bats
-:!dev-tools/tests/dead-ip-sweep-wiring.bats
-:!dev-tools/tests/check-db-relocation-class.bats
-:!tests/personal-id-no-real-values.bats'
+# This file contains detector mechanics but no real address. All dead-IP sweep
+# fixtures use RFC 5737 documentation space and are scanned like shipped code.
+EXEMPT_PATHS=':!tests/personal-id-no-real-values.bats'
 
 @test "no real infrastructure address appears anywhere in the repository" {
     [ -n "$OVERLAY" ] || skip "no local overlay present — nothing to compare against"


### PR DESCRIPTION
Completes the v2.67.3 correction before release: aligns the framework header, makes known-fix query corruption fail visibly, replaces retired real-address fixtures with RFC 5737 values, removes four obsolete scan suppressions, anonymizes public fleet capability comments, and documents the strengthened protected-main gate. Focused verification: version consistency PASS; shard 7 48/48; security fixture suite 47/47; personal-ID gate PASS; shellcheck PASS. Branch protection now requires version consistency, task-ID/regression checks, and all eight Bats shards.